### PR TITLE
feat: gate incidents with cross-client safety filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ src/
   metrics.rs       # Uptime Kuma /metrics scraper (Prometheus format parser)
   watchdog.rs      # Proactive monitoring: polls Kuma, detects transitions, auto-creates incidents
   zammad.rs        # Zammad REST API client (HTTP, Token auth, ticket/article CRUD)
-migrations/        # 23 sqlx migration files (auto-run on startup)
+migrations/        # 24 sqlx migration files (auto-run on startup)
 seed/seed.sql      # Idempotent seed data with real infrastructure
 ```
 
@@ -109,7 +109,7 @@ These principles govern how ops-brain handles multi-client data. The system serv
 managing two clients (HSR hospice + CPA firm) with different compliance domains (HIPAA vs IRS/tax).
 Since there is no second pair of eyes, the system itself must act as the safety gate.
 
-1. **Default-deny cross-client surfacing**: `cross_client_safe` boolean (default: false) on runbooks and knowledge tables. Content scoped to client A does NOT surface in client B context unless explicitly marked safe. The entries you forget to tag are the ones with compliance implications.
+1. **Default-deny cross-client surfacing**: `cross_client_safe` boolean (default: false) on runbooks, knowledge, and incidents tables. Content scoped to client A does NOT surface in client B context unless explicitly marked safe. The entries you forget to tag are the ones with compliance implications.
 
 2. **Withhold-by-default on scope mismatch**: When semantic search or context tools would surface cross-client content, the actual content is **withheld** and replaced with a scope mismatch notice. An explicit `acknowledge_cross_client: true` parameter on a second call releases the result. Content that never reaches the context window can't influence reasoning. A gate, not a banner.
 
@@ -129,16 +129,18 @@ Since there is no second pair of eyes, the system itself must act as the safety 
 
 ### Tools Affected by Cross-Client Gate
 
-- `get_situational_awareness` — gates runbooks + knowledge via resolved client_id
-- `get_server_context` — gates runbooks + knowledge via resolved client_id
+- `get_situational_awareness` — gates runbooks, knowledge, and incidents via resolved client_id
+- `get_server_context` — gates runbooks, knowledge, and incidents via resolved client_id
 - `search_runbooks` — optional `client_slug` + `acknowledge_cross_client` params
 - `search_knowledge` — optional `client_slug` + `acknowledge_cross_client` params
-- `semantic_search` — gates runbook + knowledge results (incidents/handoffs not gated)
+- `semantic_search` — gates runbook, knowledge, and incident results (handoffs not gated — no client_id)
 - `list_runbooks` — optional `client_slug` filter (DB-level, shows client + global)
 - `create_runbook` — optional `client_slug` + `cross_client_safe` params
 - `update_runbook` — optional `cross_client_safe` param
 - `add_knowledge` — optional `cross_client_safe` param
 - `update_knowledge` — optional `cross_client_safe` param
+- `create_incident` — optional `cross_client_safe` param (default: false)
+- `update_incident` — optional `cross_client_safe` param
 - `delete_knowledge` — deletes by ID (no cross-client gate needed, operates on explicit ID)
 - Watchdog: runbook suggestions client-scoped (same-client + global only)
 

--- a/migrations/20260326000001_add_cross_client_safe_to_incidents.sql
+++ b/migrations/20260326000001_add_cross_client_safe_to_incidents.sql
@@ -1,0 +1,2 @@
+-- Cross-client safety gate for incidents (compliance: HIPAA/IRS §7216 isolation)
+ALTER TABLE incidents ADD COLUMN cross_client_safe BOOLEAN NOT NULL DEFAULT false;

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -202,6 +202,7 @@ mod tests {
             prevention: Some("Set up disk monitoring".to_string()),
             time_to_resolve_minutes: Some(45),
             notes: None,
+            cross_client_safe: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -230,6 +231,7 @@ mod tests {
             prevention: None,
             time_to_resolve_minutes: None,
             notes: None,
+            cross_client_safe: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/src/models/incident.rs
+++ b/src/models/incident.rs
@@ -17,6 +17,7 @@ pub struct Incident {
     pub prevention: Option<String>,
     pub time_to_resolve_minutes: Option<i32>,
     pub notes: Option<String>,
+    pub cross_client_safe: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/src/repo/incident_repo.rs
+++ b/src/repo/incident_repo.rs
@@ -64,11 +64,12 @@ pub async fn create_incident(
     client_id: Option<Uuid>,
     symptoms: Option<&str>,
     notes: Option<&str>,
+    cross_client_safe: bool,
 ) -> Result<Incident, sqlx::Error> {
     let id = Uuid::now_v7();
     sqlx::query_as::<_, Incident>(
-        "INSERT INTO incidents (id, title, status, severity, client_id, symptoms, notes)
-         VALUES ($1, $2, 'open', $3, $4, $5, $6)
+        "INSERT INTO incidents (id, title, status, severity, client_id, symptoms, notes, cross_client_safe)
+         VALUES ($1, $2, 'open', $3, $4, $5, $6, $7)
          RETURNING *",
     )
     .bind(id)
@@ -77,6 +78,7 @@ pub async fn create_incident(
     .bind(client_id)
     .bind(symptoms)
     .bind(notes)
+    .bind(cross_client_safe)
     .fetch_one(pool)
     .await
 }
@@ -93,6 +95,7 @@ pub async fn update_incident(
     resolution: Option<&str>,
     prevention: Option<&str>,
     notes: Option<&str>,
+    cross_client_safe: Option<bool>,
 ) -> Result<Incident, sqlx::Error> {
     // If resolving, calculate TTR and set resolved_at
     let incident = sqlx::query_as::<_, Incident>(
@@ -105,6 +108,7 @@ pub async fn update_incident(
             resolution = COALESCE($7, resolution),
             prevention = COALESCE($8, prevention),
             notes = COALESCE($9, notes),
+            cross_client_safe = COALESCE($10, cross_client_safe),
             resolved_at = CASE
                 WHEN $3 = 'resolved' AND resolved_at IS NULL THEN now()
                 ELSE resolved_at
@@ -126,6 +130,7 @@ pub async fn update_incident(
     .bind(resolution)
     .bind(prevention)
     .bind(notes)
+    .bind(cross_client_safe)
     .fetch_one(pool)
     .await?;
 

--- a/src/tools/incidents.rs
+++ b/src/tools/incidents.rs
@@ -17,6 +17,8 @@ pub struct CreateIncidentParams {
     pub server_slugs: Option<Vec<String>>,
     /// Service slugs affected by this incident
     pub service_slugs: Option<Vec<String>>,
+    /// Mark as safe to surface in cross-client contexts (default: false)
+    pub cross_client_safe: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -39,6 +41,8 @@ pub struct UpdateIncidentParams {
     pub prevention: Option<String>,
     /// Additional notes
     pub notes: Option<String>,
+    /// Mark as safe to surface in cross-client contexts
+    pub cross_client_safe: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1643,7 +1643,7 @@ impl OpsBrain {
             }
         }
 
-        // ── Cross-client scope gate for runbooks and knowledge ──
+        // ── Cross-client scope gate for runbooks, knowledge, and incidents ──
         {
             let client_lookup = self.build_client_lookup().await;
 
@@ -1682,6 +1682,25 @@ impl OpsBrain {
                 client_id,
                 "knowledge",
                 &kn_filtered.audit_entries,
+            )
+            .await;
+
+            let inc_filtered = filter_cross_client(
+                std::mem::take(&mut awareness.recent_incidents),
+                "incident",
+                client_id,
+                acknowledge,
+                &client_lookup,
+            );
+            awareness.recent_incidents = inc_filtered.allowed;
+            awareness
+                .cross_client_withheld
+                .extend(inc_filtered.withheld_notices);
+            self.log_audit_entries(
+                "get_situational_awareness",
+                client_id,
+                "incident",
+                &inc_filtered.audit_entries,
             )
             .await;
         }
@@ -2062,7 +2081,7 @@ impl OpsBrain {
             }
         }
 
-        // ── Cross-client scope gate for runbooks and knowledge ──
+        // ── Cross-client scope gate for runbooks, knowledge, and incidents ──
         let mut cross_client_withheld: Vec<serde_json::Value> = Vec::new();
         {
             let client_lookup = self.build_client_lookup().await;
@@ -2098,6 +2117,23 @@ impl OpsBrain {
                 client_id,
                 "knowledge",
                 &kn_filtered.audit_entries,
+            )
+            .await;
+
+            let inc_filtered = filter_cross_client(
+                std::mem::take(&mut all_incidents),
+                "incident",
+                client_id,
+                acknowledge,
+                &client_lookup,
+            );
+            all_incidents = inc_filtered.allowed;
+            cross_client_withheld.extend(inc_filtered.withheld_notices);
+            self.log_audit_entries(
+                "get_server_context",
+                client_id,
+                "incident",
+                &inc_filtered.audit_entries,
             )
             .await;
         }
@@ -2207,6 +2243,7 @@ impl OpsBrain {
             None => None,
         };
 
+        let cross_client_safe = p.cross_client_safe.unwrap_or(false);
         let incident = match crate::repo::incident_repo::create_incident(
             &self.pool,
             &p.title,
@@ -2214,6 +2251,7 @@ impl OpsBrain {
             client_id,
             p.symptoms.as_deref(),
             p.notes.as_deref(),
+            cross_client_safe,
         )
         .await
         {
@@ -2301,6 +2339,7 @@ impl OpsBrain {
             p.resolution.as_deref(),
             p.prevention.as_deref(),
             p.notes.as_deref(),
+            p.cross_client_safe,
         )
         .await
         {
@@ -2979,7 +3018,7 @@ impl OpsBrain {
                 }
             }
         }
-        // Incidents and handoffs are NOT gated (factual records, already client-scoped)
+        // Incidents are gated — HIPAA/IRS §7216 cross-client isolation
         if tables.iter().any(|t| t == "incidents") {
             match crate::repo::embedding_repo::hybrid_search_incidents(
                 &self.pool, &p.query, emb_ref, limit,
@@ -2987,10 +3026,29 @@ impl OpsBrain {
             .await
             {
                 Ok(items) => {
+                    let json_items: Vec<serde_json::Value> = items
+                        .iter()
+                        .filter_map(|i| serde_json::to_value(i).ok())
+                        .collect();
+                    let filtered = filter_cross_client(
+                        json_items,
+                        "incident",
+                        requesting_client_id,
+                        acknowledge,
+                        &client_lookup,
+                    );
                     results.insert(
                         "incidents".to_string(),
-                        serde_json::to_value(&items).unwrap_or_default(),
+                        serde_json::to_value(&filtered.allowed).unwrap_or_default(),
                     );
+                    all_withheld.extend(filtered.withheld_notices);
+                    self.log_audit_entries(
+                        "semantic_search",
+                        requesting_client_id,
+                        "incident",
+                        &filtered.audit_entries,
+                    )
+                    .await;
                 }
                 Err(e) => {
                     results.insert(
@@ -4449,6 +4507,53 @@ mod tests {
         assert_eq!(result.withheld_notices[0]["count"], 1);
         // 1 released_safe + 1 withheld
         assert_eq!(result.audit_entries.len(), 2);
+    }
+
+    // ===== incident cross-client gating tests =====
+
+    #[test]
+    fn filter_incident_cross_client_withheld() {
+        let (hsr_id, cpa_id, lookup) = make_lookup();
+        let item_id = Uuid::now_v7();
+        // HSR incident, NOT safe, NOT acknowledged, requesting from CPA context
+        let items = vec![make_item(item_id, Some(hsr_id), false)];
+
+        let result = filter_cross_client(items, "incident", Some(cpa_id), false, &lookup);
+
+        assert!(result.allowed.is_empty());
+        assert_eq!(result.withheld_notices.len(), 1);
+        assert_eq!(result.withheld_notices[0]["entity_type"], "incident");
+        assert_eq!(result.withheld_notices[0]["owning_client_slug"], "hsr");
+        assert_eq!(result.audit_entries.len(), 1);
+        assert_eq!(result.audit_entries[0].2, "withheld");
+    }
+
+    #[test]
+    fn filter_incident_cross_client_safe_allowed() {
+        let (hsr_id, cpa_id, lookup) = make_lookup();
+        let item_id = Uuid::now_v7();
+        // HSR incident marked cross_client_safe, requesting from CPA
+        let items = vec![make_item(item_id, Some(hsr_id), true)];
+
+        let result = filter_cross_client(items, "incident", Some(cpa_id), false, &lookup);
+
+        assert_eq!(result.allowed.len(), 1);
+        assert!(result.withheld_notices.is_empty());
+        assert_eq!(result.audit_entries.len(), 1);
+        assert_eq!(result.audit_entries[0].2, "released_safe");
+    }
+
+    #[test]
+    fn filter_incident_same_client_allowed() {
+        let (hsr_id, _, lookup) = make_lookup();
+        let item_id = Uuid::now_v7();
+        let items = vec![make_item(item_id, Some(hsr_id), false)];
+
+        let result = filter_cross_client(items, "incident", Some(hsr_id), false, &lookup);
+
+        assert_eq!(result.allowed.len(), 1);
+        assert!(result.withheld_notices.is_empty());
+        assert!(result.audit_entries.is_empty());
     }
 
     // ===== inject_provenance tests =====

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -267,6 +267,7 @@ async fn handle_down_transition(
         client_id,
         Some(&symptoms),
         Some("Auto-created by ops-brain watchdog on monitor DOWN transition"),
+        false, // cross_client_safe: watchdog incidents are client-scoped by default
     )
     .await;
 
@@ -336,6 +337,7 @@ async fn handle_up_transition(pool: &PgPool, incident_id: Uuid, monitor_name: &s
         )),
         None, // prevention
         None, // notes
+        None, // cross_client_safe (preserve existing value)
     )
     .await;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -361,6 +361,7 @@ mod incident_tests {
             None,
             Some("Cannot SSH"),
             Some("Created by test"),
+            false,
         )
         .await
         .unwrap();
@@ -396,6 +397,7 @@ mod incident_tests {
             None,
             None,
             None,
+            false,
         )
         .await
         .unwrap();
@@ -413,6 +415,7 @@ mod incident_tests {
             Some("Cleared old logs"),
             None,
             None,
+            None, // cross_client_safe
         )
         .await
         .unwrap();
@@ -442,6 +445,7 @@ mod incident_tests {
             None,
             None,
             None,
+            false,
         )
         .await
         .unwrap();
@@ -453,6 +457,7 @@ mod incident_tests {
             None,
             None,
             None,
+            false,
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

- **Closes compliance gap**: `semantic_search`, `get_situational_awareness`, and `get_server_context` now gate incidents through `filter_cross_client()` — previously incidents were returned unfiltered across client boundaries (HIPAA vs IRS §7216)
- **New migration**: adds `cross_client_safe` boolean (default: false) to incidents table, matching the existing runbook/knowledge pattern
- **Tool updates**: `create_incident` and `update_incident` accept optional `cross_client_safe` param; watchdog auto-created incidents default to `false`

## What Changed

| File | Change |
|------|--------|
| `migrations/20260326000001_*` | Add `cross_client_safe` column to incidents |
| `src/models/incident.rs` | Add field to Incident struct |
| `src/repo/incident_repo.rs` | Plumb through create/update queries |
| `src/tools/mod.rs` | Gate incidents in 3 tools + 3 new unit tests |
| `src/tools/incidents.rs` | Add param to CreateIncident/UpdateIncident |
| `src/watchdog.rs` | Pass `false` on create, `None` on resolve |
| `src/embeddings.rs` | Add field to test fixtures |
| `tests/integration.rs` | Update call sites |
| `CLAUDE.md` | Update safety docs, migration count |

## Origin

Identified by kensai-cloud CC in handoff `019d2780-860a-7c33-bfb3-829d7430c871` (Priority 3: Cross-Client Incident Gating Gap).

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — 74 unit + 20 integration tests pass
- [ ] CI pipeline validates on push
- [ ] Deploy to kensai.cloud and verify migration runs
- [ ] kensai-cloud CC validates gating via MCP tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)