### PR TITLE
refactor: split tools/mod.rs into category modules + push monitor hints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,17 +23,19 @@ src/
   models/          # Domain structs (sqlx::FromRow + serde derives)
   repo/            # Database query layer (all runtime query_as, not macros)
   tools/
-    mod.rs           # OpsBrain struct with ALL 64 #[tool] methods in one impl block
-    inventory.rs     # Parameter structs for inventory tools
-    runbooks.rs      # Parameter structs for runbook tools
-    knowledge.rs     # Parameter structs for knowledge tools
-    context.rs       # Parameter structs + response structs for context tools
-    incidents.rs     # Parameter structs for incident tools
-    coordination.rs  # Parameter structs for session + handoff tools
-    monitoring.rs    # Parameter structs for monitoring tools
-    search.rs        # Parameter structs for semantic search tools
-    zammad.rs        # Parameter structs for Zammad ticketing tools
-    briefings.rs     # Parameter structs + response structs for briefing tools
+    mod.rs           # OpsBrain struct + 64 #[tool] stubs (delegate to category modules)
+    helpers.rs       # Shared helpers: json_result, error_result, filter_cross_client, compact_*, etc.
+    shared.rs        # Shared async functions: embed_and_store, get_query_embedding, build_client_lookup, log_audit_entries
+    inventory.rs     # Parameter structs + handler implementations for inventory tools
+    runbooks.rs      # Parameter structs + handler implementations for runbook tools
+    knowledge.rs     # Parameter structs + handler implementations for knowledge tools
+    context.rs       # Parameter/response structs + handler implementations for context tools
+    incidents.rs     # Parameter structs + handler implementations for incident tools
+    coordination.rs  # Parameter structs + handler implementations for session + handoff tools
+    monitoring.rs    # Parameter structs + handler implementations for monitoring tools
+    search.rs        # Parameter structs + handler implementations for semantic search tools
+    zammad.rs        # Parameter structs + handler implementations for Zammad ticketing tools
+    briefings.rs     # Parameter/response structs + handler implementations for briefing tools
   embeddings.rs    # OpenAI embedding client + text preparation functions
   metrics.rs       # Uptime Kuma /metrics scraper (Prometheus format parser)
   watchdog.rs      # Proactive monitoring: polls Kuma, detects transitions, auto-creates incidents
@@ -44,8 +46,10 @@ seed/seed.sql      # Idempotent seed data with real infrastructure
 
 ## Architecture Constraints
 
-- All `#[tool]` methods MUST be in the single `#[tool_router] impl OpsBrain` block in `src/tools/mod.rs` — rmcp macro requirement
-- Parameter structs go in sub-modules (inventory.rs, runbooks.rs, zammad.rs, etc.) and are referenced from tool methods
+- All `#[tool]` stubs MUST remain in the single `#[tool_router] impl OpsBrain` block in `src/tools/mod.rs` — rmcp macro requirement. Each stub delegates to a `handle_*` function in the appropriate category module.
+- Parameter structs and handler implementations live together in category modules (inventory.rs, runbooks.rs, zammad.rs, etc.)
+- Shared helpers (json_result, filter_cross_client, compact_*) live in `tools/helpers.rs`; shared async functions (embed_and_store, get_query_embedding, etc.) live in `tools/shared.rs`
+- OpsBrain fields are `pub(crate)` so category modules can access pool, kuma_config, embedding_client, zammad_config
 - Tool errors return `Ok(CallToolResult::error(...))`, never `Err(McpError)`
 - Slugs are the public API (not UUIDs) — tools resolve slugs to IDs internally
 - Tracing writes to stderr (critical: stdout is the MCP stdio transport)
@@ -378,24 +382,34 @@ pub struct DeleteThingParams {
 }
 ```
 
-**5. Tool method**
+**5. Handler function**
 
-Add to the `#[tool_router] impl OpsBrain` block in `src/tools/mod.rs`. Pattern:
+Add the handler implementation to the appropriate category file (e.g., `src/tools/inventory.rs`):
 ```rust
-#[tool(description = "Delete a thing by slug. Requires confirm=true. Refuses if referenced by other entities.")]
-async fn delete_thing(&self, #[tool(aggr)] params: DeleteThingParams) -> Result<CallToolResult, McpError> {
-    // 1. Resolve slug to entity
+pub(crate) async fn handle_delete_thing(brain: &super::OpsBrain, params: DeleteThingParams) -> CallToolResult {
+    // 1. Resolve slug to entity (brain.pool)
     // 2. Check for FK references (safety gate)
     // 3. Require confirm=true
     // 4. Delete
-    // 5. Return success message
+    // 5. Return success message via json_result()
 }
 ```
-- Tools MUST be in the single `#[tool_router] impl OpsBrain` block — rmcp macro requirement
-- Return `Ok(CallToolResult::error(...))` for user-facing errors, never `Err()`
-- Use `self.pool` for DB access
 
-**6. Integration test**
+**6. Tool stub**
+
+Add a thin stub to the `#[tool_router] impl OpsBrain` block in `src/tools/mod.rs`:
+```rust
+#[tool(description = "Delete a thing by slug. Requires confirm=true.")]
+async fn delete_thing(&self, params: Parameters<inventory::DeleteThingParams>) -> Result<CallToolResult, McpError> {
+    Ok(inventory::handle_delete_thing(self, params.0).await)
+}
+```
+- Tool stubs MUST be in the single `#[tool_router] impl OpsBrain` block — rmcp macro requirement
+- Stubs only delegate — all logic lives in the category handler
+- Handler returns `CallToolResult` directly; stub wraps in `Ok()`
+- Handler accesses `brain.pool`, `brain.embedding_client`, etc.
+
+**7. Integration test**
 
 Add to `tests/integration.rs`. Pattern:
 ```rust
@@ -409,7 +423,7 @@ async fn test_delete_thing() {
 }
 ```
 
-**7. Update counts**
+**8. Update counts**
 
 - Update tool count in `CLAUDE.md` (Quick Reference, Phase Status, Project Layout comment)
 - Update tool count in `README.md`
@@ -432,7 +446,7 @@ Before opening a PR, verify:
 
 - **Don't modify existing migrations** — checksum mismatch will break deployments
 - **Don't use compile-time sqlx macros** — we use runtime queries for flexibility
-- **Don't add tools outside the `#[tool_router]` impl block** — rmcp requires them all in one place
+- **Don't add tool stubs outside the `#[tool_router]` impl block** — rmcp requires them all in one place. Handler logic goes in category modules.
 - **Don't write to stdout** — it's the MCP stdio transport. Use `tracing::info!()` (goes to stderr)
 - **Don't add fictional/placeholder data to seed.sql** — only foundational structure
 - **Don't merge without CI green** — the pipeline exists to protect us all

--- a/src/tools/briefings.rs
+++ b/src/tools/briefings.rs
@@ -1,6 +1,9 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::helpers::{error_result, json_result, not_found};
+use rmcp::model::*;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GenerateBriefingParams {
     /// Briefing type: "daily" or "weekly"
@@ -78,4 +81,99 @@ pub struct WeeklyStats {
     pub resolved_count: usize,
     pub avg_ttr_minutes: Option<f64>,
     pub watchdog_resolved: usize,
+}
+
+// ===== HANDLERS =====
+
+pub(crate) async fn handle_generate_briefing(
+    brain: &super::OpsBrain,
+    p: GenerateBriefingParams,
+) -> CallToolResult {
+    if let Err(msg) = crate::validation::validate_required(
+        &p.briefing_type,
+        "briefing_type",
+        crate::validation::BRIEFING_TYPES,
+    ) {
+        return error_result(&msg);
+    }
+
+    let client = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    match crate::api::generate_briefing_inner(
+        &brain.pool,
+        &brain.kuma_config,
+        &brain.zammad_config,
+        &p.briefing_type.to_lowercase(),
+        client.as_ref(),
+    )
+    .await
+    {
+        Ok(output) => json_result(&output),
+        Err(e) => error_result(&e),
+    }
+}
+
+pub(crate) async fn handle_list_briefings(
+    brain: &super::OpsBrain,
+    p: ListBriefingsParams,
+) -> CallToolResult {
+    let limit = p.limit.unwrap_or(10);
+
+    if let Err(msg) = crate::validation::validate_option(
+        p.briefing_type.as_deref(),
+        "briefing_type",
+        crate::validation::BRIEFING_TYPES,
+    ) {
+        return error_result(&msg);
+    }
+
+    let client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    match crate::repo::briefing_repo::list_briefings(
+        &brain.pool,
+        p.briefing_type.as_deref(),
+        client_id,
+        limit,
+    )
+    .await
+    {
+        Ok(briefings) => {
+            let result = serde_json::json!({
+                "count": briefings.len(),
+                "briefings": briefings,
+            });
+            json_result(&result)
+        }
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_get_briefing(
+    brain: &super::OpsBrain,
+    p: GetBriefingParams,
+) -> CallToolResult {
+    let id = match uuid::Uuid::parse_str(&p.id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.id)),
+    };
+
+    match crate::repo::briefing_repo::get_briefing(&brain.pool, id).await {
+        Ok(Some(briefing)) => json_result(&briefing),
+        Ok(None) => not_found("Briefing", &p.id),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
 }

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -1,6 +1,15 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::helpers::{
+    compact_value, compact_vec, error_result, filter_cross_client, json_result, not_found,
+    section_included,
+};
+use super::shared::{build_client_lookup, get_query_embedding, log_audit_entries};
+use crate::models::handoff::Handoff;
+use crate::models::incident::Incident;
+use rmcp::model::*;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetSituationalAwarenessParams {
     /// Server slug to get context for
@@ -72,4 +81,1064 @@ pub struct ClientOverview {
     pub pending_handoffs: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub recent_tickets: Vec<serde_json::Value>,
+}
+
+// ===== HANDLERS =====
+
+pub(crate) async fn handle_get_situational_awareness(
+    brain: &super::OpsBrain,
+    p: GetSituationalAwarenessParams,
+) -> CallToolResult {
+    if p.server_slug.is_none() && p.service_slug.is_none() && p.client_slug.is_none() {
+        return error_result("Provide at least one of: server_slug, service_slug, or client_slug");
+    }
+
+    let compact = p.compact.unwrap_or(false);
+    let sections = p.sections;
+    let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
+
+    let mut awareness = SituationalAwareness {
+        server: None,
+        site: None,
+        client: None,
+        services: Vec::new(),
+        networks: Vec::new(),
+        vendors: Vec::new(),
+        recent_incidents: Vec::new(),
+        relevant_runbooks: Vec::new(),
+        pending_handoffs: Vec::new(),
+        knowledge: Vec::new(),
+        monitoring: Vec::new(),
+        linked_tickets: Vec::new(),
+        cross_client_withheld: Vec::new(),
+    };
+
+    let mut client_id: Option<uuid::Uuid> = None;
+    #[allow(unused_assignments)]
+    let mut site_id: Option<uuid::Uuid> = None;
+    let mut server_id: Option<uuid::Uuid> = None;
+    let mut service_id: Option<uuid::Uuid> = None;
+
+    // Resolve server if provided — this gives us site and client context too
+    if let Some(slug) = &p.server_slug {
+        if let Ok(Some(server)) =
+            crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await
+        {
+            server_id = Some(server.id);
+            site_id = Some(server.site_id);
+            awareness.server = serde_json::to_value(&server).ok();
+
+            // Get services for this server
+            if let Ok(services) =
+                crate::repo::service_repo::get_services_for_server(&brain.pool, server.id).await
+            {
+                awareness.services = services
+                    .iter()
+                    .filter_map(|s| serde_json::to_value(s).ok())
+                    .collect();
+            }
+
+            // Get site
+            if let Ok(Some(site)) =
+                crate::repo::site_repo::get_site(&brain.pool, server.site_id).await
+            {
+                client_id = Some(site.client_id);
+                awareness.site = serde_json::to_value(&site).ok();
+
+                // Get client from site
+                if let Ok(Some(client)) =
+                    crate::repo::client_repo::get_client(&brain.pool, site.client_id).await
+                {
+                    awareness.client = serde_json::to_value(&client).ok();
+                }
+            }
+
+            // Get networks for this site
+            if let Some(sid) = site_id {
+                if let Ok(networks) =
+                    crate::repo::network_repo::list_networks(&brain.pool, Some(sid)).await
+                {
+                    awareness.networks = networks
+                        .iter()
+                        .filter_map(|n| serde_json::to_value(n).ok())
+                        .collect();
+                }
+            }
+
+            // Get runbooks linked to this server
+            if let Ok(runbooks) = crate::repo::runbook_repo::list_runbooks(
+                &brain.pool,
+                None,
+                None,
+                Some(server.id),
+                None,
+                None,
+            )
+            .await
+            {
+                awareness.relevant_runbooks = runbooks
+                    .iter()
+                    .filter_map(|r| serde_json::to_value(r).ok())
+                    .collect();
+            }
+        } else {
+            return not_found("Server", slug);
+        }
+    }
+
+    // Resolve service if provided
+    if let Some(slug) = &p.service_slug {
+        if let Ok(Some(svc)) =
+            crate::repo::service_repo::get_service_by_slug(&brain.pool, slug).await
+        {
+            service_id = Some(svc.id);
+
+            // Add service to list if not already present from server lookup
+            if awareness.services.is_empty() {
+                awareness.services =
+                    vec![serde_json::to_value(&svc).unwrap_or(serde_json::Value::Null)];
+            }
+
+            // Get servers running this service
+            if let Ok(servers) =
+                crate::repo::service_repo::get_servers_for_service(&brain.pool, svc.id).await
+            {
+                // If we don't have a server yet, use the first one for context
+                if awareness.server.is_none() {
+                    if let Some(first_server) = servers.first() {
+                        server_id = Some(first_server.id);
+                        #[allow(unused_assignments)]
+                        {
+                            site_id = Some(first_server.site_id);
+                        }
+                        awareness.server = serde_json::to_value(first_server).ok();
+
+                        if let Ok(Some(site)) =
+                            crate::repo::site_repo::get_site(&brain.pool, first_server.site_id)
+                                .await
+                        {
+                            client_id = Some(site.client_id);
+                            awareness.site = serde_json::to_value(&site).ok();
+                        }
+                    }
+                }
+            }
+
+            // Get runbooks linked to this service (merge with existing)
+            if let Ok(runbooks) = crate::repo::runbook_repo::list_runbooks(
+                &brain.pool,
+                None,
+                Some(svc.id),
+                None,
+                None,
+                None,
+            )
+            .await
+            {
+                for rb in &runbooks {
+                    if let Ok(val) = serde_json::to_value(rb) {
+                        if !awareness.relevant_runbooks.contains(&val) {
+                            awareness.relevant_runbooks.push(val);
+                        }
+                    }
+                }
+            }
+        } else {
+            return not_found("Service", slug);
+        }
+    }
+
+    // Resolve client if provided (may already be set from server/service lookup)
+    if let Some(slug) = &p.client_slug {
+        if let Ok(Some(client)) =
+            crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await
+        {
+            client_id = Some(client.id);
+            awareness.client = serde_json::to_value(&client).ok();
+        } else {
+            return not_found("Client", slug);
+        }
+    }
+
+    // Get vendors for client
+    if let Some(cid) = client_id {
+        if let Ok(vendors) =
+            crate::repo::vendor_repo::get_vendors_for_client(&brain.pool, cid).await
+        {
+            awareness.vendors = vendors
+                .iter()
+                .filter_map(|v| serde_json::to_value(v).ok())
+                .collect();
+        }
+
+        // Get recent incidents for this client
+        let incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
+            "SELECT * FROM incidents WHERE client_id = $1 ORDER BY reported_at DESC LIMIT 10",
+        )
+        .bind(cid)
+        .fetch_all(&brain.pool)
+        .await
+        .unwrap_or_default();
+
+        awareness.recent_incidents = incidents
+            .iter()
+            .filter_map(|i| serde_json::to_value(i).ok())
+            .collect();
+
+        // Get knowledge for this client
+        if let Ok(entries) =
+            crate::repo::knowledge_repo::list_knowledge(&brain.pool, None, Some(cid)).await
+        {
+            awareness.knowledge = entries
+                .iter()
+                .filter_map(|k| serde_json::to_value(k).ok())
+                .collect();
+        }
+    }
+
+    // If we have a server, also get incidents linked to that server
+    if let Some(srv_id) = server_id {
+        let server_incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
+            "SELECT i.* FROM incidents i \
+             JOIN incident_servers isv ON i.id = isv.incident_id \
+             WHERE isv.server_id = $1 \
+             ORDER BY i.reported_at DESC LIMIT 10",
+        )
+        .bind(srv_id)
+        .fetch_all(&brain.pool)
+        .await
+        .unwrap_or_default();
+
+        // Merge with existing incidents (avoid duplicates by ID)
+        for inc in &server_incidents {
+            if let Ok(val) = serde_json::to_value(inc) {
+                if !awareness
+                    .recent_incidents
+                    .iter()
+                    .any(|existing| existing.get("id") == val.get("id"))
+                {
+                    awareness.recent_incidents.push(val);
+                }
+            }
+        }
+    }
+
+    // If we have a service, also get incidents linked to that service
+    if let Some(svc_id) = service_id {
+        let service_incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
+            "SELECT i.* FROM incidents i \
+             JOIN incident_services iss ON i.id = iss.incident_id \
+             WHERE iss.service_id = $1 \
+             ORDER BY i.reported_at DESC LIMIT 10",
+        )
+        .bind(svc_id)
+        .fetch_all(&brain.pool)
+        .await
+        .unwrap_or_default();
+
+        for inc in &service_incidents {
+            if let Ok(val) = serde_json::to_value(inc) {
+                if !awareness
+                    .recent_incidents
+                    .iter()
+                    .any(|existing| existing.get("id") == val.get("id"))
+                {
+                    awareness.recent_incidents.push(val);
+                }
+            }
+        }
+    }
+
+    // Get pending handoffs
+    let handoffs: Vec<Handoff> = sqlx::query_as::<_, Handoff>(
+        "SELECT * FROM handoffs WHERE status = 'pending' ORDER BY created_at DESC LIMIT 10",
+    )
+    .fetch_all(&brain.pool)
+    .await
+    .unwrap_or_default();
+
+    awareness.pending_handoffs = handoffs
+        .iter()
+        .filter_map(|h| serde_json::to_value(h).ok())
+        .collect();
+
+    // Also add general knowledge (not client-specific)
+    if let Ok(general_knowledge) =
+        crate::repo::knowledge_repo::list_knowledge(&brain.pool, None, None).await
+    {
+        for entry in &general_knowledge {
+            if let Ok(val) = serde_json::to_value(entry) {
+                if !awareness
+                    .knowledge
+                    .iter()
+                    .any(|existing| existing.get("id") == val.get("id"))
+                {
+                    awareness.knowledge.push(val);
+                }
+            }
+        }
+    }
+
+    // Semantic enrichment: find related runbooks/knowledge beyond explicit links
+    if brain.embedding_client.is_some() {
+        // Build context string from resolved entities
+        let mut context_parts = Vec::new();
+        if let Some(ref srv) = awareness.server {
+            if let Some(hostname) = srv.get("hostname").and_then(|v| v.as_str()) {
+                context_parts.push(hostname.to_string());
+            }
+            if let Some(os) = srv.get("os").and_then(|v| v.as_str()) {
+                context_parts.push(os.to_string());
+            }
+        }
+        for svc in &awareness.services {
+            if let Some(name) = svc.get("name").and_then(|v| v.as_str()) {
+                context_parts.push(name.to_string());
+            }
+        }
+        if let Some(ref client) = awareness.client {
+            if let Some(name) = client.get("name").and_then(|v| v.as_str()) {
+                context_parts.push(name.to_string());
+            }
+        }
+
+        if !context_parts.is_empty() {
+            let context_query = context_parts.join(" ");
+            if let Some(emb) = get_query_embedding(&brain.embedding_client, &context_query).await {
+                // Find semantically related runbooks
+                if let Ok(related_runbooks) =
+                    crate::repo::embedding_repo::vector_search_runbooks(&brain.pool, &emb, 5).await
+                {
+                    for rb in &related_runbooks {
+                        if let Ok(val) = serde_json::to_value(rb) {
+                            if !awareness
+                                .relevant_runbooks
+                                .iter()
+                                .any(|existing| existing.get("id") == val.get("id"))
+                            {
+                                awareness.relevant_runbooks.push(val);
+                            }
+                        }
+                    }
+                }
+                // Find semantically related knowledge
+                if let Ok(related_knowledge) =
+                    crate::repo::embedding_repo::vector_search_knowledge(&brain.pool, &emb, 5).await
+                {
+                    for k in &related_knowledge {
+                        if let Ok(val) = serde_json::to_value(k) {
+                            if !awareness
+                                .knowledge
+                                .iter()
+                                .any(|existing| existing.get("id") == val.get("id"))
+                            {
+                                awareness.knowledge.push(val);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Cross-client scope gate for runbooks, knowledge, and incidents
+    {
+        let client_lookup = build_client_lookup(&brain.pool).await;
+
+        let rb_filtered = filter_cross_client(
+            std::mem::take(&mut awareness.relevant_runbooks),
+            "runbook",
+            client_id,
+            acknowledge,
+            &client_lookup,
+        );
+        awareness.relevant_runbooks = rb_filtered.allowed;
+        awareness
+            .cross_client_withheld
+            .extend(rb_filtered.withheld_notices);
+        log_audit_entries(
+            &brain.pool,
+            "get_situational_awareness",
+            client_id,
+            "runbook",
+            &rb_filtered.audit_entries,
+        )
+        .await;
+
+        let kn_filtered = filter_cross_client(
+            std::mem::take(&mut awareness.knowledge),
+            "knowledge",
+            client_id,
+            acknowledge,
+            &client_lookup,
+        );
+        awareness.knowledge = kn_filtered.allowed;
+        awareness
+            .cross_client_withheld
+            .extend(kn_filtered.withheld_notices);
+        log_audit_entries(
+            &brain.pool,
+            "get_situational_awareness",
+            client_id,
+            "knowledge",
+            &kn_filtered.audit_entries,
+        )
+        .await;
+
+        let inc_filtered = filter_cross_client(
+            std::mem::take(&mut awareness.recent_incidents),
+            "incident",
+            client_id,
+            acknowledge,
+            &client_lookup,
+        );
+        awareness.recent_incidents = inc_filtered.allowed;
+        awareness
+            .cross_client_withheld
+            .extend(inc_filtered.withheld_notices);
+        log_audit_entries(
+            &brain.pool,
+            "get_situational_awareness",
+            client_id,
+            "incident",
+            &inc_filtered.audit_entries,
+        )
+        .await;
+    }
+
+    // Fetch live monitoring data for linked servers/services
+    if let Some(ref kuma_config) = brain.kuma_config {
+        if let Ok(metrics) = crate::metrics::fetch_metrics(kuma_config).await {
+            // Get monitor mappings for this server and its services
+            let mut monitor_names: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+
+            if let Some(srv_id) = server_id {
+                if let Ok(monitors) =
+                    crate::repo::monitor_repo::get_monitors_for_server(&brain.pool, srv_id).await
+                {
+                    for m in &monitors {
+                        monitor_names.insert(m.monitor_name.clone());
+                    }
+                }
+            }
+
+            if let Some(svc_id) = service_id {
+                if let Ok(monitors) =
+                    crate::repo::monitor_repo::get_monitors_for_service(&brain.pool, svc_id).await
+                {
+                    for m in &monitors {
+                        monitor_names.insert(m.monitor_name.clone());
+                    }
+                }
+            }
+
+            // Match metrics to mapped monitors
+            for status in &metrics.monitors {
+                if monitor_names.contains(&status.name) {
+                    if let Ok(val) = serde_json::to_value(status) {
+                        awareness.monitoring.push(val);
+                    }
+                }
+            }
+        }
+    }
+
+    // Zammad linked tickets for this server/service
+    if brain.zammad_config.is_some() {
+        if let Some(srv_id) = server_id {
+            if let Ok(links) =
+                crate::repo::ticket_link_repo::get_links_for_server(&brain.pool, srv_id).await
+            {
+                for link in &links {
+                    if let Ok(val) = serde_json::to_value(link) {
+                        awareness.linked_tickets.push(val);
+                    }
+                }
+            }
+        }
+        if let Some(svc_id) = service_id {
+            if let Ok(links) =
+                crate::repo::ticket_link_repo::get_links_for_service(&brain.pool, svc_id).await
+            {
+                for link in &links {
+                    if let Ok(val) = serde_json::to_value(link) {
+                        awareness.linked_tickets.push(val);
+                    }
+                }
+            }
+        }
+    }
+
+    // Apply compact mode and sections filtering
+    if compact || sections.is_some() {
+        if compact {
+            if let Some(ref v) = awareness.server {
+                awareness.server = Some(compact_value(v, "server"));
+            }
+            if let Some(ref v) = awareness.site {
+                awareness.site = Some(compact_value(v, "site"));
+            }
+            if let Some(ref v) = awareness.client {
+                awareness.client = Some(compact_value(v, "client"));
+            }
+            awareness.services = compact_vec(&awareness.services, "service");
+            awareness.networks = compact_vec(&awareness.networks, "network");
+            awareness.vendors = compact_vec(&awareness.vendors, "vendor");
+            awareness.recent_incidents = compact_vec(&awareness.recent_incidents, "incident");
+            awareness.relevant_runbooks = compact_vec(&awareness.relevant_runbooks, "runbook");
+            awareness.pending_handoffs = compact_vec(&awareness.pending_handoffs, "handoff");
+            awareness.knowledge = compact_vec(&awareness.knowledge, "knowledge");
+            awareness.monitoring = compact_vec(&awareness.monitoring, "monitor");
+            awareness.linked_tickets = compact_vec(&awareness.linked_tickets, "ticket");
+        }
+        if sections.is_some() {
+            if !section_included(&sections, "server") {
+                awareness.server = None;
+            }
+            if !section_included(&sections, "site") {
+                awareness.site = None;
+            }
+            if !section_included(&sections, "client") {
+                awareness.client = None;
+            }
+            if !section_included(&sections, "services") {
+                awareness.services.clear();
+            }
+            if !section_included(&sections, "networks") {
+                awareness.networks.clear();
+            }
+            if !section_included(&sections, "vendors") {
+                awareness.vendors.clear();
+            }
+            if !section_included(&sections, "incidents") {
+                awareness.recent_incidents.clear();
+            }
+            if !section_included(&sections, "runbooks") {
+                awareness.relevant_runbooks.clear();
+            }
+            if !section_included(&sections, "handoffs") {
+                awareness.pending_handoffs.clear();
+            }
+            if !section_included(&sections, "knowledge") {
+                awareness.knowledge.clear();
+            }
+            if !section_included(&sections, "monitoring") {
+                awareness.monitoring.clear();
+            }
+            if !section_included(&sections, "tickets") {
+                awareness.linked_tickets.clear();
+            }
+        }
+    }
+
+    json_result(&awareness)
+}
+
+pub(crate) async fn handle_get_client_overview(
+    brain: &super::OpsBrain,
+    p: GetClientOverviewParams,
+) -> CallToolResult {
+    let client =
+        match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug).await {
+            Ok(Some(c)) => c,
+            Ok(None) => return not_found("Client", &p.client_slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        };
+
+    let sites = crate::repo::site_repo::list_sites(&brain.pool, Some(client.id))
+        .await
+        .unwrap_or_default();
+
+    let servers =
+        crate::repo::server_repo::list_servers(&brain.pool, Some(client.id), None, None, None)
+            .await
+            .unwrap_or_default();
+
+    // Collect all service IDs from all servers
+    let mut all_services = Vec::new();
+    let mut seen_service_ids = std::collections::HashSet::new();
+    for server in &servers {
+        if let Ok(svcs) =
+            crate::repo::service_repo::get_services_for_server(&brain.pool, server.id).await
+        {
+            for svc in svcs {
+                if seen_service_ids.insert(svc.id) {
+                    all_services.push(svc);
+                }
+            }
+        }
+    }
+
+    // Get networks for all sites
+    let mut all_networks = Vec::new();
+    for site in &sites {
+        if let Ok(nets) = crate::repo::network_repo::list_networks(&brain.pool, Some(site.id)).await
+        {
+            all_networks.extend(nets);
+        }
+    }
+
+    let vendors = crate::repo::vendor_repo::get_vendors_for_client(&brain.pool, client.id)
+        .await
+        .unwrap_or_default();
+
+    let recent_incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
+        "SELECT * FROM incidents WHERE client_id = $1 ORDER BY reported_at DESC LIMIT 10",
+    )
+    .bind(client.id)
+    .fetch_all(&brain.pool)
+    .await
+    .unwrap_or_default();
+
+    let pending_handoffs: Vec<Handoff> = sqlx::query_as::<_, Handoff>(
+        "SELECT * FROM handoffs WHERE status = 'pending' ORDER BY created_at DESC LIMIT 10",
+    )
+    .fetch_all(&brain.pool)
+    .await
+    .unwrap_or_default();
+
+    let mut overview = ClientOverview {
+        client: serde_json::to_value(&client).unwrap_or(serde_json::Value::Null),
+        sites: sites
+            .iter()
+            .filter_map(|s| serde_json::to_value(s).ok())
+            .collect(),
+        servers: servers
+            .iter()
+            .filter_map(|s| serde_json::to_value(s).ok())
+            .collect(),
+        services: all_services
+            .iter()
+            .filter_map(|s| serde_json::to_value(s).ok())
+            .collect(),
+        networks: all_networks
+            .iter()
+            .filter_map(|n| serde_json::to_value(n).ok())
+            .collect(),
+        vendors: vendors
+            .iter()
+            .filter_map(|v| serde_json::to_value(v).ok())
+            .collect(),
+        recent_incidents: recent_incidents
+            .iter()
+            .filter_map(|i| serde_json::to_value(i).ok())
+            .collect(),
+        pending_handoffs: pending_handoffs
+            .iter()
+            .filter_map(|h| serde_json::to_value(h).ok())
+            .collect(),
+        recent_tickets: Vec::new(),
+    };
+
+    // Fetch recent Zammad tickets for this client
+    if let Some(ref zammad) = brain.zammad_config {
+        if let Some(org_id) = client.zammad_org_id {
+            let query = format!("organization.id:{org_id}");
+            match crate::zammad::search_tickets(zammad, &query, 5).await {
+                Ok(tickets) => {
+                    overview.recent_tickets = tickets
+                        .iter()
+                        .filter_map(|t| serde_json::to_value(t).ok())
+                        .collect();
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to fetch Zammad tickets for client overview: {e}");
+                }
+            }
+        }
+    }
+
+    json_result(&overview)
+}
+
+pub(crate) async fn handle_get_server_context(
+    brain: &super::OpsBrain,
+    p: GetServerContextParams,
+) -> CallToolResult {
+    let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
+    let compact = p.compact.unwrap_or(false);
+    let sections = p.sections;
+
+    let server =
+        match crate::repo::server_repo::get_server_by_slug(&brain.pool, &p.server_slug).await {
+            Ok(Some(s)) => s,
+            Ok(None) => return not_found("Server", &p.server_slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        };
+
+    let services = crate::repo::service_repo::get_services_for_server(&brain.pool, server.id)
+        .await
+        .unwrap_or_default();
+
+    let site = crate::repo::site_repo::get_site(&brain.pool, server.site_id)
+        .await
+        .ok()
+        .flatten();
+
+    let networks = crate::repo::network_repo::list_networks(&brain.pool, Some(server.site_id))
+        .await
+        .unwrap_or_default();
+
+    // Get client for vendor lookup
+    let client_id = site.as_ref().map(|s| s.client_id);
+    let client = if let Some(cid) = client_id {
+        crate::repo::client_repo::get_client(&brain.pool, cid)
+            .await
+            .ok()
+            .flatten()
+    } else {
+        None
+    };
+
+    let vendors = if let Some(cid) = client_id {
+        crate::repo::vendor_repo::get_vendors_for_client(&brain.pool, cid)
+            .await
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    // Get incidents linked to this server
+    let incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
+        "SELECT i.* FROM incidents i \
+         JOIN incident_servers isv ON i.id = isv.incident_id \
+         WHERE isv.server_id = $1 \
+         ORDER BY i.reported_at DESC LIMIT 10",
+    )
+    .bind(server.id)
+    .fetch_all(&brain.pool)
+    .await
+    .unwrap_or_default();
+
+    // Also get client-level incidents
+    let client_incidents: Vec<Incident> = if let Some(cid) = client_id {
+        sqlx::query_as::<_, Incident>(
+            "SELECT * FROM incidents WHERE client_id = $1 ORDER BY reported_at DESC LIMIT 10",
+        )
+        .bind(cid)
+        .fetch_all(&brain.pool)
+        .await
+        .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    // Merge incidents, dedup by id
+    let mut all_incidents: Vec<serde_json::Value> = Vec::new();
+    let mut seen_ids = std::collections::HashSet::new();
+    for inc in incidents.iter().chain(client_incidents.iter()) {
+        if seen_ids.insert(inc.id) {
+            if let Ok(val) = serde_json::to_value(inc) {
+                all_incidents.push(val);
+            }
+        }
+    }
+
+    // Get runbooks linked to this server
+    let runbooks = crate::repo::runbook_repo::list_runbooks(
+        &brain.pool,
+        None,
+        None,
+        Some(server.id),
+        None,
+        None,
+    )
+    .await
+    .unwrap_or_default();
+
+    // Also get runbooks linked to any of this server's services
+    let mut all_runbooks: Vec<serde_json::Value> = runbooks
+        .iter()
+        .filter_map(|r| serde_json::to_value(r).ok())
+        .collect();
+    let mut seen_runbook_ids: std::collections::HashSet<uuid::Uuid> =
+        runbooks.iter().map(|r| r.id).collect();
+
+    for svc in &services {
+        if let Ok(svc_runbooks) = crate::repo::runbook_repo::list_runbooks(
+            &brain.pool,
+            None,
+            Some(svc.id),
+            None,
+            None,
+            None,
+        )
+        .await
+        {
+            for rb in &svc_runbooks {
+                if seen_runbook_ids.insert(rb.id) {
+                    if let Ok(val) = serde_json::to_value(rb) {
+                        all_runbooks.push(val);
+                    }
+                }
+            }
+        }
+    }
+
+    // Get knowledge entries for this client
+    let mut all_knowledge: Vec<serde_json::Value> = if let Some(cid) = client_id {
+        crate::repo::knowledge_repo::list_knowledge(&brain.pool, None, Some(cid))
+            .await
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|k| serde_json::to_value(k).ok())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let mut seen_knowledge_ids: std::collections::HashSet<uuid::Uuid> = all_knowledge
+        .iter()
+        .filter_map(|v| {
+            v.get("id")
+                .and_then(|id| id.as_str())
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+        })
+        .collect();
+
+    // Semantic enrichment: find related runbooks/knowledge beyond explicit links
+    if brain.embedding_client.is_some() {
+        let mut context_parts = vec![server.hostname.clone()];
+        if let Some(ref os) = server.os {
+            context_parts.push(os.clone());
+        }
+        for svc in &services {
+            context_parts.push(svc.name.clone());
+        }
+        let context_query = context_parts.join(" ");
+        if let Some(emb) = get_query_embedding(&brain.embedding_client, &context_query).await {
+            if let Ok(related_runbooks) =
+                crate::repo::embedding_repo::vector_search_runbooks(&brain.pool, &emb, 5).await
+            {
+                for rb in &related_runbooks {
+                    if seen_runbook_ids.insert(rb.id) {
+                        if let Ok(val) = serde_json::to_value(rb) {
+                            all_runbooks.push(val);
+                        }
+                    }
+                }
+            }
+            if let Ok(related_knowledge) =
+                crate::repo::embedding_repo::vector_search_knowledge(&brain.pool, &emb, 5).await
+            {
+                for k in &related_knowledge {
+                    if seen_knowledge_ids.insert(k.id) {
+                        if let Ok(val) = serde_json::to_value(k) {
+                            all_knowledge.push(val);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Cross-client scope gate for runbooks, knowledge, and incidents
+    let mut cross_client_withheld: Vec<serde_json::Value> = Vec::new();
+    {
+        let client_lookup = build_client_lookup(&brain.pool).await;
+
+        let rb_filtered = filter_cross_client(
+            std::mem::take(&mut all_runbooks),
+            "runbook",
+            client_id,
+            acknowledge,
+            &client_lookup,
+        );
+        all_runbooks = rb_filtered.allowed;
+        cross_client_withheld.extend(rb_filtered.withheld_notices);
+        log_audit_entries(
+            &brain.pool,
+            "get_server_context",
+            client_id,
+            "runbook",
+            &rb_filtered.audit_entries,
+        )
+        .await;
+
+        let kn_filtered = filter_cross_client(
+            std::mem::take(&mut all_knowledge),
+            "knowledge",
+            client_id,
+            acknowledge,
+            &client_lookup,
+        );
+        all_knowledge = kn_filtered.allowed;
+        cross_client_withheld.extend(kn_filtered.withheld_notices);
+        log_audit_entries(
+            &brain.pool,
+            "get_server_context",
+            client_id,
+            "knowledge",
+            &kn_filtered.audit_entries,
+        )
+        .await;
+
+        let inc_filtered = filter_cross_client(
+            std::mem::take(&mut all_incidents),
+            "incident",
+            client_id,
+            acknowledge,
+            &client_lookup,
+        );
+        all_incidents = inc_filtered.allowed;
+        cross_client_withheld.extend(inc_filtered.withheld_notices);
+        log_audit_entries(
+            &brain.pool,
+            "get_server_context",
+            client_id,
+            "incident",
+            &inc_filtered.audit_entries,
+        )
+        .await;
+    }
+
+    // Fetch live monitoring data for this server and its services
+    let mut monitoring: Vec<serde_json::Value> = Vec::new();
+    if let Some(ref kuma_config) = brain.kuma_config {
+        if let Ok(metrics) = crate::metrics::fetch_metrics(kuma_config).await {
+            let mut monitor_names: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+
+            if let Ok(monitors) =
+                crate::repo::monitor_repo::get_monitors_for_server(&brain.pool, server.id).await
+            {
+                for m in &monitors {
+                    monitor_names.insert(m.monitor_name.clone());
+                }
+            }
+
+            for svc in &services {
+                if let Ok(monitors) =
+                    crate::repo::monitor_repo::get_monitors_for_service(&brain.pool, svc.id).await
+                {
+                    for m in &monitors {
+                        monitor_names.insert(m.monitor_name.clone());
+                    }
+                }
+            }
+
+            for status in &metrics.monitors {
+                if monitor_names.contains(&status.name) {
+                    if let Ok(val) = serde_json::to_value(status) {
+                        monitoring.push(val);
+                    }
+                }
+            }
+        }
+    }
+
+    // Zammad linked tickets for this server
+    let mut linked_tickets: Vec<serde_json::Value> = Vec::new();
+    if brain.zammad_config.is_some() {
+        if let Ok(links) =
+            crate::repo::ticket_link_repo::get_links_for_server(&brain.pool, server.id).await
+        {
+            for link in &links {
+                if let Ok(val) = serde_json::to_value(link) {
+                    linked_tickets.push(val);
+                }
+            }
+        }
+    }
+
+    let server_json = serde_json::to_value(&server).unwrap_or_default();
+    let site_json = serde_json::to_value(&site).unwrap_or_default();
+    let client_json = serde_json::to_value(&client).unwrap_or_default();
+    let services_json: Vec<serde_json::Value> = services
+        .iter()
+        .filter_map(|s| serde_json::to_value(s).ok())
+        .collect();
+    let networks_json: Vec<serde_json::Value> = networks
+        .iter()
+        .filter_map(|n| serde_json::to_value(n).ok())
+        .collect();
+    let vendors_json: Vec<serde_json::Value> = vendors
+        .iter()
+        .filter_map(|v| serde_json::to_value(v).ok())
+        .collect();
+
+    let mut result = serde_json::json!({});
+
+    if section_included(&sections, "server") {
+        result["server"] = if compact {
+            compact_value(&server_json, "server")
+        } else {
+            server_json
+        };
+    }
+    if section_included(&sections, "services") {
+        result["services"] = if compact {
+            serde_json::to_value(compact_vec(&services_json, "service")).unwrap_or_default()
+        } else {
+            serde_json::to_value(&services_json).unwrap_or_default()
+        };
+    }
+    if section_included(&sections, "site") {
+        result["site"] = if compact {
+            compact_value(&site_json, "site")
+        } else {
+            site_json
+        };
+    }
+    if section_included(&sections, "client") {
+        result["client"] = if compact {
+            compact_value(&client_json, "client")
+        } else {
+            client_json
+        };
+    }
+    if section_included(&sections, "networks") {
+        result["networks"] = if compact {
+            serde_json::to_value(compact_vec(&networks_json, "network")).unwrap_or_default()
+        } else {
+            serde_json::to_value(&networks_json).unwrap_or_default()
+        };
+    }
+    if section_included(&sections, "vendors") {
+        result["vendors"] = if compact {
+            serde_json::to_value(compact_vec(&vendors_json, "vendor")).unwrap_or_default()
+        } else {
+            serde_json::to_value(&vendors_json).unwrap_or_default()
+        };
+    }
+    if section_included(&sections, "incidents") {
+        result["recent_incidents"] = if compact {
+            serde_json::to_value(compact_vec(&all_incidents, "incident")).unwrap_or_default()
+        } else {
+            serde_json::to_value(&all_incidents).unwrap_or_default()
+        };
+    }
+    if section_included(&sections, "runbooks") {
+        result["runbooks"] = if compact {
+            serde_json::to_value(compact_vec(&all_runbooks, "runbook")).unwrap_or_default()
+        } else {
+            serde_json::to_value(&all_runbooks).unwrap_or_default()
+        };
+    }
+    if section_included(&sections, "knowledge") {
+        result["knowledge"] = if compact {
+            serde_json::to_value(compact_vec(&all_knowledge, "knowledge")).unwrap_or_default()
+        } else {
+            serde_json::to_value(&all_knowledge).unwrap_or_default()
+        };
+    }
+    if section_included(&sections, "monitoring") && !monitoring.is_empty() {
+        result["monitoring"] = if compact {
+            serde_json::to_value(compact_vec(&monitoring, "monitor")).unwrap_or_default()
+        } else {
+            serde_json::to_value(&monitoring).unwrap_or_default()
+        };
+    }
+    if section_included(&sections, "tickets") && !linked_tickets.is_empty() {
+        result["linked_tickets"] = if compact {
+            serde_json::to_value(compact_vec(&linked_tickets, "ticket")).unwrap_or_default()
+        } else {
+            serde_json::to_value(&linked_tickets).unwrap_or_default()
+        };
+    }
+    if !cross_client_withheld.is_empty() {
+        result["cross_client_withheld"] = serde_json::json!(cross_client_withheld);
+    }
+
+    json_result(&result)
 }

--- a/src/tools/coordination.rs
+++ b/src/tools/coordination.rs
@@ -1,6 +1,10 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use super::helpers::{error_result, json_result, not_found};
+use super::shared::{embed_and_store, get_query_embedding};
+use rmcp::model::*;
+
 // ===== SESSION PARAMS =====
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -73,4 +77,219 @@ pub struct SearchHandoffsParams {
     pub query: String,
     /// Search mode: "fts" (default), "semantic" (vector only), or "hybrid" (FTS + vector RRF)
     pub mode: Option<String>,
+}
+
+// ===== SESSION HANDLERS =====
+
+pub(crate) async fn handle_start_session(
+    brain: &super::OpsBrain,
+    p: StartSessionParams,
+) -> CallToolResult {
+    match crate::repo::session_repo::start_session(&brain.pool, &p.machine_id, &p.machine_hostname)
+        .await
+    {
+        Ok(session) => json_result(&session),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_end_session(
+    brain: &super::OpsBrain,
+    p: EndSessionParams,
+) -> CallToolResult {
+    let id = match uuid::Uuid::parse_str(&p.session_id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.session_id)),
+    };
+
+    match crate::repo::session_repo::end_session(&brain.pool, id, p.summary.as_deref()).await {
+        Ok(session) => json_result(&session),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_list_sessions(
+    brain: &super::OpsBrain,
+    p: ListSessionsParams,
+) -> CallToolResult {
+    let limit = p.limit.unwrap_or(20);
+    let active_only = p.active_only.unwrap_or(false);
+
+    match crate::repo::session_repo::list_sessions(
+        &brain.pool,
+        p.machine_id.as_deref(),
+        active_only,
+        limit,
+    )
+    .await
+    {
+        Ok(sessions) => json_result(&sessions),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+// ===== HANDOFF HANDLERS =====
+
+pub(crate) async fn handle_create_handoff(
+    brain: &super::OpsBrain,
+    p: CreateHandoffParams,
+) -> CallToolResult {
+    let priority = p.priority.as_deref().unwrap_or("normal");
+
+    if let Err(msg) = crate::validation::validate_required(
+        priority,
+        "priority",
+        crate::validation::HANDOFF_PRIORITIES,
+    ) {
+        return error_result(&msg);
+    }
+
+    // Resolve optional session ID
+    let from_session_id = match &p.from_session_id {
+        Some(id_str) => match uuid::Uuid::parse_str(id_str) {
+            Ok(id) => Some(id),
+            Err(_) => return error_result(&format!("Invalid session UUID: {id_str}")),
+        },
+        None => None,
+    };
+
+    match crate::repo::handoff_repo::create_handoff(
+        &brain.pool,
+        from_session_id,
+        &p.from_machine,
+        p.to_machine.as_deref(),
+        priority,
+        &p.title,
+        &p.body,
+        p.context.as_ref(),
+    )
+    .await
+    {
+        Ok(handoff) => {
+            let text = crate::embeddings::prepare_handoff_text(&handoff);
+            embed_and_store(
+                &brain.pool,
+                &brain.embedding_client,
+                "handoffs",
+                handoff.id,
+                &text,
+            )
+            .await;
+            json_result(&handoff)
+        }
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_accept_handoff(
+    brain: &super::OpsBrain,
+    p: UpdateHandoffStatusParams,
+) -> CallToolResult {
+    let id = match uuid::Uuid::parse_str(&p.handoff_id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.handoff_id)),
+    };
+
+    // Verify it's pending
+    match crate::repo::handoff_repo::get_handoff(&brain.pool, id).await {
+        Ok(Some(h)) if h.status == "pending" => {}
+        Ok(Some(h)) => {
+            return error_result(&format!("Handoff is already '{}', cannot accept", h.status))
+        }
+        Ok(None) => return not_found("Handoff", &p.handoff_id),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    }
+
+    match crate::repo::handoff_repo::update_handoff_status(&brain.pool, id, "accepted").await {
+        Ok(handoff) => json_result(&handoff),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_complete_handoff(
+    brain: &super::OpsBrain,
+    p: UpdateHandoffStatusParams,
+) -> CallToolResult {
+    let id = match uuid::Uuid::parse_str(&p.handoff_id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.handoff_id)),
+    };
+
+    // Verify it exists and is not already completed
+    match crate::repo::handoff_repo::get_handoff(&brain.pool, id).await {
+        Ok(Some(h)) if h.status == "completed" => {
+            return error_result("Handoff is already completed")
+        }
+        Ok(Some(_)) => {}
+        Ok(None) => return not_found("Handoff", &p.handoff_id),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    }
+
+    match crate::repo::handoff_repo::update_handoff_status(&brain.pool, id, "completed").await {
+        Ok(handoff) => json_result(&handoff),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_list_handoffs(
+    brain: &super::OpsBrain,
+    p: ListHandoffsParams,
+) -> CallToolResult {
+    let limit = p.limit.unwrap_or(20);
+
+    if let Err(msg) = crate::validation::validate_option(
+        p.status.as_deref(),
+        "status",
+        crate::validation::HANDOFF_STATUSES,
+    ) {
+        return error_result(&msg);
+    }
+
+    match crate::repo::handoff_repo::list_handoffs(
+        &brain.pool,
+        p.status.as_deref(),
+        p.to_machine.as_deref(),
+        p.from_machine.as_deref(),
+        limit,
+    )
+    .await
+    {
+        Ok(handoffs) => json_result(&handoffs),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_search_handoffs(
+    brain: &super::OpsBrain,
+    p: SearchHandoffsParams,
+) -> CallToolResult {
+    let mode = p.mode.as_deref().unwrap_or("fts");
+    if let Err(msg) =
+        crate::validation::validate_required(mode, "mode", crate::validation::SEARCH_MODES)
+    {
+        return error_result(&msg);
+    }
+    let result = match mode {
+        "semantic" => {
+            let Some(emb) = get_query_embedding(&brain.embedding_client, &p.query).await else {
+                return error_result("Semantic search unavailable (OPENAI_API_KEY not set)");
+            };
+            crate::repo::embedding_repo::vector_search_handoffs(&brain.pool, &emb, 20).await
+        }
+        "hybrid" => {
+            let emb = get_query_embedding(&brain.embedding_client, &p.query).await;
+            crate::repo::embedding_repo::hybrid_search_handoffs(
+                &brain.pool,
+                &p.query,
+                emb.as_deref(),
+                20,
+            )
+            .await
+        }
+        _ => crate::repo::handoff_repo::search_handoffs(&brain.pool, &p.query).await,
+    };
+    match result {
+        Ok(handoffs) => json_result(&handoffs),
+        Err(e) => error_result(&format!("Search error: {e}")),
+    }
 }

--- a/src/tools/helpers.rs
+++ b/src/tools/helpers.rs
@@ -1,0 +1,278 @@
+use rmcp::model::*;
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Helper to format tool results as JSON text content.
+pub(crate) fn json_result<T: Serialize>(data: &T) -> CallToolResult {
+    match serde_json::to_string_pretty(data) {
+        Ok(json) => CallToolResult::success(vec![Content::text(json)]),
+        Err(e) => CallToolResult::error(vec![Content::text(format!("Serialization error: {e}"))]),
+    }
+}
+
+pub(crate) fn error_result(msg: &str) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(msg.to_string())])
+}
+
+pub(crate) fn not_found(entity: &str, key: &str) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(format!("{entity} not found: {key}"))])
+}
+
+/// Result of cross-client scope filtering.
+pub(crate) struct CrossClientFilterResult {
+    /// Items that passed the gate (with _provenance fields injected)
+    pub allowed: Vec<serde_json::Value>,
+    /// Grouped notices about withheld content (for response)
+    pub withheld_notices: Vec<serde_json::Value>,
+    /// Individual (entity_id, owning_client_id, action) for audit logging
+    pub audit_entries: Vec<(uuid::Uuid, Option<uuid::Uuid>, String)>,
+}
+
+/// Partition items into allowed and withheld based on cross-client scope.
+///
+/// Rules:
+/// - No requesting client → all items allowed (no scope to enforce)
+/// - Item client_id is NULL → allowed (global content)
+/// - Item client_id == requesting → allowed (same client)
+/// - Item client_id != requesting + cross_client_safe=true → allowed
+/// - Item client_id != requesting + cross_client_safe=false + acknowledge=true → allowed (released)
+/// - Item client_id != requesting + cross_client_safe=false + acknowledge=false → WITHHELD
+pub(crate) fn filter_cross_client(
+    items: Vec<serde_json::Value>,
+    entity_type: &str,
+    requesting_client_id: Option<uuid::Uuid>,
+    acknowledge: bool,
+    client_lookup: &HashMap<uuid::Uuid, (String, String)>,
+) -> CrossClientFilterResult {
+    let Some(req_cid) = requesting_client_id else {
+        // No requesting client scope — all items are allowed, inject provenance
+        let allowed = items
+            .into_iter()
+            .map(|mut item| {
+                inject_provenance(&mut item, client_lookup);
+                item
+            })
+            .collect();
+        return CrossClientFilterResult {
+            allowed,
+            withheld_notices: Vec::new(),
+            audit_entries: Vec::new(),
+        };
+    };
+
+    let mut allowed = Vec::new();
+    let mut withheld_by_client: HashMap<uuid::Uuid, Vec<uuid::Uuid>> = HashMap::new();
+    let mut audit_entries = Vec::new();
+
+    for mut item in items {
+        let item_client_id = item
+            .get("client_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| uuid::Uuid::parse_str(s).ok());
+
+        let cross_client_safe = item
+            .get("cross_client_safe")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let entity_id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| uuid::Uuid::parse_str(s).ok());
+
+        match item_client_id {
+            // Global content (no client_id) — always allowed
+            None => {
+                inject_provenance(&mut item, client_lookup);
+                allowed.push(item);
+            }
+            // Same client — allowed
+            Some(cid) if cid == req_cid => {
+                inject_provenance(&mut item, client_lookup);
+                allowed.push(item);
+            }
+            // Different client but marked safe — allowed
+            Some(cid) if cross_client_safe => {
+                inject_provenance(&mut item, client_lookup);
+                allowed.push(item);
+                if let Some(eid) = entity_id {
+                    audit_entries.push((eid, Some(cid), "released_safe".to_string()));
+                }
+            }
+            // Different client, not safe, but acknowledged — released
+            Some(cid) if acknowledge => {
+                inject_provenance(&mut item, client_lookup);
+                allowed.push(item);
+                if let Some(eid) = entity_id {
+                    audit_entries.push((eid, Some(cid), "released".to_string()));
+                }
+            }
+            // Different client, not safe, not acknowledged — WITHHELD
+            Some(cid) => {
+                if let Some(eid) = entity_id {
+                    withheld_by_client.entry(cid).or_default().push(eid);
+                    audit_entries.push((eid, Some(cid), "withheld".to_string()));
+                }
+            }
+        }
+    }
+
+    // Build grouped withheld notices
+    let withheld_notices: Vec<serde_json::Value> = withheld_by_client
+        .into_iter()
+        .map(|(cid, entity_ids)| {
+            let (slug, name) = client_lookup
+                .get(&cid)
+                .cloned()
+                .unwrap_or_else(|| ("unknown".to_string(), "Unknown".to_string()));
+            serde_json::json!({
+                "entity_type": entity_type,
+                "count": entity_ids.len(),
+                "owning_client_slug": slug,
+                "owning_client_name": name,
+                "message": format!(
+                    "{} {}(s) from client '{}' withheld — cross-client scope mismatch. Re-call with acknowledge_cross_client: true to release.",
+                    entity_ids.len(), entity_type, name
+                )
+            })
+        })
+        .collect();
+
+    CrossClientFilterResult {
+        allowed,
+        withheld_notices,
+        audit_entries,
+    }
+}
+
+/// Inject _provenance fields (client slug + name) into a JSON item.
+pub(crate) fn inject_provenance(
+    item: &mut serde_json::Value,
+    client_lookup: &HashMap<uuid::Uuid, (String, String)>,
+) {
+    if let Some(obj) = item.as_object_mut() {
+        let client_id = obj
+            .get("client_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| uuid::Uuid::parse_str(s).ok());
+        match client_id {
+            Some(cid) => {
+                if let Some((slug, name)) = client_lookup.get(&cid) {
+                    obj.insert(
+                        "_client_slug".to_string(),
+                        serde_json::Value::String(slug.clone()),
+                    );
+                    obj.insert(
+                        "_client_name".to_string(),
+                        serde_json::Value::String(name.clone()),
+                    );
+                }
+            }
+            None => {
+                obj.insert("_client_slug".to_string(), serde_json::Value::Null);
+                obj.insert(
+                    "_client_name".to_string(),
+                    serde_json::Value::String("Global".to_string()),
+                );
+            }
+        }
+    }
+}
+
+/// Fields to keep per entity type in compact mode. Everything else is stripped.
+pub(crate) fn compact_keep_fields(entity_type: &str) -> &'static [&'static str] {
+    match entity_type {
+        "server" => &[
+            "id",
+            "hostname",
+            "slug",
+            "os",
+            "ip_address",
+            "status",
+            "roles",
+            "site_id",
+        ],
+        "site" => &["id", "name", "slug", "address", "client_id"],
+        "client" => &["id", "name", "slug"],
+        "service" => &["id", "name", "slug", "port", "protocol", "criticality"],
+        "network" => &["id", "name", "cidr", "vlan_id"],
+        "vendor" => &["id", "name", "category"],
+        "incident" => &[
+            "id",
+            "title",
+            "severity",
+            "status",
+            "client_id",
+            "reported_at",
+            "resolved_at",
+            "time_to_resolve_minutes",
+            "cross_client_safe",
+            "_client_slug",
+            "_client_name",
+        ],
+        "runbook" => &[
+            "id",
+            "title",
+            "slug",
+            "category",
+            "client_id",
+            "cross_client_safe",
+            "_client_slug",
+            "_client_name",
+        ],
+        "handoff" => &[
+            "id",
+            "title",
+            "status",
+            "priority",
+            "from_machine",
+            "to_machine",
+            "created_at",
+        ],
+        "knowledge" => &[
+            "id",
+            "title",
+            "category",
+            "client_id",
+            "cross_client_safe",
+            "_client_slug",
+            "_client_name",
+        ],
+        "monitor" => &["name", "status_text", "monitor_type"],
+        "ticket" => &["ticket_id", "title", "state", "priority", "created_at"],
+        _ => &["id", "title", "slug", "name"],
+    }
+}
+
+/// Strip a JSON value down to only the fields allowed for its entity type.
+pub(crate) fn compact_value(val: &serde_json::Value, entity_type: &str) -> serde_json::Value {
+    let Some(obj) = val.as_object() else {
+        return val.clone();
+    };
+    let keep = compact_keep_fields(entity_type);
+    let compacted: serde_json::Map<String, serde_json::Value> = obj
+        .iter()
+        .filter(|(k, _)| keep.contains(&k.as_str()))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    serde_json::Value::Object(compacted)
+}
+
+/// Apply compact mode to a Vec of JSON values.
+pub(crate) fn compact_vec(
+    items: &[serde_json::Value],
+    entity_type: &str,
+) -> Vec<serde_json::Value> {
+    items
+        .iter()
+        .map(|v| compact_value(v, entity_type))
+        .collect()
+}
+
+/// Check if a section is included (None means all sections included).
+pub(crate) fn section_included(sections: &Option<Vec<String>>, name: &str) -> bool {
+    match sections {
+        None => true,
+        Some(list) => list.iter().any(|s| s == name),
+    }
+}

--- a/src/tools/incidents.rs
+++ b/src/tools/incidents.rs
@@ -1,6 +1,10 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use super::helpers::{error_result, json_result, not_found};
+use super::shared::{embed_and_store, get_query_embedding};
+use rmcp::model::*;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CreateIncidentParams {
     /// Short title describing the incident
@@ -91,4 +95,393 @@ pub struct RunbookLink {
     pub slug: String,
     /// Usage: followed, not-applicable, or not-followed
     pub usage: Option<String>,
+}
+
+// ===== HANDLERS =====
+
+pub(crate) async fn handle_create_incident(
+    brain: &super::OpsBrain,
+    p: CreateIncidentParams,
+) -> CallToolResult {
+    let severity = p.severity.as_deref().unwrap_or("medium");
+
+    if let Err(msg) = crate::validation::validate_required(
+        severity,
+        "severity",
+        crate::validation::INCIDENT_SEVERITIES,
+    ) {
+        return error_result(&msg);
+    }
+
+    // Resolve client_slug
+    let client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    let cross_client_safe = p.cross_client_safe.unwrap_or(false);
+    let incident = match crate::repo::incident_repo::create_incident(
+        &brain.pool,
+        &p.title,
+        severity,
+        client_id,
+        p.symptoms.as_deref(),
+        p.notes.as_deref(),
+        cross_client_safe,
+    )
+    .await
+    {
+        Ok(i) => i,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+
+    // Link servers if provided
+    if let Some(slugs) = &p.server_slugs {
+        for slug in slugs {
+            if let Ok(Some(server)) =
+                crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await
+            {
+                let _ = crate::repo::incident_repo::link_incident_server(
+                    &brain.pool,
+                    incident.id,
+                    server.id,
+                )
+                .await;
+            }
+        }
+    }
+
+    // Link services if provided
+    if let Some(slugs) = &p.service_slugs {
+        for slug in slugs {
+            if let Ok(Some(service)) =
+                crate::repo::service_repo::get_service_by_slug(&brain.pool, slug).await
+            {
+                let _ = crate::repo::incident_repo::link_incident_service(
+                    &brain.pool,
+                    incident.id,
+                    service.id,
+                )
+                .await;
+            }
+        }
+    }
+
+    let text = crate::embeddings::prepare_incident_text(&incident);
+    embed_and_store(
+        &brain.pool,
+        &brain.embedding_client,
+        "incidents",
+        incident.id,
+        &text,
+    )
+    .await;
+
+    json_result(&incident)
+}
+
+pub(crate) async fn handle_update_incident(
+    brain: &super::OpsBrain,
+    p: UpdateIncidentParams,
+) -> CallToolResult {
+    let id = match uuid::Uuid::parse_str(&p.id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.id)),
+    };
+
+    if let Err(msg) = crate::validation::validate_option(
+        p.status.as_deref(),
+        "status",
+        crate::validation::INCIDENT_STATUSES,
+    ) {
+        return error_result(&msg);
+    }
+    if let Err(msg) = crate::validation::validate_option(
+        p.severity.as_deref(),
+        "severity",
+        crate::validation::INCIDENT_SEVERITIES,
+    ) {
+        return error_result(&msg);
+    }
+
+    match crate::repo::incident_repo::update_incident(
+        &brain.pool,
+        id,
+        p.title.as_deref(),
+        p.status.as_deref(),
+        p.severity.as_deref(),
+        p.symptoms.as_deref(),
+        p.root_cause.as_deref(),
+        p.resolution.as_deref(),
+        p.prevention.as_deref(),
+        p.notes.as_deref(),
+        p.cross_client_safe,
+    )
+    .await
+    {
+        Ok(incident) => {
+            let text = crate::embeddings::prepare_incident_text(&incident);
+            embed_and_store(
+                &brain.pool,
+                &brain.embedding_client,
+                "incidents",
+                incident.id,
+                &text,
+            )
+            .await;
+            json_result(&incident)
+        }
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_get_incident(
+    brain: &super::OpsBrain,
+    p: GetIncidentParams,
+) -> CallToolResult {
+    let id = match uuid::Uuid::parse_str(&p.id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.id)),
+    };
+
+    let incident = match crate::repo::incident_repo::get_incident(&brain.pool, id).await {
+        Ok(Some(i)) => i,
+        Ok(None) => return not_found("Incident", &p.id),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+
+    // Get linked entities
+    let linked_servers: Vec<crate::models::server::Server> = sqlx::query_as(
+        "SELECT s.* FROM servers s JOIN incident_servers isv ON s.id = isv.server_id WHERE isv.incident_id = $1",
+    )
+    .bind(id)
+    .fetch_all(&brain.pool)
+    .await
+    .unwrap_or_default();
+
+    let linked_services: Vec<crate::models::service::Service> = sqlx::query_as(
+        "SELECT s.* FROM services s JOIN incident_services iss ON s.id = iss.service_id WHERE iss.incident_id = $1",
+    )
+    .bind(id)
+    .fetch_all(&brain.pool)
+    .await
+    .unwrap_or_default();
+
+    let result = serde_json::json!({
+        "incident": incident,
+        "linked_servers": linked_servers,
+        "linked_services": linked_services,
+    });
+
+    json_result(&result)
+}
+
+pub(crate) async fn handle_list_incidents(
+    brain: &super::OpsBrain,
+    p: ListIncidentsParams,
+) -> CallToolResult {
+    let limit = p.limit.unwrap_or(20);
+
+    // Validate filters
+    if let Err(msg) = crate::validation::validate_option(
+        p.status.as_deref(),
+        "status",
+        crate::validation::INCIDENT_STATUSES,
+    ) {
+        return error_result(&msg);
+    }
+    if let Err(msg) = crate::validation::validate_option(
+        p.severity.as_deref(),
+        "severity",
+        crate::validation::INCIDENT_SEVERITIES,
+    ) {
+        return error_result(&msg);
+    }
+
+    // Resolve client_slug
+    let client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    match crate::repo::incident_repo::list_incidents(
+        &brain.pool,
+        client_id,
+        p.status.as_deref(),
+        p.severity.as_deref(),
+        limit,
+    )
+    .await
+    {
+        Ok(incidents) => json_result(&incidents),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_search_incidents(
+    brain: &super::OpsBrain,
+    p: SearchIncidentsParams,
+) -> CallToolResult {
+    let mode = p.mode.as_deref().unwrap_or("fts");
+    if let Err(msg) =
+        crate::validation::validate_required(mode, "mode", crate::validation::SEARCH_MODES)
+    {
+        return error_result(&msg);
+    }
+    let result = match mode {
+        "semantic" => {
+            let Some(emb) = get_query_embedding(&brain.embedding_client, &p.query).await else {
+                return error_result("Semantic search unavailable (OPENAI_API_KEY not set)");
+            };
+            crate::repo::embedding_repo::vector_search_incidents(&brain.pool, &emb, 20).await
+        }
+        "hybrid" => {
+            let emb = get_query_embedding(&brain.embedding_client, &p.query).await;
+            crate::repo::embedding_repo::hybrid_search_incidents(
+                &brain.pool,
+                &p.query,
+                emb.as_deref(),
+                20,
+            )
+            .await
+        }
+        _ => crate::repo::incident_repo::search_incidents(&brain.pool, &p.query).await,
+    };
+    match result {
+        Ok(incidents) => json_result(&incidents),
+        Err(e) => error_result(&format!("Search error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_link_incident(
+    brain: &super::OpsBrain,
+    p: LinkIncidentParams,
+) -> CallToolResult {
+    let incident_id = match uuid::Uuid::parse_str(&p.incident_id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.incident_id)),
+    };
+
+    // Verify incident exists
+    match crate::repo::incident_repo::get_incident(&brain.pool, incident_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return not_found("Incident", &p.incident_id),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    }
+
+    let mut linked = Vec::new();
+
+    // Link servers
+    if let Some(slugs) = &p.server_slugs {
+        for slug in slugs {
+            match crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await {
+                Ok(Some(server)) => {
+                    if let Err(e) = crate::repo::incident_repo::link_incident_server(
+                        &brain.pool,
+                        incident_id,
+                        server.id,
+                    )
+                    .await
+                    {
+                        return error_result(&format!("Failed to link server '{slug}': {e}"));
+                    }
+                    linked.push(format!("server:{slug}"));
+                }
+                Ok(None) => return not_found("Server", slug),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            }
+        }
+    }
+
+    // Link services
+    if let Some(slugs) = &p.service_slugs {
+        for slug in slugs {
+            match crate::repo::service_repo::get_service_by_slug(&brain.pool, slug).await {
+                Ok(Some(service)) => {
+                    if let Err(e) = crate::repo::incident_repo::link_incident_service(
+                        &brain.pool,
+                        incident_id,
+                        service.id,
+                    )
+                    .await
+                    {
+                        return error_result(&format!("Failed to link service '{slug}': {e}"));
+                    }
+                    linked.push(format!("service:{slug}"));
+                }
+                Ok(None) => return not_found("Service", slug),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            }
+        }
+    }
+
+    // Link runbooks
+    if let Some(rb_links) = &p.runbook_links {
+        for rb_link in rb_links {
+            let usage = rb_link.usage.as_deref().unwrap_or("followed");
+            if let Err(msg) = crate::validation::validate_required(
+                usage,
+                "runbook usage",
+                crate::validation::RUNBOOK_USAGES,
+            ) {
+                return error_result(&msg);
+            }
+            match crate::repo::runbook_repo::get_runbook_by_slug(&brain.pool, &rb_link.slug).await {
+                Ok(Some(runbook)) => {
+                    if let Err(e) = crate::repo::incident_repo::link_incident_runbook(
+                        &brain.pool,
+                        incident_id,
+                        runbook.id,
+                        usage,
+                    )
+                    .await
+                    {
+                        return error_result(&format!(
+                            "Failed to link runbook '{}': {e}",
+                            rb_link.slug
+                        ));
+                    }
+                    linked.push(format!("runbook:{}", rb_link.slug));
+                }
+                Ok(None) => return not_found("Runbook", &rb_link.slug),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            }
+        }
+    }
+
+    // Link vendors
+    if let Some(names) = &p.vendor_names {
+        for name in names {
+            match crate::repo::vendor_repo::get_vendor_by_name(&brain.pool, name).await {
+                Ok(Some(vendor)) => {
+                    if let Err(e) = crate::repo::incident_repo::link_incident_vendor(
+                        &brain.pool,
+                        incident_id,
+                        vendor.id,
+                    )
+                    .await
+                    {
+                        return error_result(&format!("Failed to link vendor '{name}': {e}"));
+                    }
+                    linked.push(format!("vendor:{name}"));
+                }
+                Ok(None) => return not_found("Vendor", name),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            }
+        }
+    }
+
+    CallToolResult::success(vec![Content::text(format!(
+        "Linked to incident {}: {}",
+        p.incident_id,
+        linked.join(", ")
+    ))])
 }

--- a/src/tools/inventory.rs
+++ b/src/tools/inventory.rs
@@ -1,5 +1,8 @@
+use rmcp::model::*;
 use schemars::JsonSchema;
 use serde::Deserialize;
+
+use super::helpers::{error_result, json_result, not_found};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetServerParams {
@@ -159,4 +162,515 @@ pub struct LinkServerServiceParams {
     pub service_slug: String,
     pub port: Option<i32>,
     pub config_notes: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Handler functions
+// ---------------------------------------------------------------------------
+
+pub(crate) async fn handle_get_server(
+    brain: &super::OpsBrain,
+    p: GetServerParams,
+) -> CallToolResult {
+    let server = match crate::repo::server_repo::get_server_by_slug(&brain.pool, &p.slug).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return not_found("Server", &p.slug),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+    let services = crate::repo::service_repo::get_services_for_server(&brain.pool, server.id)
+        .await
+        .unwrap_or_default();
+    let site = crate::repo::site_repo::get_site(&brain.pool, server.site_id)
+        .await
+        .ok()
+        .flatten();
+    let networks = crate::repo::network_repo::list_networks(&brain.pool, Some(server.site_id))
+        .await
+        .unwrap_or_default();
+
+    let result = serde_json::json!({
+        "server": server,
+        "services": services,
+        "site": site,
+        "networks": networks,
+    });
+    json_result(&result)
+}
+
+pub(crate) async fn handle_list_servers(
+    brain: &super::OpsBrain,
+    p: ListServersParams,
+) -> CallToolResult {
+    let client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+    let site_id = match &p.site_slug {
+        Some(slug) => match crate::repo::site_repo::get_site_by_slug(&brain.pool, slug).await {
+            Ok(Some(s)) => Some(s.id),
+            Ok(None) => return not_found("Site", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+    match crate::repo::server_repo::list_servers(
+        &brain.pool,
+        client_id,
+        site_id,
+        p.role.as_deref(),
+        p.status.as_deref(),
+    )
+    .await
+    {
+        Ok(servers) => json_result(&servers),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_get_service(
+    brain: &super::OpsBrain,
+    p: GetServiceParams,
+) -> CallToolResult {
+    let service = match crate::repo::service_repo::get_service_by_slug(&brain.pool, &p.slug).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return not_found("Service", &p.slug),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+    let servers = crate::repo::service_repo::get_servers_for_service(&brain.pool, service.id)
+        .await
+        .unwrap_or_default();
+    let result = serde_json::json!({
+        "service": service,
+        "servers": servers,
+    });
+    json_result(&result)
+}
+
+pub(crate) async fn handle_list_services(
+    brain: &super::OpsBrain,
+    p: ListServicesParams,
+) -> CallToolResult {
+    match crate::repo::service_repo::list_services(&brain.pool, p.category.as_deref()).await {
+        Ok(services) => json_result(&services),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_get_site(brain: &super::OpsBrain, p: GetSiteParams) -> CallToolResult {
+    let site = match crate::repo::site_repo::get_site_by_slug(&brain.pool, &p.slug).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return not_found("Site", &p.slug),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+    let servers =
+        crate::repo::server_repo::list_servers(&brain.pool, None, Some(site.id), None, None)
+            .await
+            .unwrap_or_default();
+    let networks = crate::repo::network_repo::list_networks(&brain.pool, Some(site.id))
+        .await
+        .unwrap_or_default();
+    let result = serde_json::json!({
+        "site": site,
+        "servers": servers,
+        "networks": networks,
+    });
+    json_result(&result)
+}
+
+pub(crate) async fn handle_get_client(
+    brain: &super::OpsBrain,
+    p: GetClientParams,
+) -> CallToolResult {
+    match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.slug).await {
+        Ok(Some(client)) => json_result(&client),
+        Ok(None) => not_found("Client", &p.slug),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_get_network(
+    brain: &super::OpsBrain,
+    p: GetNetworkParams,
+) -> CallToolResult {
+    if let Some(id_str) = &p.id {
+        let id = match uuid::Uuid::parse_str(id_str) {
+            Ok(id) => id,
+            Err(_) => return error_result(&format!("Invalid UUID: {id_str}")),
+        };
+        return match crate::repo::network_repo::get_network(&brain.pool, id).await {
+            Ok(Some(network)) => json_result(&network),
+            Ok(None) => not_found("Network", id_str),
+            Err(e) => error_result(&format!("Database error: {e}")),
+        };
+    }
+    let site_id = match &p.site_slug {
+        Some(slug) => match crate::repo::site_repo::get_site_by_slug(&brain.pool, slug).await {
+            Ok(Some(s)) => Some(s.id),
+            Ok(None) => return not_found("Site", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+    match crate::repo::network_repo::list_networks(&brain.pool, site_id).await {
+        Ok(networks) => json_result(&networks),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_get_vendor(
+    brain: &super::OpsBrain,
+    p: GetVendorParams,
+) -> CallToolResult {
+    match crate::repo::vendor_repo::get_vendor_by_name(&brain.pool, &p.name).await {
+        Ok(Some(vendor)) => json_result(&vendor),
+        Ok(None) => not_found("Vendor", &p.name),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_search_inventory(
+    brain: &super::OpsBrain,
+    p: SearchInventoryParams,
+) -> CallToolResult {
+    match crate::repo::search_repo::search_inventory(&brain.pool, &p.query).await {
+        Ok(results) => json_result(&results),
+        Err(e) => error_result(&format!("Search error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_upsert_client(
+    brain: &super::OpsBrain,
+    p: UpsertClientParams,
+) -> CallToolResult {
+    match crate::repo::client_repo::upsert_client(
+        &brain.pool,
+        &p.name,
+        &p.slug,
+        p.notes.as_deref(),
+        p.zammad_org_id,
+        p.zammad_group_id,
+        p.zammad_customer_id,
+    )
+    .await
+    {
+        Ok(client) => json_result(&client),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_upsert_site(
+    brain: &super::OpsBrain,
+    p: UpsertSiteParams,
+) -> CallToolResult {
+    let client =
+        match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug).await {
+            Ok(Some(c)) => c,
+            Ok(None) => return not_found("Client", &p.client_slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        };
+    match crate::repo::site_repo::upsert_site(
+        &brain.pool,
+        client.id,
+        &p.name,
+        &p.slug,
+        p.address.as_deref(),
+        p.wan_provider.as_deref(),
+        p.wan_ip.as_deref(),
+        p.notes.as_deref(),
+    )
+    .await
+    {
+        Ok(site) => json_result(&site),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_upsert_server(
+    brain: &super::OpsBrain,
+    p: UpsertServerParams,
+) -> CallToolResult {
+    let site = match crate::repo::site_repo::get_site_by_slug(&brain.pool, &p.site_slug).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return not_found("Site", &p.site_slug),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+    let hypervisor_id = match &p.hypervisor_slug {
+        Some(slug) => match crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await {
+            Ok(Some(h)) => Some(h.id),
+            Ok(None) => return not_found("Hypervisor server", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+    let ip_addresses = p.ip_addresses.unwrap_or_default();
+    let roles = p.roles.unwrap_or_default();
+    let is_virtual = p.is_virtual.unwrap_or(false);
+    let status = p.status.as_deref().unwrap_or("active");
+    match crate::repo::server_repo::upsert_server(
+        &brain.pool,
+        site.id,
+        &p.hostname,
+        &p.slug,
+        p.os.as_deref(),
+        &ip_addresses,
+        p.ssh_alias.as_deref(),
+        &roles,
+        p.hardware.as_deref(),
+        p.cpu.as_deref(),
+        p.ram_gb,
+        p.storage_summary.as_deref(),
+        is_virtual,
+        hypervisor_id,
+        status,
+        p.notes.as_deref(),
+    )
+    .await
+    {
+        Ok(server) => json_result(&server),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_upsert_service(
+    brain: &super::OpsBrain,
+    p: UpsertServiceParams,
+) -> CallToolResult {
+    let criticality = p.criticality.as_deref().unwrap_or("medium");
+    match crate::repo::service_repo::upsert_service(
+        &brain.pool,
+        &p.name,
+        &p.slug,
+        p.category.as_deref(),
+        p.description.as_deref(),
+        criticality,
+        p.notes.as_deref(),
+    )
+    .await
+    {
+        Ok(service) => json_result(&service),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_upsert_vendor(
+    brain: &super::OpsBrain,
+    p: UpsertVendorParams,
+) -> CallToolResult {
+    let contract_end = match &p.contract_end {
+        Some(date_str) => match chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+            Ok(d) => Some(d),
+            Err(_) => {
+                return error_result(&format!(
+                    "Invalid date format '{}', expected YYYY-MM-DD",
+                    date_str
+                ))
+            }
+        },
+        None => None,
+    };
+    match crate::repo::vendor_repo::upsert_vendor(
+        &brain.pool,
+        &p.name,
+        p.category.as_deref(),
+        p.account_number.as_deref(),
+        p.support_phone.as_deref(),
+        p.support_email.as_deref(),
+        p.support_portal.as_deref(),
+        p.sla_summary.as_deref(),
+        contract_end,
+        p.notes.as_deref(),
+    )
+    .await
+    {
+        Ok(vendor) => json_result(&vendor),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_link_server_service(
+    brain: &super::OpsBrain,
+    p: LinkServerServiceParams,
+) -> CallToolResult {
+    let server =
+        match crate::repo::server_repo::get_server_by_slug(&brain.pool, &p.server_slug).await {
+            Ok(Some(s)) => s,
+            Ok(None) => return not_found("Server", &p.server_slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        };
+    let service =
+        match crate::repo::service_repo::get_service_by_slug(&brain.pool, &p.service_slug).await {
+            Ok(Some(s)) => s,
+            Ok(None) => return not_found("Service", &p.service_slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        };
+    match crate::repo::service_repo::link_server_service(
+        &brain.pool,
+        server.id,
+        service.id,
+        p.port,
+        p.config_notes.as_deref(),
+    )
+    .await
+    {
+        Ok(()) => CallToolResult::success(vec![Content::text(format!(
+            "Linked server '{}' to service '{}'",
+            p.server_slug, p.service_slug
+        ))]),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_delete_server(
+    brain: &super::OpsBrain,
+    params: DeleteServerParams,
+) -> CallToolResult {
+    let server = match crate::repo::server_repo::get_server_by_slug(&brain.pool, &params.slug).await
+    {
+        Ok(Some(s)) => s,
+        Ok(None) => return not_found("Server", &params.slug),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+    let refs = match crate::repo::server_repo::count_server_references(&brain.pool, server.id).await
+    {
+        Ok(r) => r,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+    if params.confirm != Some(true) {
+        let mut preview = serde_json::json!({
+            "action": "delete_server",
+            "server": server.hostname,
+            "slug": server.slug,
+            "status": server.status,
+            "confirmed": false,
+            "message": "Pass confirm=true to proceed with deletion.",
+        });
+        if !refs.is_empty() {
+            let ref_map: serde_json::Map<String, serde_json::Value> = refs
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::from(*v)))
+                .collect();
+            preview["linked_entities"] = serde_json::Value::Object(ref_map);
+            preview["warning"] = "Junction table links will be CASCADE-deleted or SET NULL.".into();
+        } else {
+            preview["linked_entities"] = serde_json::json!("none");
+        }
+        return json_result(&preview);
+    }
+    match crate::repo::server_repo::delete_server(&brain.pool, server.id).await {
+        Ok(true) => json_result(&serde_json::json!({
+            "deleted": true,
+            "server": server.hostname,
+            "slug": server.slug,
+            "cascade_summary": refs.iter()
+                .map(|(k, v)| format!("{k}: {v}"))
+                .collect::<Vec<_>>()
+                .join(", "),
+        })),
+        Ok(false) => not_found("Server", &params.slug),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_delete_service(
+    brain: &super::OpsBrain,
+    params: DeleteServiceParams,
+) -> CallToolResult {
+    let service =
+        match crate::repo::service_repo::get_service_by_slug(&brain.pool, &params.slug).await {
+            Ok(Some(s)) => s,
+            Ok(None) => return not_found("Service", &params.slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        };
+    let refs =
+        match crate::repo::service_repo::count_service_references(&brain.pool, service.id).await {
+            Ok(r) => r,
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        };
+    if params.confirm != Some(true) {
+        let mut preview = serde_json::json!({
+            "action": "delete_service",
+            "service": service.name,
+            "slug": service.slug,
+            "confirmed": false,
+            "message": "Pass confirm=true to proceed with deletion.",
+        });
+        if !refs.is_empty() {
+            let ref_map: serde_json::Map<String, serde_json::Value> = refs
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::from(*v)))
+                .collect();
+            preview["linked_entities"] = serde_json::Value::Object(ref_map);
+            preview["warning"] = "Junction table links will be CASCADE-deleted or SET NULL.".into();
+        } else {
+            preview["linked_entities"] = serde_json::json!("none");
+        }
+        return json_result(&preview);
+    }
+    match crate::repo::service_repo::delete_service(&brain.pool, service.id).await {
+        Ok(true) => json_result(&serde_json::json!({
+            "deleted": true,
+            "service": service.name,
+            "slug": service.slug,
+            "cascade_summary": refs.iter()
+                .map(|(k, v)| format!("{k}: {v}"))
+                .collect::<Vec<_>>()
+                .join(", "),
+        })),
+        Ok(false) => not_found("Service", &params.slug),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_delete_vendor(
+    brain: &super::OpsBrain,
+    params: DeleteVendorParams,
+) -> CallToolResult {
+    let vendor = match crate::repo::vendor_repo::get_vendor_by_name(&brain.pool, &params.name).await
+    {
+        Ok(Some(v)) => v,
+        Ok(None) => return not_found("Vendor", &params.name),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+    let refs = match crate::repo::vendor_repo::count_vendor_references(&brain.pool, vendor.id).await
+    {
+        Ok(r) => r,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+    if params.confirm != Some(true) {
+        let mut preview = serde_json::json!({
+            "action": "delete_vendor",
+            "vendor": vendor.name,
+            "id": vendor.id.to_string(),
+            "confirmed": false,
+            "message": "Pass confirm=true to proceed with deletion.",
+        });
+        if !refs.is_empty() {
+            let ref_map: serde_json::Map<String, serde_json::Value> = refs
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::from(*v)))
+                .collect();
+            preview["linked_entities"] = serde_json::Value::Object(ref_map);
+            preview["warning"] = "Client links and incident links will be CASCADE-deleted.".into();
+        } else {
+            preview["linked_entities"] = serde_json::json!("none");
+        }
+        return json_result(&preview);
+    }
+    match crate::repo::vendor_repo::delete_vendor(&brain.pool, vendor.id).await {
+        Ok(true) => json_result(&serde_json::json!({
+            "deleted": true,
+            "vendor": vendor.name,
+            "id": vendor.id.to_string(),
+            "cascade_summary": refs.iter()
+                .map(|(k, v)| format!("{k}: {v}"))
+                .collect::<Vec<_>>()
+                .join(", "),
+        })),
+        Ok(false) => not_found("Vendor", &params.name),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
 }

--- a/src/tools/knowledge.rs
+++ b/src/tools/knowledge.rs
@@ -1,6 +1,10 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use super::helpers::{error_result, filter_cross_client, json_result, not_found};
+use super::shared::{build_client_lookup, embed_and_store, get_query_embedding, log_audit_entries};
+use rmcp::model::*;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AddKnowledgeParams {
     pub title: String,
@@ -45,4 +49,206 @@ pub struct DeleteKnowledgeParams {
 pub struct ListKnowledgeParams {
     pub category: Option<String>,
     pub client_slug: Option<String>,
+}
+
+// ===== HANDLERS =====
+
+pub(crate) async fn handle_add_knowledge(
+    brain: &super::OpsBrain,
+    p: AddKnowledgeParams,
+) -> CallToolResult {
+    let tags = p.tags.unwrap_or_default();
+    let cross_client_safe = p.cross_client_safe.unwrap_or(false);
+
+    // Resolve optional client_slug
+    let client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    match crate::repo::knowledge_repo::add_knowledge(
+        &brain.pool,
+        &p.title,
+        &p.content,
+        p.category.as_deref(),
+        &tags,
+        client_id,
+        cross_client_safe,
+    )
+    .await
+    {
+        Ok(entry) => {
+            let text = crate::embeddings::prepare_knowledge_text(&entry);
+            embed_and_store(
+                &brain.pool,
+                &brain.embedding_client,
+                "knowledge",
+                entry.id,
+                &text,
+            )
+            .await;
+            json_result(&entry)
+        }
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_update_knowledge(
+    brain: &super::OpsBrain,
+    p: UpdateKnowledgeParams,
+) -> CallToolResult {
+    let id = match uuid::Uuid::parse_str(&p.id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.id)),
+    };
+
+    // Verify entry exists
+    match crate::repo::knowledge_repo::get_knowledge(&brain.pool, id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return not_found("Knowledge", &p.id),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+
+    match crate::repo::knowledge_repo::update_knowledge(
+        &brain.pool,
+        id,
+        p.title.as_deref(),
+        p.content.as_deref(),
+        p.category.as_deref(),
+        p.tags.as_deref(),
+        p.cross_client_safe,
+    )
+    .await
+    {
+        Ok(updated) => {
+            let text = crate::embeddings::prepare_knowledge_text(&updated);
+            embed_and_store(
+                &brain.pool,
+                &brain.embedding_client,
+                "knowledge",
+                updated.id,
+                &text,
+            )
+            .await;
+            json_result(&updated)
+        }
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_delete_knowledge(
+    brain: &super::OpsBrain,
+    p: DeleteKnowledgeParams,
+) -> CallToolResult {
+    let id = match uuid::Uuid::parse_str(&p.id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.id)),
+    };
+
+    match crate::repo::knowledge_repo::delete_knowledge(&brain.pool, id).await {
+        Ok(true) => json_result(&serde_json::json!({"deleted": true, "id": p.id})),
+        Ok(false) => not_found("Knowledge", &p.id),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_search_knowledge(
+    brain: &super::OpsBrain,
+    p: SearchKnowledgeParams,
+) -> CallToolResult {
+    let mode = p.mode.as_deref().unwrap_or("fts");
+    if let Err(msg) =
+        crate::validation::validate_required(mode, "mode", crate::validation::SEARCH_MODES)
+    {
+        return error_result(&msg);
+    }
+
+    // Resolve optional client_slug for cross-client gate
+    let requesting_client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+    let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
+
+    let result = match mode {
+        "semantic" => {
+            let Some(emb) = get_query_embedding(&brain.embedding_client, &p.query).await else {
+                return error_result("Semantic search unavailable (OPENAI_API_KEY not set)");
+            };
+            crate::repo::embedding_repo::vector_search_knowledge(&brain.pool, &emb, 20).await
+        }
+        "hybrid" => {
+            let emb = get_query_embedding(&brain.embedding_client, &p.query).await;
+            crate::repo::embedding_repo::hybrid_search_knowledge(
+                &brain.pool,
+                &p.query,
+                emb.as_deref(),
+                20,
+            )
+            .await
+        }
+        _ => crate::repo::knowledge_repo::search_knowledge(&brain.pool, &p.query).await,
+    };
+    match result {
+        Ok(entries) => {
+            let items: Vec<serde_json::Value> = entries
+                .iter()
+                .filter_map(|k| serde_json::to_value(k).ok())
+                .collect();
+            let client_lookup = build_client_lookup(&brain.pool).await;
+            let filtered = filter_cross_client(
+                items,
+                "knowledge",
+                requesting_client_id,
+                acknowledge,
+                &client_lookup,
+            );
+
+            log_audit_entries(
+                &brain.pool,
+                "search_knowledge",
+                requesting_client_id,
+                "knowledge",
+                &filtered.audit_entries,
+            )
+            .await;
+
+            let mut response = serde_json::json!({ "knowledge": filtered.allowed });
+            if !filtered.withheld_notices.is_empty() {
+                response["cross_client_withheld"] = serde_json::json!(filtered.withheld_notices);
+            }
+            json_result(&response)
+        }
+        Err(e) => error_result(&format!("Search error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_list_knowledge(
+    brain: &super::OpsBrain,
+    p: ListKnowledgeParams,
+) -> CallToolResult {
+    // Resolve optional client_slug
+    let client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    match crate::repo::knowledge_repo::list_knowledge(&brain.pool, p.category.as_deref(), client_id)
+        .await
+    {
+        Ok(entries) => json_result(&entries),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,12 +1,14 @@
 pub mod briefings;
 mod context;
 mod coordination;
+mod helpers;
 mod incidents;
 mod inventory;
 mod knowledge;
 mod monitoring;
 mod runbooks;
 mod search;
+mod shared;
 mod zammad;
 
 use rmcp::{
@@ -14,296 +16,19 @@ use rmcp::{
     model::*,
     tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
 };
-use serde::Serialize;
 use sqlx::PgPool;
-
-use std::collections::HashMap;
 
 use crate::embeddings::EmbeddingClient;
 use crate::metrics::UptimeKumaConfig;
-use crate::models::handoff::Handoff;
-use crate::models::incident::Incident;
 use crate::zammad::ZammadConfig;
 
 #[derive(Clone)]
 pub struct OpsBrain {
-    pool: PgPool,
-    kuma_config: Option<UptimeKumaConfig>,
-    embedding_client: Option<EmbeddingClient>,
-    zammad_config: Option<ZammadConfig>,
+    pub(crate) pool: PgPool,
+    pub(crate) kuma_config: Option<UptimeKumaConfig>,
+    pub(crate) embedding_client: Option<EmbeddingClient>,
+    pub(crate) zammad_config: Option<ZammadConfig>,
     tool_router: ToolRouter<Self>,
-}
-
-// Helper to format tool results as JSON text content
-fn json_result<T: Serialize>(data: &T) -> CallToolResult {
-    match serde_json::to_string_pretty(data) {
-        Ok(json) => CallToolResult::success(vec![Content::text(json)]),
-        Err(e) => CallToolResult::error(vec![Content::text(format!("Serialization error: {e}"))]),
-    }
-}
-
-fn error_result(msg: &str) -> CallToolResult {
-    CallToolResult::error(vec![Content::text(msg.to_string())])
-}
-
-fn not_found(entity: &str, key: &str) -> CallToolResult {
-    CallToolResult::error(vec![Content::text(format!("{entity} not found: {key}"))])
-}
-
-/// Result of cross-client scope filtering.
-struct CrossClientFilterResult {
-    /// Items that passed the gate (with _provenance fields injected)
-    pub allowed: Vec<serde_json::Value>,
-    /// Grouped notices about withheld content (for response)
-    pub withheld_notices: Vec<serde_json::Value>,
-    /// Individual (entity_id, owning_client_id, action) for audit logging
-    pub audit_entries: Vec<(uuid::Uuid, Option<uuid::Uuid>, String)>,
-}
-
-/// Partition items into allowed and withheld based on cross-client scope.
-///
-/// Rules:
-/// - No requesting client → all items allowed (no scope to enforce)
-/// - Item client_id is NULL → allowed (global content)
-/// - Item client_id == requesting → allowed (same client)
-/// - Item client_id != requesting + cross_client_safe=true → allowed
-/// - Item client_id != requesting + cross_client_safe=false + acknowledge=true → allowed (released)
-/// - Item client_id != requesting + cross_client_safe=false + acknowledge=false → WITHHELD
-fn filter_cross_client(
-    items: Vec<serde_json::Value>,
-    entity_type: &str,
-    requesting_client_id: Option<uuid::Uuid>,
-    acknowledge: bool,
-    client_lookup: &HashMap<uuid::Uuid, (String, String)>, // client_id -> (slug, name)
-) -> CrossClientFilterResult {
-    let Some(req_cid) = requesting_client_id else {
-        // No requesting client scope — all items are allowed, inject provenance
-        let allowed = items
-            .into_iter()
-            .map(|mut item| {
-                inject_provenance(&mut item, client_lookup);
-                item
-            })
-            .collect();
-        return CrossClientFilterResult {
-            allowed,
-            withheld_notices: Vec::new(),
-            audit_entries: Vec::new(),
-        };
-    };
-
-    let mut allowed = Vec::new();
-    let mut withheld_by_client: HashMap<uuid::Uuid, Vec<uuid::Uuid>> = HashMap::new();
-    let mut audit_entries = Vec::new();
-
-    for mut item in items {
-        let item_client_id = item
-            .get("client_id")
-            .and_then(|v| v.as_str())
-            .and_then(|s| uuid::Uuid::parse_str(s).ok());
-
-        let cross_client_safe = item
-            .get("cross_client_safe")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-
-        let entity_id = item
-            .get("id")
-            .and_then(|v| v.as_str())
-            .and_then(|s| uuid::Uuid::parse_str(s).ok());
-
-        match item_client_id {
-            // Global content (no client_id) — always allowed
-            None => {
-                inject_provenance(&mut item, client_lookup);
-                allowed.push(item);
-            }
-            // Same client — allowed
-            Some(cid) if cid == req_cid => {
-                inject_provenance(&mut item, client_lookup);
-                allowed.push(item);
-            }
-            // Different client but marked safe — allowed
-            Some(cid) if cross_client_safe => {
-                inject_provenance(&mut item, client_lookup);
-                allowed.push(item);
-                if let Some(eid) = entity_id {
-                    audit_entries.push((eid, Some(cid), "released_safe".to_string()));
-                }
-            }
-            // Different client, not safe, but acknowledged — released
-            Some(cid) if acknowledge => {
-                inject_provenance(&mut item, client_lookup);
-                allowed.push(item);
-                if let Some(eid) = entity_id {
-                    audit_entries.push((eid, Some(cid), "released".to_string()));
-                }
-            }
-            // Different client, not safe, not acknowledged — WITHHELD
-            Some(cid) => {
-                if let Some(eid) = entity_id {
-                    withheld_by_client.entry(cid).or_default().push(eid);
-                    audit_entries.push((eid, Some(cid), "withheld".to_string()));
-                }
-            }
-        }
-    }
-
-    // Build grouped withheld notices
-    let withheld_notices: Vec<serde_json::Value> = withheld_by_client
-        .into_iter()
-        .map(|(cid, entity_ids)| {
-            let (slug, name) = client_lookup
-                .get(&cid)
-                .cloned()
-                .unwrap_or_else(|| ("unknown".to_string(), "Unknown".to_string()));
-            serde_json::json!({
-                "entity_type": entity_type,
-                "count": entity_ids.len(),
-                "owning_client_slug": slug,
-                "owning_client_name": name,
-                "message": format!(
-                    "{} {}(s) from client '{}' withheld — cross-client scope mismatch. Re-call with acknowledge_cross_client: true to release.",
-                    entity_ids.len(), entity_type, name
-                )
-            })
-        })
-        .collect();
-
-    CrossClientFilterResult {
-        allowed,
-        withheld_notices,
-        audit_entries,
-    }
-}
-
-/// Inject _provenance fields (client slug + name) into a JSON item.
-fn inject_provenance(
-    item: &mut serde_json::Value,
-    client_lookup: &HashMap<uuid::Uuid, (String, String)>,
-) {
-    if let Some(obj) = item.as_object_mut() {
-        let client_id = obj
-            .get("client_id")
-            .and_then(|v| v.as_str())
-            .and_then(|s| uuid::Uuid::parse_str(s).ok());
-        match client_id {
-            Some(cid) => {
-                if let Some((slug, name)) = client_lookup.get(&cid) {
-                    obj.insert(
-                        "_client_slug".to_string(),
-                        serde_json::Value::String(slug.clone()),
-                    );
-                    obj.insert(
-                        "_client_name".to_string(),
-                        serde_json::Value::String(name.clone()),
-                    );
-                }
-            }
-            None => {
-                obj.insert("_client_slug".to_string(), serde_json::Value::Null);
-                obj.insert(
-                    "_client_name".to_string(),
-                    serde_json::Value::String("Global".to_string()),
-                );
-            }
-        }
-    }
-}
-
-/// Fields to keep per entity type in compact mode. Everything else is stripped.
-fn compact_keep_fields(entity_type: &str) -> &'static [&'static str] {
-    match entity_type {
-        "server" => &[
-            "id",
-            "hostname",
-            "slug",
-            "os",
-            "ip_address",
-            "status",
-            "roles",
-            "site_id",
-        ],
-        "site" => &["id", "name", "slug", "address", "client_id"],
-        "client" => &["id", "name", "slug"],
-        "service" => &["id", "name", "slug", "port", "protocol", "criticality"],
-        "network" => &["id", "name", "cidr", "vlan_id"],
-        "vendor" => &["id", "name", "category"],
-        "incident" => &[
-            "id",
-            "title",
-            "severity",
-            "status",
-            "client_id",
-            "reported_at",
-            "resolved_at",
-            "time_to_resolve_minutes",
-            "cross_client_safe",
-            "_client_slug",
-            "_client_name",
-        ],
-        "runbook" => &[
-            "id",
-            "title",
-            "slug",
-            "category",
-            "client_id",
-            "cross_client_safe",
-            "_client_slug",
-            "_client_name",
-        ],
-        "handoff" => &[
-            "id",
-            "title",
-            "status",
-            "priority",
-            "from_machine",
-            "to_machine",
-            "created_at",
-        ],
-        "knowledge" => &[
-            "id",
-            "title",
-            "category",
-            "client_id",
-            "cross_client_safe",
-            "_client_slug",
-            "_client_name",
-        ],
-        "monitor" => &["name", "status_text", "monitor_type"],
-        "ticket" => &["ticket_id", "title", "state", "priority", "created_at"],
-        _ => &["id", "title", "slug", "name"],
-    }
-}
-
-/// Strip a JSON value down to only the fields allowed for its entity type.
-fn compact_value(val: &serde_json::Value, entity_type: &str) -> serde_json::Value {
-    let Some(obj) = val.as_object() else {
-        return val.clone();
-    };
-    let keep = compact_keep_fields(entity_type);
-    let compacted: serde_json::Map<String, serde_json::Value> = obj
-        .iter()
-        .filter(|(k, _)| keep.contains(&k.as_str()))
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
-    serde_json::Value::Object(compacted)
-}
-
-/// Apply compact mode to a Vec of JSON values.
-fn compact_vec(items: &[serde_json::Value], entity_type: &str) -> Vec<serde_json::Value> {
-    items
-        .iter()
-        .map(|v| compact_value(v, entity_type))
-        .collect()
-}
-
-/// Check if a section is included (None means all sections included).
-fn section_included(sections: &Option<Vec<String>>, name: &str) -> bool {
-    match sections {
-        None => true,
-        Some(list) => list.iter().any(|s| s == name),
-    }
 }
 
 #[tool_router]
@@ -323,98 +48,6 @@ impl OpsBrain {
         }
     }
 
-    /// Best-effort embed and store: logs warning on failure, never blocks the caller.
-    async fn embed_and_store(&self, table: &str, id: uuid::Uuid, text: &str) {
-        let Some(ref client) = self.embedding_client else {
-            return;
-        };
-        match client.embed_text(text).await {
-            Ok(embedding) => {
-                let result = match table {
-                    "runbooks" => {
-                        crate::repo::embedding_repo::store_runbook_embedding(
-                            &self.pool, id, &embedding,
-                        )
-                        .await
-                    }
-                    "knowledge" => {
-                        crate::repo::embedding_repo::store_knowledge_embedding(
-                            &self.pool, id, &embedding,
-                        )
-                        .await
-                    }
-                    "incidents" => {
-                        crate::repo::embedding_repo::store_incident_embedding(
-                            &self.pool, id, &embedding,
-                        )
-                        .await
-                    }
-                    "handoffs" => {
-                        crate::repo::embedding_repo::store_handoff_embedding(
-                            &self.pool, id, &embedding,
-                        )
-                        .await
-                    }
-                    _ => return,
-                };
-                if let Err(e) = result {
-                    tracing::warn!("Failed to store embedding for {table}/{id}: {e}");
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Failed to generate embedding for {table}/{id}: {e}");
-            }
-        }
-    }
-
-    /// Helper to get query embedding, returning None if embedding client unavailable.
-    async fn get_query_embedding(&self, text: &str) -> Option<Vec<f32>> {
-        let client = self.embedding_client.as_ref()?;
-        match client.embed_text(text).await {
-            Ok(emb) => Some(emb),
-            Err(e) => {
-                tracing::warn!("Failed to embed query: {e}");
-                None
-            }
-        }
-    }
-
-    /// Build a client_id -> (slug, name) lookup from the database.
-    async fn build_client_lookup(&self) -> HashMap<uuid::Uuid, (String, String)> {
-        match crate::repo::client_repo::list_clients(&self.pool).await {
-            Ok(clients) => clients
-                .into_iter()
-                .map(|c| (c.id, (c.slug, c.name)))
-                .collect(),
-            Err(e) => {
-                tracing::warn!("Failed to build client lookup: {e}");
-                HashMap::new()
-            }
-        }
-    }
-
-    /// Write audit log entries for cross-client filtering results.
-    async fn log_audit_entries(
-        &self,
-        tool_name: &str,
-        requesting_client_id: Option<uuid::Uuid>,
-        entity_type: &str,
-        entries: &[(uuid::Uuid, Option<uuid::Uuid>, String)],
-    ) {
-        for (entity_id, owning_client_id, action) in entries {
-            crate::repo::audit_log_repo::log_access(
-                &self.pool,
-                tool_name,
-                requesting_client_id,
-                entity_type,
-                *entity_id,
-                *owning_client_id,
-                action,
-            )
-            .await;
-        }
-    }
-
     // ===== INVENTORY: READ TOOLS =====
 
     #[tool(
@@ -425,30 +58,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::GetServerParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let server = match crate::repo::server_repo::get_server_by_slug(&self.pool, &p.slug).await {
-            Ok(Some(s)) => s,
-            Ok(None) => return Ok(not_found("Server", &p.slug)),
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        };
-        let services = crate::repo::service_repo::get_services_for_server(&self.pool, server.id)
-            .await
-            .unwrap_or_default();
-        let site = crate::repo::site_repo::get_site(&self.pool, server.site_id)
-            .await
-            .ok()
-            .flatten();
-        let networks = crate::repo::network_repo::list_networks(&self.pool, Some(server.site_id))
-            .await
-            .unwrap_or_default();
-
-        let result = serde_json::json!({
-            "server": server,
-            "services": services,
-            "site": site,
-            "networks": networks,
-        });
-        Ok(json_result(&result))
+        Ok(inventory::handle_get_server(self, params.0).await)
     }
 
     #[tool(
@@ -459,42 +69,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::ListServersParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        // Resolve client_slug to client_id
-        let client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        // Resolve site_slug to site_id
-        let site_id = match &p.site_slug {
-            Some(slug) => match crate::repo::site_repo::get_site_by_slug(&self.pool, slug).await {
-                Ok(Some(s)) => Some(s.id),
-                Ok(None) => return Ok(not_found("Site", slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            },
-            None => None,
-        };
-
-        match crate::repo::server_repo::list_servers(
-            &self.pool,
-            client_id,
-            site_id,
-            p.role.as_deref(),
-            p.status.as_deref(),
-        )
-        .await
-        {
-            Ok(servers) => Ok(json_result(&servers)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_list_servers(self, params.0).await)
     }
 
     #[tool(
@@ -505,22 +80,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::GetServiceParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let service =
-            match crate::repo::service_repo::get_service_by_slug(&self.pool, &p.slug).await {
-                Ok(Some(s)) => s,
-                Ok(None) => return Ok(not_found("Service", &p.slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-        let servers = crate::repo::service_repo::get_servers_for_service(&self.pool, service.id)
-            .await
-            .unwrap_or_default();
-
-        let result = serde_json::json!({
-            "service": service,
-            "servers": servers,
-        });
-        Ok(json_result(&result))
+        Ok(inventory::handle_get_service(self, params.0).await)
     }
 
     #[tool(
@@ -531,11 +91,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::ListServicesParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        match crate::repo::service_repo::list_services(&self.pool, p.category.as_deref()).await {
-            Ok(services) => Ok(json_result(&services)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_list_services(self, params.0).await)
     }
 
     #[tool(
@@ -546,26 +102,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::GetSiteParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let site = match crate::repo::site_repo::get_site_by_slug(&self.pool, &p.slug).await {
-            Ok(Some(s)) => s,
-            Ok(None) => return Ok(not_found("Site", &p.slug)),
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        };
-        let servers =
-            crate::repo::server_repo::list_servers(&self.pool, None, Some(site.id), None, None)
-                .await
-                .unwrap_or_default();
-        let networks = crate::repo::network_repo::list_networks(&self.pool, Some(site.id))
-            .await
-            .unwrap_or_default();
-
-        let result = serde_json::json!({
-            "site": site,
-            "servers": servers,
-            "networks": networks,
-        });
-        Ok(json_result(&result))
+        Ok(inventory::handle_get_site(self, params.0).await)
     }
 
     #[tool(name = "get_client", description = "Get client information by slug")]
@@ -573,12 +110,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::GetClientParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        match crate::repo::client_repo::get_client_by_slug(&self.pool, &p.slug).await {
-            Ok(Some(client)) => Ok(json_result(&client)),
-            Ok(None) => Ok(not_found("Client", &p.slug)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_get_client(self, params.0).await)
     }
 
     #[tool(
@@ -589,35 +121,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::GetNetworkParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        // If ID is provided, look up directly
-        if let Some(id_str) = &p.id {
-            let id = match uuid::Uuid::parse_str(id_str) {
-                Ok(id) => id,
-                Err(_) => return Ok(error_result(&format!("Invalid UUID: {id_str}"))),
-            };
-            return match crate::repo::network_repo::get_network(&self.pool, id).await {
-                Ok(Some(network)) => Ok(json_result(&network)),
-                Ok(None) => Ok(not_found("Network", id_str)),
-                Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-            };
-        }
-
-        // Otherwise filter by site_slug
-        let site_id = match &p.site_slug {
-            Some(slug) => match crate::repo::site_repo::get_site_by_slug(&self.pool, slug).await {
-                Ok(Some(s)) => Some(s.id),
-                Ok(None) => return Ok(not_found("Site", slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            },
-            None => None,
-        };
-
-        match crate::repo::network_repo::list_networks(&self.pool, site_id).await {
-            Ok(networks) => Ok(json_result(&networks)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_get_network(self, params.0).await)
     }
 
     #[tool(
@@ -628,12 +132,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::GetVendorParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        match crate::repo::vendor_repo::get_vendor_by_name(&self.pool, &p.name).await {
-            Ok(Some(vendor)) => Ok(json_result(&vendor)),
-            Ok(None) => Ok(not_found("Vendor", &p.name)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_get_vendor(self, params.0).await)
     }
 
     #[tool(
@@ -644,11 +143,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::SearchInventoryParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        match crate::repo::search_repo::search_inventory(&self.pool, &p.query).await {
-            Ok(results) => Ok(json_result(&results)),
-            Err(e) => Ok(error_result(&format!("Search error: {e}"))),
-        }
+        Ok(inventory::handle_search_inventory(self, params.0).await)
     }
 
     // ===== INVENTORY: WRITE TOOLS =====
@@ -661,21 +156,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::UpsertClientParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        match crate::repo::client_repo::upsert_client(
-            &self.pool,
-            &p.name,
-            &p.slug,
-            p.notes.as_deref(),
-            p.zammad_org_id,
-            p.zammad_group_id,
-            p.zammad_customer_id,
-        )
-        .await
-        {
-            Ok(client) => Ok(json_result(&client)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_upsert_client(self, params.0).await)
     }
 
     #[tool(
@@ -686,30 +167,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::UpsertSiteParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let client =
-            match crate::repo::client_repo::get_client_by_slug(&self.pool, &p.client_slug).await {
-                Ok(Some(c)) => c,
-                Ok(None) => return Ok(not_found("Client", &p.client_slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        match crate::repo::site_repo::upsert_site(
-            &self.pool,
-            client.id,
-            &p.name,
-            &p.slug,
-            p.address.as_deref(),
-            p.wan_provider.as_deref(),
-            p.wan_ip.as_deref(),
-            p.notes.as_deref(),
-        )
-        .await
-        {
-            Ok(site) => Ok(json_result(&site)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_upsert_site(self, params.0).await)
     }
 
     #[tool(
@@ -720,54 +178,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::UpsertServerParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let site = match crate::repo::site_repo::get_site_by_slug(&self.pool, &p.site_slug).await {
-            Ok(Some(s)) => s,
-            Ok(None) => return Ok(not_found("Site", &p.site_slug)),
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        };
-
-        // Resolve optional hypervisor_slug
-        let hypervisor_id = match &p.hypervisor_slug {
-            Some(slug) => {
-                match crate::repo::server_repo::get_server_by_slug(&self.pool, slug).await {
-                    Ok(Some(h)) => Some(h.id),
-                    Ok(None) => return Ok(not_found("Hypervisor server", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        let ip_addresses = p.ip_addresses.unwrap_or_default();
-        let roles = p.roles.unwrap_or_default();
-        let is_virtual = p.is_virtual.unwrap_or(false);
-        let status = p.status.as_deref().unwrap_or("active");
-
-        match crate::repo::server_repo::upsert_server(
-            &self.pool,
-            site.id,
-            &p.hostname,
-            &p.slug,
-            p.os.as_deref(),
-            &ip_addresses,
-            p.ssh_alias.as_deref(),
-            &roles,
-            p.hardware.as_deref(),
-            p.cpu.as_deref(),
-            p.ram_gb,
-            p.storage_summary.as_deref(),
-            is_virtual,
-            hypervisor_id,
-            status,
-            p.notes.as_deref(),
-        )
-        .await
-        {
-            Ok(server) => Ok(json_result(&server)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_upsert_server(self, params.0).await)
     }
 
     #[tool(
@@ -778,23 +189,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::UpsertServiceParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let criticality = p.criticality.as_deref().unwrap_or("medium");
-
-        match crate::repo::service_repo::upsert_service(
-            &self.pool,
-            &p.name,
-            &p.slug,
-            p.category.as_deref(),
-            p.description.as_deref(),
-            criticality,
-            p.notes.as_deref(),
-        )
-        .await
-        {
-            Ok(service) => Ok(json_result(&service)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_upsert_service(self, params.0).await)
     }
 
     #[tool(
@@ -805,39 +200,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::UpsertVendorParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        // Parse optional contract_end date
-        let contract_end = match &p.contract_end {
-            Some(date_str) => match chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
-                Ok(d) => Some(d),
-                Err(_) => {
-                    return Ok(error_result(&format!(
-                        "Invalid date format '{}', expected YYYY-MM-DD",
-                        date_str
-                    )))
-                }
-            },
-            None => None,
-        };
-
-        match crate::repo::vendor_repo::upsert_vendor(
-            &self.pool,
-            &p.name,
-            p.category.as_deref(),
-            p.account_number.as_deref(),
-            p.support_phone.as_deref(),
-            p.support_email.as_deref(),
-            p.support_portal.as_deref(),
-            p.sla_summary.as_deref(),
-            contract_end,
-            p.notes.as_deref(),
-        )
-        .await
-        {
-            Ok(vendor) => Ok(json_result(&vendor)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_upsert_vendor(self, params.0).await)
     }
 
     #[tool(
@@ -848,37 +211,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::LinkServerServiceParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let server =
-            match crate::repo::server_repo::get_server_by_slug(&self.pool, &p.server_slug).await {
-                Ok(Some(s)) => s,
-                Ok(None) => return Ok(not_found("Server", &p.server_slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-        let service =
-            match crate::repo::service_repo::get_service_by_slug(&self.pool, &p.service_slug).await
-            {
-                Ok(Some(s)) => s,
-                Ok(None) => return Ok(not_found("Service", &p.service_slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        match crate::repo::service_repo::link_server_service(
-            &self.pool,
-            server.id,
-            service.id,
-            p.port,
-            p.config_notes.as_deref(),
-        )
-        .await
-        {
-            Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
-                "Linked server '{}' to service '{}'",
-                p.server_slug, p.service_slug
-            ))])),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_link_server_service(self, params.0).await)
     }
 
     // ===== RUNBOOK TOOLS =====
@@ -891,12 +224,7 @@ impl OpsBrain {
         &self,
         params: Parameters<runbooks::GetRunbookParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        match crate::repo::runbook_repo::get_runbook_by_slug(&self.pool, &p.slug).await {
-            Ok(Some(runbook)) => Ok(json_result(&runbook)),
-            Ok(None) => Ok(not_found("Runbook", &p.slug)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(runbooks::handle_get_runbook(self, params.0).await)
     }
 
     #[tool(
@@ -907,57 +235,7 @@ impl OpsBrain {
         &self,
         params: Parameters<runbooks::ListRunbooksParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        // Resolve optional client_slug
-        let client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        // Resolve optional service_slug
-        let service_id = match &p.service_slug {
-            Some(slug) => {
-                match crate::repo::service_repo::get_service_by_slug(&self.pool, slug).await {
-                    Ok(Some(s)) => Some(s.id),
-                    Ok(None) => return Ok(not_found("Service", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        // Resolve optional server_slug
-        let server_id = match &p.server_slug {
-            Some(slug) => {
-                match crate::repo::server_repo::get_server_by_slug(&self.pool, slug).await {
-                    Ok(Some(s)) => Some(s.id),
-                    Ok(None) => return Ok(not_found("Server", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        match crate::repo::runbook_repo::list_runbooks(
-            &self.pool,
-            p.category.as_deref(),
-            service_id,
-            server_id,
-            p.tag.as_deref(),
-            client_id,
-        )
-        .await
-        {
-            Ok(runbooks) => Ok(json_result(&runbooks)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(runbooks::handle_list_runbooks(self, params.0).await)
     }
 
     #[tool(
@@ -969,81 +247,7 @@ impl OpsBrain {
         &self,
         params: Parameters<runbooks::SearchRunbooksParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let mode = p.mode.as_deref().unwrap_or("fts");
-        if let Err(msg) =
-            crate::validation::validate_required(mode, "mode", crate::validation::SEARCH_MODES)
-        {
-            return Ok(error_result(&msg));
-        }
-
-        // Resolve optional client_slug for cross-client gate
-        let requesting_client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-        let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
-
-        let result = match mode {
-            "semantic" => {
-                let Some(emb) = self.get_query_embedding(&p.query).await else {
-                    return Ok(error_result(
-                        "Semantic search unavailable (OPENAI_API_KEY not set)",
-                    ));
-                };
-                crate::repo::embedding_repo::vector_search_runbooks(&self.pool, &emb, 20).await
-            }
-            "hybrid" => {
-                let emb = self.get_query_embedding(&p.query).await;
-                crate::repo::embedding_repo::hybrid_search_runbooks(
-                    &self.pool,
-                    &p.query,
-                    emb.as_deref(),
-                    20,
-                )
-                .await
-            }
-            _ => crate::repo::search_repo::search_runbooks(&self.pool, &p.query).await,
-        };
-        match result {
-            Ok(runbooks) => {
-                let items: Vec<serde_json::Value> = runbooks
-                    .iter()
-                    .filter_map(|r| serde_json::to_value(r).ok())
-                    .collect();
-                let client_lookup = self.build_client_lookup().await;
-                let filtered = filter_cross_client(
-                    items,
-                    "runbook",
-                    requesting_client_id,
-                    acknowledge,
-                    &client_lookup,
-                );
-
-                // Log audit entries
-                self.log_audit_entries(
-                    "search_runbooks",
-                    requesting_client_id,
-                    "runbook",
-                    &filtered.audit_entries,
-                )
-                .await;
-
-                let mut response = serde_json::json!({ "runbooks": filtered.allowed });
-                if !filtered.withheld_notices.is_empty() {
-                    response["cross_client_withheld"] =
-                        serde_json::json!(filtered.withheld_notices);
-                }
-                Ok(json_result(&response))
-            }
-            Err(e) => Ok(error_result(&format!("Search error: {e}"))),
-        }
+        Ok(runbooks::handle_search_runbooks(self, params.0).await)
     }
 
     #[tool(
@@ -1054,45 +258,7 @@ impl OpsBrain {
         &self,
         params: Parameters<runbooks::CreateRunbookParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let tags = p.tags.unwrap_or_default();
-        let requires_reboot = p.requires_reboot.unwrap_or(false);
-        let cross_client_safe = p.cross_client_safe.unwrap_or(false);
-
-        // Resolve optional client_slug
-        let client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        match crate::repo::runbook_repo::create_runbook(
-            &self.pool,
-            &p.title,
-            &p.slug,
-            p.category.as_deref(),
-            &p.content,
-            &tags,
-            p.estimated_minutes,
-            requires_reboot,
-            p.notes.as_deref(),
-            client_id,
-            cross_client_safe,
-        )
-        .await
-        {
-            Ok(runbook) => {
-                let text = crate::embeddings::prepare_runbook_text(&runbook);
-                self.embed_and_store("runbooks", runbook.id, &text).await;
-                Ok(json_result(&runbook))
-            }
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(runbooks::handle_create_runbook(self, params.0).await)
     }
 
     #[tool(
@@ -1103,39 +269,7 @@ impl OpsBrain {
         &self,
         params: Parameters<runbooks::UpdateRunbookParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let runbook =
-            match crate::repo::runbook_repo::get_runbook_by_slug(&self.pool, &p.slug).await {
-                Ok(Some(r)) => r,
-                Ok(None) => return Ok(not_found("Runbook", &p.slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        // Wrap estimated_minutes in Option<Option<i32>> for COALESCE
-        let estimated_minutes: Option<Option<i32>> = p.estimated_minutes.map(Some);
-
-        match crate::repo::runbook_repo::update_runbook(
-            &self.pool,
-            runbook.id,
-            p.title.as_deref(),
-            p.category.as_deref(),
-            p.content.as_deref(),
-            p.tags.as_deref(),
-            estimated_minutes,
-            p.requires_reboot,
-            p.notes.as_deref(),
-            p.cross_client_safe,
-        )
-        .await
-        {
-            Ok(updated) => {
-                let text = crate::embeddings::prepare_runbook_text(&updated);
-                self.embed_and_store("runbooks", updated.id, &text).await;
-                Ok(json_result(&updated))
-            }
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(runbooks::handle_update_runbook(self, params.0).await)
     }
 
     // ===== KNOWLEDGE TOOLS =====
@@ -1148,40 +282,7 @@ impl OpsBrain {
         &self,
         params: Parameters<knowledge::AddKnowledgeParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let tags = p.tags.unwrap_or_default();
-        let cross_client_safe = p.cross_client_safe.unwrap_or(false);
-
-        // Resolve optional client_slug
-        let client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        match crate::repo::knowledge_repo::add_knowledge(
-            &self.pool,
-            &p.title,
-            &p.content,
-            p.category.as_deref(),
-            &tags,
-            client_id,
-            cross_client_safe,
-        )
-        .await
-        {
-            Ok(entry) => {
-                let text = crate::embeddings::prepare_knowledge_text(&entry);
-                self.embed_and_store("knowledge", entry.id, &text).await;
-                Ok(json_result(&entry))
-            }
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(knowledge::handle_add_knowledge(self, params.0).await)
     }
 
     #[tool(
@@ -1192,38 +293,7 @@ impl OpsBrain {
         &self,
         params: Parameters<knowledge::UpdateKnowledgeParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let id = match uuid::Uuid::parse_str(&p.id) {
-            Ok(id) => id,
-            Err(_) => return Ok(error_result(&format!("Invalid UUID: {}", p.id))),
-        };
-
-        // Verify entry exists
-        match crate::repo::knowledge_repo::get_knowledge(&self.pool, id).await {
-            Ok(Some(_)) => {}
-            Ok(None) => return Ok(not_found("Knowledge", &p.id)),
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        };
-
-        match crate::repo::knowledge_repo::update_knowledge(
-            &self.pool,
-            id,
-            p.title.as_deref(),
-            p.content.as_deref(),
-            p.category.as_deref(),
-            p.tags.as_deref(),
-            p.cross_client_safe,
-        )
-        .await
-        {
-            Ok(updated) => {
-                let text = crate::embeddings::prepare_knowledge_text(&updated);
-                self.embed_and_store("knowledge", updated.id, &text).await;
-                Ok(json_result(&updated))
-            }
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(knowledge::handle_update_knowledge(self, params.0).await)
     }
 
     #[tool(
@@ -1234,20 +304,7 @@ impl OpsBrain {
         &self,
         params: Parameters<knowledge::DeleteKnowledgeParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let id = match uuid::Uuid::parse_str(&p.id) {
-            Ok(id) => id,
-            Err(_) => return Ok(error_result(&format!("Invalid UUID: {}", p.id))),
-        };
-
-        match crate::repo::knowledge_repo::delete_knowledge(&self.pool, id).await {
-            Ok(true) => Ok(json_result(
-                &serde_json::json!({"deleted": true, "id": p.id}),
-            )),
-            Ok(false) => Ok(not_found("Knowledge", &p.id)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(knowledge::handle_delete_knowledge(self, params.0).await)
     }
 
     #[tool(
@@ -1259,80 +316,7 @@ impl OpsBrain {
         &self,
         params: Parameters<knowledge::SearchKnowledgeParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let mode = p.mode.as_deref().unwrap_or("fts");
-        if let Err(msg) =
-            crate::validation::validate_required(mode, "mode", crate::validation::SEARCH_MODES)
-        {
-            return Ok(error_result(&msg));
-        }
-
-        // Resolve optional client_slug for cross-client gate
-        let requesting_client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-        let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
-
-        let result = match mode {
-            "semantic" => {
-                let Some(emb) = self.get_query_embedding(&p.query).await else {
-                    return Ok(error_result(
-                        "Semantic search unavailable (OPENAI_API_KEY not set)",
-                    ));
-                };
-                crate::repo::embedding_repo::vector_search_knowledge(&self.pool, &emb, 20).await
-            }
-            "hybrid" => {
-                let emb = self.get_query_embedding(&p.query).await;
-                crate::repo::embedding_repo::hybrid_search_knowledge(
-                    &self.pool,
-                    &p.query,
-                    emb.as_deref(),
-                    20,
-                )
-                .await
-            }
-            _ => crate::repo::knowledge_repo::search_knowledge(&self.pool, &p.query).await,
-        };
-        match result {
-            Ok(entries) => {
-                let items: Vec<serde_json::Value> = entries
-                    .iter()
-                    .filter_map(|k| serde_json::to_value(k).ok())
-                    .collect();
-                let client_lookup = self.build_client_lookup().await;
-                let filtered = filter_cross_client(
-                    items,
-                    "knowledge",
-                    requesting_client_id,
-                    acknowledge,
-                    &client_lookup,
-                );
-
-                self.log_audit_entries(
-                    "search_knowledge",
-                    requesting_client_id,
-                    "knowledge",
-                    &filtered.audit_entries,
-                )
-                .await;
-
-                let mut response = serde_json::json!({ "knowledge": filtered.allowed });
-                if !filtered.withheld_notices.is_empty() {
-                    response["cross_client_withheld"] =
-                        serde_json::json!(filtered.withheld_notices);
-                }
-                Ok(json_result(&response))
-            }
-            Err(e) => Ok(error_result(&format!("Search error: {e}"))),
-        }
+        Ok(knowledge::handle_search_knowledge(self, params.0).await)
     }
 
     #[tool(
@@ -1343,30 +327,7 @@ impl OpsBrain {
         &self,
         params: Parameters<knowledge::ListKnowledgeParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        // Resolve optional client_slug
-        let client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        match crate::repo::knowledge_repo::list_knowledge(
-            &self.pool,
-            p.category.as_deref(),
-            client_id,
-        )
-        .await
-        {
-            Ok(entries) => Ok(json_result(&entries)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(knowledge::handle_list_knowledge(self, params.0).await)
     }
 
     // ===== CONTEXT TOOLS =====
@@ -1384,555 +345,7 @@ impl OpsBrain {
         &self,
         params: Parameters<context::GetSituationalAwarenessParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        if p.server_slug.is_none() && p.service_slug.is_none() && p.client_slug.is_none() {
-            return Ok(error_result(
-                "Provide at least one of: server_slug, service_slug, or client_slug",
-            ));
-        }
-
-        let compact = p.compact.unwrap_or(false);
-        let sections = p.sections;
-
-        let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
-
-        let mut awareness = context::SituationalAwareness {
-            server: None,
-            site: None,
-            client: None,
-            services: Vec::new(),
-            networks: Vec::new(),
-            vendors: Vec::new(),
-            recent_incidents: Vec::new(),
-            relevant_runbooks: Vec::new(),
-            pending_handoffs: Vec::new(),
-            knowledge: Vec::new(),
-            monitoring: Vec::new(),
-            linked_tickets: Vec::new(),
-            cross_client_withheld: Vec::new(),
-        };
-
-        let mut client_id: Option<uuid::Uuid> = None;
-        #[allow(unused_assignments)]
-        let mut site_id: Option<uuid::Uuid> = None;
-        let mut server_id: Option<uuid::Uuid> = None;
-        let mut service_id: Option<uuid::Uuid> = None;
-
-        // Resolve server if provided — this gives us site and client context too
-        if let Some(slug) = &p.server_slug {
-            if let Ok(Some(server)) =
-                crate::repo::server_repo::get_server_by_slug(&self.pool, slug).await
-            {
-                server_id = Some(server.id);
-                site_id = Some(server.site_id);
-                awareness.server = serde_json::to_value(&server).ok();
-
-                // Get services for this server
-                if let Ok(services) =
-                    crate::repo::service_repo::get_services_for_server(&self.pool, server.id).await
-                {
-                    awareness.services = services
-                        .iter()
-                        .filter_map(|s| serde_json::to_value(s).ok())
-                        .collect();
-                }
-
-                // Get site
-                if let Ok(Some(site)) =
-                    crate::repo::site_repo::get_site(&self.pool, server.site_id).await
-                {
-                    client_id = Some(site.client_id);
-                    awareness.site = serde_json::to_value(&site).ok();
-
-                    // Get client from site
-                    if let Ok(Some(client)) =
-                        crate::repo::client_repo::get_client(&self.pool, site.client_id).await
-                    {
-                        awareness.client = serde_json::to_value(&client).ok();
-                    }
-                }
-
-                // Get networks for this site
-                if let Some(sid) = site_id {
-                    if let Ok(networks) =
-                        crate::repo::network_repo::list_networks(&self.pool, Some(sid)).await
-                    {
-                        awareness.networks = networks
-                            .iter()
-                            .filter_map(|n| serde_json::to_value(n).ok())
-                            .collect();
-                    }
-                }
-
-                // Get runbooks linked to this server
-                if let Ok(runbooks) = crate::repo::runbook_repo::list_runbooks(
-                    &self.pool,
-                    None,
-                    None,
-                    Some(server.id),
-                    None,
-                    None,
-                )
-                .await
-                {
-                    awareness.relevant_runbooks = runbooks
-                        .iter()
-                        .filter_map(|r| serde_json::to_value(r).ok())
-                        .collect();
-                }
-            } else {
-                return Ok(not_found("Server", slug));
-            }
-        }
-
-        // Resolve service if provided
-        if let Some(slug) = &p.service_slug {
-            if let Ok(Some(svc)) =
-                crate::repo::service_repo::get_service_by_slug(&self.pool, slug).await
-            {
-                service_id = Some(svc.id);
-
-                // Add service to list if not already present from server lookup
-                if awareness.services.is_empty() {
-                    awareness.services =
-                        vec![serde_json::to_value(&svc).unwrap_or(serde_json::Value::Null)];
-                }
-
-                // Get servers running this service
-                if let Ok(servers) =
-                    crate::repo::service_repo::get_servers_for_service(&self.pool, svc.id).await
-                {
-                    // If we don't have a server yet, use the first one for context
-                    if awareness.server.is_none() {
-                        if let Some(first_server) = servers.first() {
-                            server_id = Some(first_server.id);
-                            #[allow(unused_assignments)]
-                            {
-                                site_id = Some(first_server.site_id);
-                            }
-                            awareness.server = serde_json::to_value(first_server).ok();
-
-                            if let Ok(Some(site)) =
-                                crate::repo::site_repo::get_site(&self.pool, first_server.site_id)
-                                    .await
-                            {
-                                client_id = Some(site.client_id);
-                                awareness.site = serde_json::to_value(&site).ok();
-                            }
-                        }
-                    }
-                }
-
-                // Get runbooks linked to this service (merge with existing)
-                if let Ok(runbooks) = crate::repo::runbook_repo::list_runbooks(
-                    &self.pool,
-                    None,
-                    Some(svc.id),
-                    None,
-                    None,
-                    None,
-                )
-                .await
-                {
-                    for rb in &runbooks {
-                        if let Ok(val) = serde_json::to_value(rb) {
-                            if !awareness.relevant_runbooks.contains(&val) {
-                                awareness.relevant_runbooks.push(val);
-                            }
-                        }
-                    }
-                }
-            } else {
-                return Ok(not_found("Service", slug));
-            }
-        }
-
-        // Resolve client if provided (may already be set from server/service lookup)
-        if let Some(slug) = &p.client_slug {
-            if let Ok(Some(client)) =
-                crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await
-            {
-                client_id = Some(client.id);
-                awareness.client = serde_json::to_value(&client).ok();
-            } else {
-                return Ok(not_found("Client", slug));
-            }
-        }
-
-        // Get vendors for client
-        if let Some(cid) = client_id {
-            if let Ok(vendors) =
-                crate::repo::vendor_repo::get_vendors_for_client(&self.pool, cid).await
-            {
-                awareness.vendors = vendors
-                    .iter()
-                    .filter_map(|v| serde_json::to_value(v).ok())
-                    .collect();
-            }
-
-            // Get recent incidents for this client
-            let incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
-                "SELECT * FROM incidents WHERE client_id = $1 ORDER BY reported_at DESC LIMIT 10",
-            )
-            .bind(cid)
-            .fetch_all(&self.pool)
-            .await
-            .unwrap_or_default();
-
-            awareness.recent_incidents = incidents
-                .iter()
-                .filter_map(|i| serde_json::to_value(i).ok())
-                .collect();
-
-            // Get knowledge for this client
-            if let Ok(entries) =
-                crate::repo::knowledge_repo::list_knowledge(&self.pool, None, Some(cid)).await
-            {
-                awareness.knowledge = entries
-                    .iter()
-                    .filter_map(|k| serde_json::to_value(k).ok())
-                    .collect();
-            }
-        }
-
-        // If we have a server, also get incidents linked to that server
-        if let Some(srv_id) = server_id {
-            let server_incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
-                "SELECT i.* FROM incidents i \
-                 JOIN incident_servers isv ON i.id = isv.incident_id \
-                 WHERE isv.server_id = $1 \
-                 ORDER BY i.reported_at DESC LIMIT 10",
-            )
-            .bind(srv_id)
-            .fetch_all(&self.pool)
-            .await
-            .unwrap_or_default();
-
-            // Merge with existing incidents (avoid duplicates by ID)
-            for inc in &server_incidents {
-                if let Ok(val) = serde_json::to_value(inc) {
-                    if !awareness
-                        .recent_incidents
-                        .iter()
-                        .any(|existing| existing.get("id") == val.get("id"))
-                    {
-                        awareness.recent_incidents.push(val);
-                    }
-                }
-            }
-        }
-
-        // If we have a service, also get incidents linked to that service
-        if let Some(svc_id) = service_id {
-            let service_incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
-                "SELECT i.* FROM incidents i \
-                 JOIN incident_services iss ON i.id = iss.incident_id \
-                 WHERE iss.service_id = $1 \
-                 ORDER BY i.reported_at DESC LIMIT 10",
-            )
-            .bind(svc_id)
-            .fetch_all(&self.pool)
-            .await
-            .unwrap_or_default();
-
-            for inc in &service_incidents {
-                if let Ok(val) = serde_json::to_value(inc) {
-                    if !awareness
-                        .recent_incidents
-                        .iter()
-                        .any(|existing| existing.get("id") == val.get("id"))
-                    {
-                        awareness.recent_incidents.push(val);
-                    }
-                }
-            }
-        }
-
-        // Get pending handoffs
-        let handoffs: Vec<Handoff> = sqlx::query_as::<_, Handoff>(
-            "SELECT * FROM handoffs WHERE status = 'pending' ORDER BY created_at DESC LIMIT 10",
-        )
-        .fetch_all(&self.pool)
-        .await
-        .unwrap_or_default();
-
-        awareness.pending_handoffs = handoffs
-            .iter()
-            .filter_map(|h| serde_json::to_value(h).ok())
-            .collect();
-
-        // Also add general knowledge (not client-specific)
-        if let Ok(general_knowledge) =
-            crate::repo::knowledge_repo::list_knowledge(&self.pool, None, None).await
-        {
-            for entry in &general_knowledge {
-                if let Ok(val) = serde_json::to_value(entry) {
-                    if !awareness
-                        .knowledge
-                        .iter()
-                        .any(|existing| existing.get("id") == val.get("id"))
-                    {
-                        awareness.knowledge.push(val);
-                    }
-                }
-            }
-        }
-
-        // Semantic enrichment: find related runbooks/knowledge beyond explicit links
-        if self.embedding_client.is_some() {
-            // Build context string from resolved entities
-            let mut context_parts = Vec::new();
-            if let Some(ref srv) = awareness.server {
-                if let Some(hostname) = srv.get("hostname").and_then(|v| v.as_str()) {
-                    context_parts.push(hostname.to_string());
-                }
-                if let Some(os) = srv.get("os").and_then(|v| v.as_str()) {
-                    context_parts.push(os.to_string());
-                }
-            }
-            for svc in &awareness.services {
-                if let Some(name) = svc.get("name").and_then(|v| v.as_str()) {
-                    context_parts.push(name.to_string());
-                }
-            }
-            if let Some(ref client) = awareness.client {
-                if let Some(name) = client.get("name").and_then(|v| v.as_str()) {
-                    context_parts.push(name.to_string());
-                }
-            }
-
-            if !context_parts.is_empty() {
-                let context_query = context_parts.join(" ");
-                if let Some(emb) = self.get_query_embedding(&context_query).await {
-                    // Find semantically related runbooks
-                    if let Ok(related_runbooks) =
-                        crate::repo::embedding_repo::vector_search_runbooks(&self.pool, &emb, 5)
-                            .await
-                    {
-                        for rb in &related_runbooks {
-                            if let Ok(val) = serde_json::to_value(rb) {
-                                if !awareness
-                                    .relevant_runbooks
-                                    .iter()
-                                    .any(|existing| existing.get("id") == val.get("id"))
-                                {
-                                    awareness.relevant_runbooks.push(val);
-                                }
-                            }
-                        }
-                    }
-                    // Find semantically related knowledge
-                    if let Ok(related_knowledge) =
-                        crate::repo::embedding_repo::vector_search_knowledge(&self.pool, &emb, 5)
-                            .await
-                    {
-                        for k in &related_knowledge {
-                            if let Ok(val) = serde_json::to_value(k) {
-                                if !awareness
-                                    .knowledge
-                                    .iter()
-                                    .any(|existing| existing.get("id") == val.get("id"))
-                                {
-                                    awareness.knowledge.push(val);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // ── Cross-client scope gate for runbooks, knowledge, and incidents ──
-        {
-            let client_lookup = self.build_client_lookup().await;
-
-            let rb_filtered = filter_cross_client(
-                std::mem::take(&mut awareness.relevant_runbooks),
-                "runbook",
-                client_id,
-                acknowledge,
-                &client_lookup,
-            );
-            awareness.relevant_runbooks = rb_filtered.allowed;
-            awareness
-                .cross_client_withheld
-                .extend(rb_filtered.withheld_notices);
-            self.log_audit_entries(
-                "get_situational_awareness",
-                client_id,
-                "runbook",
-                &rb_filtered.audit_entries,
-            )
-            .await;
-
-            let kn_filtered = filter_cross_client(
-                std::mem::take(&mut awareness.knowledge),
-                "knowledge",
-                client_id,
-                acknowledge,
-                &client_lookup,
-            );
-            awareness.knowledge = kn_filtered.allowed;
-            awareness
-                .cross_client_withheld
-                .extend(kn_filtered.withheld_notices);
-            self.log_audit_entries(
-                "get_situational_awareness",
-                client_id,
-                "knowledge",
-                &kn_filtered.audit_entries,
-            )
-            .await;
-
-            let inc_filtered = filter_cross_client(
-                std::mem::take(&mut awareness.recent_incidents),
-                "incident",
-                client_id,
-                acknowledge,
-                &client_lookup,
-            );
-            awareness.recent_incidents = inc_filtered.allowed;
-            awareness
-                .cross_client_withheld
-                .extend(inc_filtered.withheld_notices);
-            self.log_audit_entries(
-                "get_situational_awareness",
-                client_id,
-                "incident",
-                &inc_filtered.audit_entries,
-            )
-            .await;
-        }
-
-        // Fetch live monitoring data for linked servers/services
-        if let Some(ref kuma_config) = self.kuma_config {
-            if let Ok(metrics) = crate::metrics::fetch_metrics(kuma_config).await {
-                // Get monitor mappings for this server and its services
-                let mut monitor_names: std::collections::HashSet<String> =
-                    std::collections::HashSet::new();
-
-                if let Some(srv_id) = server_id {
-                    if let Ok(monitors) =
-                        crate::repo::monitor_repo::get_monitors_for_server(&self.pool, srv_id).await
-                    {
-                        for m in &monitors {
-                            monitor_names.insert(m.monitor_name.clone());
-                        }
-                    }
-                }
-
-                if let Some(svc_id) = service_id {
-                    if let Ok(monitors) =
-                        crate::repo::monitor_repo::get_monitors_for_service(&self.pool, svc_id)
-                            .await
-                    {
-                        for m in &monitors {
-                            monitor_names.insert(m.monitor_name.clone());
-                        }
-                    }
-                }
-
-                // Match metrics to mapped monitors
-                for status in &metrics.monitors {
-                    if monitor_names.contains(&status.name) {
-                        if let Ok(val) = serde_json::to_value(status) {
-                            awareness.monitoring.push(val);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Zammad linked tickets for this server/service
-        if self.zammad_config.is_some() {
-            if let Some(srv_id) = server_id {
-                if let Ok(links) =
-                    crate::repo::ticket_link_repo::get_links_for_server(&self.pool, srv_id).await
-                {
-                    for link in &links {
-                        if let Ok(val) = serde_json::to_value(link) {
-                            awareness.linked_tickets.push(val);
-                        }
-                    }
-                }
-            }
-            if let Some(svc_id) = service_id {
-                if let Ok(links) =
-                    crate::repo::ticket_link_repo::get_links_for_service(&self.pool, svc_id).await
-                {
-                    for link in &links {
-                        if let Ok(val) = serde_json::to_value(link) {
-                            awareness.linked_tickets.push(val);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Apply compact mode and sections filtering
-        if compact || sections.is_some() {
-            if compact {
-                if let Some(ref v) = awareness.server {
-                    awareness.server = Some(compact_value(v, "server"));
-                }
-                if let Some(ref v) = awareness.site {
-                    awareness.site = Some(compact_value(v, "site"));
-                }
-                if let Some(ref v) = awareness.client {
-                    awareness.client = Some(compact_value(v, "client"));
-                }
-                awareness.services = compact_vec(&awareness.services, "service");
-                awareness.networks = compact_vec(&awareness.networks, "network");
-                awareness.vendors = compact_vec(&awareness.vendors, "vendor");
-                awareness.recent_incidents = compact_vec(&awareness.recent_incidents, "incident");
-                awareness.relevant_runbooks = compact_vec(&awareness.relevant_runbooks, "runbook");
-                awareness.pending_handoffs = compact_vec(&awareness.pending_handoffs, "handoff");
-                awareness.knowledge = compact_vec(&awareness.knowledge, "knowledge");
-                awareness.monitoring = compact_vec(&awareness.monitoring, "monitor");
-                awareness.linked_tickets = compact_vec(&awareness.linked_tickets, "ticket");
-            }
-            if sections.is_some() {
-                if !section_included(&sections, "server") {
-                    awareness.server = None;
-                }
-                if !section_included(&sections, "site") {
-                    awareness.site = None;
-                }
-                if !section_included(&sections, "client") {
-                    awareness.client = None;
-                }
-                if !section_included(&sections, "services") {
-                    awareness.services.clear();
-                }
-                if !section_included(&sections, "networks") {
-                    awareness.networks.clear();
-                }
-                if !section_included(&sections, "vendors") {
-                    awareness.vendors.clear();
-                }
-                if !section_included(&sections, "incidents") {
-                    awareness.recent_incidents.clear();
-                }
-                if !section_included(&sections, "runbooks") {
-                    awareness.relevant_runbooks.clear();
-                }
-                if !section_included(&sections, "handoffs") {
-                    awareness.pending_handoffs.clear();
-                }
-                if !section_included(&sections, "knowledge") {
-                    awareness.knowledge.clear();
-                }
-                if !section_included(&sections, "monitoring") {
-                    awareness.monitoring.clear();
-                }
-                if !section_included(&sections, "tickets") {
-                    awareness.linked_tickets.clear();
-                }
-            }
-        }
-
-        Ok(json_result(&awareness))
+        Ok(context::handle_get_situational_awareness(self, params.0).await)
     }
 
     #[tool(
@@ -1943,120 +356,7 @@ impl OpsBrain {
         &self,
         params: Parameters<context::GetClientOverviewParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let client =
-            match crate::repo::client_repo::get_client_by_slug(&self.pool, &p.client_slug).await {
-                Ok(Some(c)) => c,
-                Ok(None) => return Ok(not_found("Client", &p.client_slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        let sites = crate::repo::site_repo::list_sites(&self.pool, Some(client.id))
-            .await
-            .unwrap_or_default();
-
-        let servers =
-            crate::repo::server_repo::list_servers(&self.pool, Some(client.id), None, None, None)
-                .await
-                .unwrap_or_default();
-
-        // Collect all service IDs from all servers
-        let mut all_services = Vec::new();
-        let mut seen_service_ids = std::collections::HashSet::new();
-        for server in &servers {
-            if let Ok(svcs) =
-                crate::repo::service_repo::get_services_for_server(&self.pool, server.id).await
-            {
-                for svc in svcs {
-                    if seen_service_ids.insert(svc.id) {
-                        all_services.push(svc);
-                    }
-                }
-            }
-        }
-
-        // Get networks for all sites
-        let mut all_networks = Vec::new();
-        for site in &sites {
-            if let Ok(nets) =
-                crate::repo::network_repo::list_networks(&self.pool, Some(site.id)).await
-            {
-                all_networks.extend(nets);
-            }
-        }
-
-        let vendors = crate::repo::vendor_repo::get_vendors_for_client(&self.pool, client.id)
-            .await
-            .unwrap_or_default();
-
-        let recent_incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
-            "SELECT * FROM incidents WHERE client_id = $1 ORDER BY reported_at DESC LIMIT 10",
-        )
-        .bind(client.id)
-        .fetch_all(&self.pool)
-        .await
-        .unwrap_or_default();
-
-        let pending_handoffs: Vec<Handoff> = sqlx::query_as::<_, Handoff>(
-            "SELECT * FROM handoffs WHERE status = 'pending' ORDER BY created_at DESC LIMIT 10",
-        )
-        .fetch_all(&self.pool)
-        .await
-        .unwrap_or_default();
-
-        let mut overview = context::ClientOverview {
-            client: serde_json::to_value(&client).unwrap_or(serde_json::Value::Null),
-            sites: sites
-                .iter()
-                .filter_map(|s| serde_json::to_value(s).ok())
-                .collect(),
-            servers: servers
-                .iter()
-                .filter_map(|s| serde_json::to_value(s).ok())
-                .collect(),
-            services: all_services
-                .iter()
-                .filter_map(|s| serde_json::to_value(s).ok())
-                .collect(),
-            networks: all_networks
-                .iter()
-                .filter_map(|n| serde_json::to_value(n).ok())
-                .collect(),
-            vendors: vendors
-                .iter()
-                .filter_map(|v| serde_json::to_value(v).ok())
-                .collect(),
-            recent_incidents: recent_incidents
-                .iter()
-                .filter_map(|i| serde_json::to_value(i).ok())
-                .collect(),
-            pending_handoffs: pending_handoffs
-                .iter()
-                .filter_map(|h| serde_json::to_value(h).ok())
-                .collect(),
-            recent_tickets: Vec::new(),
-        };
-
-        // Fetch recent Zammad tickets for this client
-        if let Some(ref zammad) = self.zammad_config {
-            if let Some(org_id) = client.zammad_org_id {
-                let query = format!("organization.id:{org_id}");
-                match crate::zammad::search_tickets(zammad, &query, 5).await {
-                    Ok(tickets) => {
-                        overview.recent_tickets = tickets
-                            .iter()
-                            .filter_map(|t| serde_json::to_value(t).ok())
-                            .collect();
-                    }
-                    Err(e) => {
-                        tracing::warn!("Failed to fetch Zammad tickets for client overview: {e}");
-                    }
-                }
-            }
-        }
-
-        Ok(json_result(&overview))
+        Ok(context::handle_get_client_overview(self, params.0).await)
     }
 
     #[tool(
@@ -2069,390 +369,7 @@ impl OpsBrain {
         &self,
         params: Parameters<context::GetServerContextParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
-        let compact = p.compact.unwrap_or(false);
-        let sections = p.sections;
-
-        let server =
-            match crate::repo::server_repo::get_server_by_slug(&self.pool, &p.server_slug).await {
-                Ok(Some(s)) => s,
-                Ok(None) => return Ok(not_found("Server", &p.server_slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        let services = crate::repo::service_repo::get_services_for_server(&self.pool, server.id)
-            .await
-            .unwrap_or_default();
-
-        let site = crate::repo::site_repo::get_site(&self.pool, server.site_id)
-            .await
-            .ok()
-            .flatten();
-
-        let networks = crate::repo::network_repo::list_networks(&self.pool, Some(server.site_id))
-            .await
-            .unwrap_or_default();
-
-        // Get client for vendor lookup
-        let client_id = site.as_ref().map(|s| s.client_id);
-        let client = if let Some(cid) = client_id {
-            crate::repo::client_repo::get_client(&self.pool, cid)
-                .await
-                .ok()
-                .flatten()
-        } else {
-            None
-        };
-
-        let vendors = if let Some(cid) = client_id {
-            crate::repo::vendor_repo::get_vendors_for_client(&self.pool, cid)
-                .await
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
-
-        // Get incidents linked to this server
-        let incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
-            "SELECT i.* FROM incidents i \
-             JOIN incident_servers isv ON i.id = isv.incident_id \
-             WHERE isv.server_id = $1 \
-             ORDER BY i.reported_at DESC LIMIT 10",
-        )
-        .bind(server.id)
-        .fetch_all(&self.pool)
-        .await
-        .unwrap_or_default();
-
-        // Also get client-level incidents
-        let client_incidents: Vec<Incident> = if let Some(cid) = client_id {
-            sqlx::query_as::<_, Incident>(
-                "SELECT * FROM incidents WHERE client_id = $1 ORDER BY reported_at DESC LIMIT 10",
-            )
-            .bind(cid)
-            .fetch_all(&self.pool)
-            .await
-            .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
-
-        // Merge incidents, dedup by id
-        let mut all_incidents: Vec<serde_json::Value> = Vec::new();
-        let mut seen_ids = std::collections::HashSet::new();
-        for inc in incidents.iter().chain(client_incidents.iter()) {
-            if seen_ids.insert(inc.id) {
-                if let Ok(val) = serde_json::to_value(inc) {
-                    all_incidents.push(val);
-                }
-            }
-        }
-
-        // Get runbooks linked to this server
-        let runbooks = crate::repo::runbook_repo::list_runbooks(
-            &self.pool,
-            None,
-            None,
-            Some(server.id),
-            None,
-            None,
-        )
-        .await
-        .unwrap_or_default();
-
-        // Also get runbooks linked to any of this server's services
-        let mut all_runbooks: Vec<serde_json::Value> = runbooks
-            .iter()
-            .filter_map(|r| serde_json::to_value(r).ok())
-            .collect();
-        let mut seen_runbook_ids: std::collections::HashSet<uuid::Uuid> =
-            runbooks.iter().map(|r| r.id).collect();
-
-        for svc in &services {
-            if let Ok(svc_runbooks) = crate::repo::runbook_repo::list_runbooks(
-                &self.pool,
-                None,
-                Some(svc.id),
-                None,
-                None,
-                None,
-            )
-            .await
-            {
-                for rb in &svc_runbooks {
-                    if seen_runbook_ids.insert(rb.id) {
-                        if let Ok(val) = serde_json::to_value(rb) {
-                            all_runbooks.push(val);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Get knowledge entries for this client
-        let mut all_knowledge: Vec<serde_json::Value> = if let Some(cid) = client_id {
-            crate::repo::knowledge_repo::list_knowledge(&self.pool, None, Some(cid))
-                .await
-                .unwrap_or_default()
-                .iter()
-                .filter_map(|k| serde_json::to_value(k).ok())
-                .collect()
-        } else {
-            Vec::new()
-        };
-        let mut seen_knowledge_ids: std::collections::HashSet<uuid::Uuid> = all_knowledge
-            .iter()
-            .filter_map(|v| {
-                v.get("id")
-                    .and_then(|id| id.as_str())
-                    .and_then(|s| uuid::Uuid::parse_str(s).ok())
-            })
-            .collect();
-
-        // Semantic enrichment: find related runbooks/knowledge beyond explicit links
-        if self.embedding_client.is_some() {
-            let mut context_parts = vec![server.hostname.clone()];
-            if let Some(ref os) = server.os {
-                context_parts.push(os.clone());
-            }
-            for svc in &services {
-                context_parts.push(svc.name.clone());
-            }
-            let context_query = context_parts.join(" ");
-            if let Some(emb) = self.get_query_embedding(&context_query).await {
-                if let Ok(related_runbooks) =
-                    crate::repo::embedding_repo::vector_search_runbooks(&self.pool, &emb, 5).await
-                {
-                    for rb in &related_runbooks {
-                        if seen_runbook_ids.insert(rb.id) {
-                            if let Ok(val) = serde_json::to_value(rb) {
-                                all_runbooks.push(val);
-                            }
-                        }
-                    }
-                }
-                if let Ok(related_knowledge) =
-                    crate::repo::embedding_repo::vector_search_knowledge(&self.pool, &emb, 5).await
-                {
-                    for k in &related_knowledge {
-                        if seen_knowledge_ids.insert(k.id) {
-                            if let Ok(val) = serde_json::to_value(k) {
-                                all_knowledge.push(val);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // ── Cross-client scope gate for runbooks, knowledge, and incidents ──
-        let mut cross_client_withheld: Vec<serde_json::Value> = Vec::new();
-        {
-            let client_lookup = self.build_client_lookup().await;
-
-            let rb_filtered = filter_cross_client(
-                std::mem::take(&mut all_runbooks),
-                "runbook",
-                client_id,
-                acknowledge,
-                &client_lookup,
-            );
-            all_runbooks = rb_filtered.allowed;
-            cross_client_withheld.extend(rb_filtered.withheld_notices);
-            self.log_audit_entries(
-                "get_server_context",
-                client_id,
-                "runbook",
-                &rb_filtered.audit_entries,
-            )
-            .await;
-
-            let kn_filtered = filter_cross_client(
-                std::mem::take(&mut all_knowledge),
-                "knowledge",
-                client_id,
-                acknowledge,
-                &client_lookup,
-            );
-            all_knowledge = kn_filtered.allowed;
-            cross_client_withheld.extend(kn_filtered.withheld_notices);
-            self.log_audit_entries(
-                "get_server_context",
-                client_id,
-                "knowledge",
-                &kn_filtered.audit_entries,
-            )
-            .await;
-
-            let inc_filtered = filter_cross_client(
-                std::mem::take(&mut all_incidents),
-                "incident",
-                client_id,
-                acknowledge,
-                &client_lookup,
-            );
-            all_incidents = inc_filtered.allowed;
-            cross_client_withheld.extend(inc_filtered.withheld_notices);
-            self.log_audit_entries(
-                "get_server_context",
-                client_id,
-                "incident",
-                &inc_filtered.audit_entries,
-            )
-            .await;
-        }
-
-        // Fetch live monitoring data for this server and its services
-        let mut monitoring: Vec<serde_json::Value> = Vec::new();
-        if let Some(ref kuma_config) = self.kuma_config {
-            if let Ok(metrics) = crate::metrics::fetch_metrics(kuma_config).await {
-                let mut monitor_names: std::collections::HashSet<String> =
-                    std::collections::HashSet::new();
-
-                if let Ok(monitors) =
-                    crate::repo::monitor_repo::get_monitors_for_server(&self.pool, server.id).await
-                {
-                    for m in &monitors {
-                        monitor_names.insert(m.monitor_name.clone());
-                    }
-                }
-
-                for svc in &services {
-                    if let Ok(monitors) =
-                        crate::repo::monitor_repo::get_monitors_for_service(&self.pool, svc.id)
-                            .await
-                    {
-                        for m in &monitors {
-                            monitor_names.insert(m.monitor_name.clone());
-                        }
-                    }
-                }
-
-                for status in &metrics.monitors {
-                    if monitor_names.contains(&status.name) {
-                        if let Ok(val) = serde_json::to_value(status) {
-                            monitoring.push(val);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Zammad linked tickets for this server
-        let mut linked_tickets: Vec<serde_json::Value> = Vec::new();
-        if self.zammad_config.is_some() {
-            if let Ok(links) =
-                crate::repo::ticket_link_repo::get_links_for_server(&self.pool, server.id).await
-            {
-                for link in &links {
-                    if let Ok(val) = serde_json::to_value(link) {
-                        linked_tickets.push(val);
-                    }
-                }
-            }
-        }
-
-        let server_json = serde_json::to_value(&server).unwrap_or_default();
-        let site_json = serde_json::to_value(&site).unwrap_or_default();
-        let client_json = serde_json::to_value(&client).unwrap_or_default();
-        let services_json: Vec<serde_json::Value> = services
-            .iter()
-            .filter_map(|s| serde_json::to_value(s).ok())
-            .collect();
-        let networks_json: Vec<serde_json::Value> = networks
-            .iter()
-            .filter_map(|n| serde_json::to_value(n).ok())
-            .collect();
-        let vendors_json: Vec<serde_json::Value> = vendors
-            .iter()
-            .filter_map(|v| serde_json::to_value(v).ok())
-            .collect();
-
-        let mut result = serde_json::json!({});
-
-        if section_included(&sections, "server") {
-            result["server"] = if compact {
-                compact_value(&server_json, "server")
-            } else {
-                server_json
-            };
-        }
-        if section_included(&sections, "services") {
-            result["services"] = if compact {
-                serde_json::to_value(compact_vec(&services_json, "service")).unwrap_or_default()
-            } else {
-                serde_json::to_value(&services_json).unwrap_or_default()
-            };
-        }
-        if section_included(&sections, "site") {
-            result["site"] = if compact {
-                compact_value(&site_json, "site")
-            } else {
-                site_json
-            };
-        }
-        if section_included(&sections, "client") {
-            result["client"] = if compact {
-                compact_value(&client_json, "client")
-            } else {
-                client_json
-            };
-        }
-        if section_included(&sections, "networks") {
-            result["networks"] = if compact {
-                serde_json::to_value(compact_vec(&networks_json, "network")).unwrap_or_default()
-            } else {
-                serde_json::to_value(&networks_json).unwrap_or_default()
-            };
-        }
-        if section_included(&sections, "vendors") {
-            result["vendors"] = if compact {
-                serde_json::to_value(compact_vec(&vendors_json, "vendor")).unwrap_or_default()
-            } else {
-                serde_json::to_value(&vendors_json).unwrap_or_default()
-            };
-        }
-        if section_included(&sections, "incidents") {
-            result["recent_incidents"] = if compact {
-                serde_json::to_value(compact_vec(&all_incidents, "incident")).unwrap_or_default()
-            } else {
-                serde_json::to_value(&all_incidents).unwrap_or_default()
-            };
-        }
-        if section_included(&sections, "runbooks") {
-            result["runbooks"] = if compact {
-                serde_json::to_value(compact_vec(&all_runbooks, "runbook")).unwrap_or_default()
-            } else {
-                serde_json::to_value(&all_runbooks).unwrap_or_default()
-            };
-        }
-        if section_included(&sections, "knowledge") {
-            result["knowledge"] = if compact {
-                serde_json::to_value(compact_vec(&all_knowledge, "knowledge")).unwrap_or_default()
-            } else {
-                serde_json::to_value(&all_knowledge).unwrap_or_default()
-            };
-        }
-        if section_included(&sections, "monitoring") && !monitoring.is_empty() {
-            result["monitoring"] = if compact {
-                serde_json::to_value(compact_vec(&monitoring, "monitor")).unwrap_or_default()
-            } else {
-                serde_json::to_value(&monitoring).unwrap_or_default()
-            };
-        }
-        if section_included(&sections, "tickets") && !linked_tickets.is_empty() {
-            result["linked_tickets"] = if compact {
-                serde_json::to_value(compact_vec(&linked_tickets, "ticket")).unwrap_or_default()
-            } else {
-                serde_json::to_value(&linked_tickets).unwrap_or_default()
-            };
-        }
-        if !cross_client_withheld.is_empty() {
-            result["cross_client_withheld"] = serde_json::json!(cross_client_withheld);
-        }
-
-        Ok(json_result(&result))
+        Ok(context::handle_get_server_context(self, params.0).await)
     }
 
     // ===== INCIDENT TOOLS =====
@@ -2465,81 +382,7 @@ impl OpsBrain {
         &self,
         params: Parameters<incidents::CreateIncidentParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let severity = p.severity.as_deref().unwrap_or("medium");
-
-        if let Err(msg) = crate::validation::validate_required(
-            severity,
-            "severity",
-            crate::validation::INCIDENT_SEVERITIES,
-        ) {
-            return Ok(error_result(&msg));
-        }
-
-        // Resolve client_slug
-        let client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        let cross_client_safe = p.cross_client_safe.unwrap_or(false);
-        let incident = match crate::repo::incident_repo::create_incident(
-            &self.pool,
-            &p.title,
-            severity,
-            client_id,
-            p.symptoms.as_deref(),
-            p.notes.as_deref(),
-            cross_client_safe,
-        )
-        .await
-        {
-            Ok(i) => i,
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        };
-
-        // Link servers if provided
-        if let Some(slugs) = &p.server_slugs {
-            for slug in slugs {
-                if let Ok(Some(server)) =
-                    crate::repo::server_repo::get_server_by_slug(&self.pool, slug).await
-                {
-                    let _ = crate::repo::incident_repo::link_incident_server(
-                        &self.pool,
-                        incident.id,
-                        server.id,
-                    )
-                    .await;
-                }
-            }
-        }
-
-        // Link services if provided
-        if let Some(slugs) = &p.service_slugs {
-            for slug in slugs {
-                if let Ok(Some(service)) =
-                    crate::repo::service_repo::get_service_by_slug(&self.pool, slug).await
-                {
-                    let _ = crate::repo::incident_repo::link_incident_service(
-                        &self.pool,
-                        incident.id,
-                        service.id,
-                    )
-                    .await;
-                }
-            }
-        }
-
-        let text = crate::embeddings::prepare_incident_text(&incident);
-        self.embed_and_store("incidents", incident.id, &text).await;
-
-        Ok(json_result(&incident))
+        Ok(incidents::handle_create_incident(self, params.0).await)
     }
 
     #[tool(
@@ -2551,50 +394,7 @@ impl OpsBrain {
         &self,
         params: Parameters<incidents::UpdateIncidentParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let id = match uuid::Uuid::parse_str(&p.id) {
-            Ok(id) => id,
-            Err(_) => return Ok(error_result(&format!("Invalid UUID: {}", p.id))),
-        };
-
-        if let Err(msg) = crate::validation::validate_option(
-            p.status.as_deref(),
-            "status",
-            crate::validation::INCIDENT_STATUSES,
-        ) {
-            return Ok(error_result(&msg));
-        }
-        if let Err(msg) = crate::validation::validate_option(
-            p.severity.as_deref(),
-            "severity",
-            crate::validation::INCIDENT_SEVERITIES,
-        ) {
-            return Ok(error_result(&msg));
-        }
-
-        match crate::repo::incident_repo::update_incident(
-            &self.pool,
-            id,
-            p.title.as_deref(),
-            p.status.as_deref(),
-            p.severity.as_deref(),
-            p.symptoms.as_deref(),
-            p.root_cause.as_deref(),
-            p.resolution.as_deref(),
-            p.prevention.as_deref(),
-            p.notes.as_deref(),
-            p.cross_client_safe,
-        )
-        .await
-        {
-            Ok(incident) => {
-                let text = crate::embeddings::prepare_incident_text(&incident);
-                self.embed_and_store("incidents", incident.id, &text).await;
-                Ok(json_result(&incident))
-            }
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(incidents::handle_update_incident(self, params.0).await)
     }
 
     #[tool(
@@ -2605,43 +405,7 @@ impl OpsBrain {
         &self,
         params: Parameters<incidents::GetIncidentParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let id = match uuid::Uuid::parse_str(&p.id) {
-            Ok(id) => id,
-            Err(_) => return Ok(error_result(&format!("Invalid UUID: {}", p.id))),
-        };
-
-        let incident = match crate::repo::incident_repo::get_incident(&self.pool, id).await {
-            Ok(Some(i)) => i,
-            Ok(None) => return Ok(not_found("Incident", &p.id)),
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        };
-
-        // Get linked entities
-        let linked_servers: Vec<crate::models::server::Server> = sqlx::query_as(
-            "SELECT s.* FROM servers s JOIN incident_servers isv ON s.id = isv.server_id WHERE isv.incident_id = $1",
-        )
-        .bind(id)
-        .fetch_all(&self.pool)
-        .await
-        .unwrap_or_default();
-
-        let linked_services: Vec<crate::models::service::Service> = sqlx::query_as(
-            "SELECT s.* FROM services s JOIN incident_services iss ON s.id = iss.service_id WHERE iss.incident_id = $1",
-        )
-        .bind(id)
-        .fetch_all(&self.pool)
-        .await
-        .unwrap_or_default();
-
-        let result = serde_json::json!({
-            "incident": incident,
-            "linked_servers": linked_servers,
-            "linked_services": linked_services,
-        });
-
-        Ok(json_result(&result))
+        Ok(incidents::handle_get_incident(self, params.0).await)
     }
 
     #[tool(
@@ -2652,49 +416,7 @@ impl OpsBrain {
         &self,
         params: Parameters<incidents::ListIncidentsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let limit = p.limit.unwrap_or(20);
-
-        // Validate filters
-        if let Err(msg) = crate::validation::validate_option(
-            p.status.as_deref(),
-            "status",
-            crate::validation::INCIDENT_STATUSES,
-        ) {
-            return Ok(error_result(&msg));
-        }
-        if let Err(msg) = crate::validation::validate_option(
-            p.severity.as_deref(),
-            "severity",
-            crate::validation::INCIDENT_SEVERITIES,
-        ) {
-            return Ok(error_result(&msg));
-        }
-
-        // Resolve client_slug
-        let client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        match crate::repo::incident_repo::list_incidents(
-            &self.pool,
-            client_id,
-            p.status.as_deref(),
-            p.severity.as_deref(),
-            limit,
-        )
-        .await
-        {
-            Ok(incidents) => Ok(json_result(&incidents)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(incidents::handle_list_incidents(self, params.0).await)
     }
 
     #[tool(
@@ -2707,38 +429,7 @@ impl OpsBrain {
         &self,
         params: Parameters<incidents::SearchIncidentsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let mode = p.mode.as_deref().unwrap_or("fts");
-        if let Err(msg) =
-            crate::validation::validate_required(mode, "mode", crate::validation::SEARCH_MODES)
-        {
-            return Ok(error_result(&msg));
-        }
-        let result = match mode {
-            "semantic" => {
-                let Some(emb) = self.get_query_embedding(&p.query).await else {
-                    return Ok(error_result(
-                        "Semantic search unavailable (OPENAI_API_KEY not set)",
-                    ));
-                };
-                crate::repo::embedding_repo::vector_search_incidents(&self.pool, &emb, 20).await
-            }
-            "hybrid" => {
-                let emb = self.get_query_embedding(&p.query).await;
-                crate::repo::embedding_repo::hybrid_search_incidents(
-                    &self.pool,
-                    &p.query,
-                    emb.as_deref(),
-                    20,
-                )
-                .await
-            }
-            _ => crate::repo::incident_repo::search_incidents(&self.pool, &p.query).await,
-        };
-        match result {
-            Ok(incidents) => Ok(json_result(&incidents)),
-            Err(e) => Ok(error_result(&format!("Search error: {e}"))),
-        }
+        Ok(incidents::handle_search_incidents(self, params.0).await)
     }
 
     #[tool(
@@ -2750,135 +441,7 @@ impl OpsBrain {
         &self,
         params: Parameters<incidents::LinkIncidentParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let incident_id = match uuid::Uuid::parse_str(&p.incident_id) {
-            Ok(id) => id,
-            Err(_) => return Ok(error_result(&format!("Invalid UUID: {}", p.incident_id))),
-        };
-
-        // Verify incident exists
-        match crate::repo::incident_repo::get_incident(&self.pool, incident_id).await {
-            Ok(Some(_)) => {}
-            Ok(None) => return Ok(not_found("Incident", &p.incident_id)),
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        }
-
-        let mut linked = Vec::new();
-
-        // Link servers
-        if let Some(slugs) = &p.server_slugs {
-            for slug in slugs {
-                match crate::repo::server_repo::get_server_by_slug(&self.pool, slug).await {
-                    Ok(Some(server)) => {
-                        if let Err(e) = crate::repo::incident_repo::link_incident_server(
-                            &self.pool,
-                            incident_id,
-                            server.id,
-                        )
-                        .await
-                        {
-                            return Ok(error_result(&format!(
-                                "Failed to link server '{slug}': {e}"
-                            )));
-                        }
-                        linked.push(format!("server:{slug}"));
-                    }
-                    Ok(None) => return Ok(not_found("Server", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-        }
-
-        // Link services
-        if let Some(slugs) = &p.service_slugs {
-            for slug in slugs {
-                match crate::repo::service_repo::get_service_by_slug(&self.pool, slug).await {
-                    Ok(Some(service)) => {
-                        if let Err(e) = crate::repo::incident_repo::link_incident_service(
-                            &self.pool,
-                            incident_id,
-                            service.id,
-                        )
-                        .await
-                        {
-                            return Ok(error_result(&format!(
-                                "Failed to link service '{slug}': {e}"
-                            )));
-                        }
-                        linked.push(format!("service:{slug}"));
-                    }
-                    Ok(None) => return Ok(not_found("Service", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-        }
-
-        // Link runbooks
-        if let Some(rb_links) = &p.runbook_links {
-            for rb_link in rb_links {
-                let usage = rb_link.usage.as_deref().unwrap_or("followed");
-                if let Err(msg) = crate::validation::validate_required(
-                    usage,
-                    "runbook usage",
-                    crate::validation::RUNBOOK_USAGES,
-                ) {
-                    return Ok(error_result(&msg));
-                }
-                match crate::repo::runbook_repo::get_runbook_by_slug(&self.pool, &rb_link.slug)
-                    .await
-                {
-                    Ok(Some(runbook)) => {
-                        if let Err(e) = crate::repo::incident_repo::link_incident_runbook(
-                            &self.pool,
-                            incident_id,
-                            runbook.id,
-                            usage,
-                        )
-                        .await
-                        {
-                            return Ok(error_result(&format!(
-                                "Failed to link runbook '{}': {e}",
-                                rb_link.slug
-                            )));
-                        }
-                        linked.push(format!("runbook:{}", rb_link.slug));
-                    }
-                    Ok(None) => return Ok(not_found("Runbook", &rb_link.slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-        }
-
-        // Link vendors
-        if let Some(names) = &p.vendor_names {
-            for name in names {
-                match crate::repo::vendor_repo::get_vendor_by_name(&self.pool, name).await {
-                    Ok(Some(vendor)) => {
-                        if let Err(e) = crate::repo::incident_repo::link_incident_vendor(
-                            &self.pool,
-                            incident_id,
-                            vendor.id,
-                        )
-                        .await
-                        {
-                            return Ok(error_result(&format!(
-                                "Failed to link vendor '{name}': {e}"
-                            )));
-                        }
-                        linked.push(format!("vendor:{name}"));
-                    }
-                    Ok(None) => return Ok(not_found("Vendor", name)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-        }
-
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "Linked to incident {}: {}",
-            p.incident_id,
-            linked.join(", ")
-        ))]))
+        Ok(incidents::handle_link_incident(self, params.0).await)
     }
 
     // ===== SESSION TOOLS =====
@@ -2891,17 +454,7 @@ impl OpsBrain {
         &self,
         params: Parameters<coordination::StartSessionParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        match crate::repo::session_repo::start_session(
-            &self.pool,
-            &p.machine_id,
-            &p.machine_hostname,
-        )
-        .await
-        {
-            Ok(session) => Ok(json_result(&session)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(coordination::handle_start_session(self, params.0).await)
     }
 
     #[tool(
@@ -2912,17 +465,7 @@ impl OpsBrain {
         &self,
         params: Parameters<coordination::EndSessionParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let id = match uuid::Uuid::parse_str(&p.session_id) {
-            Ok(id) => id,
-            Err(_) => return Ok(error_result(&format!("Invalid UUID: {}", p.session_id))),
-        };
-
-        match crate::repo::session_repo::end_session(&self.pool, id, p.summary.as_deref()).await {
-            Ok(session) => Ok(json_result(&session)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(coordination::handle_end_session(self, params.0).await)
     }
 
     #[tool(
@@ -2933,21 +476,7 @@ impl OpsBrain {
         &self,
         params: Parameters<coordination::ListSessionsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let limit = p.limit.unwrap_or(20);
-        let active_only = p.active_only.unwrap_or(false);
-
-        match crate::repo::session_repo::list_sessions(
-            &self.pool,
-            p.machine_id.as_deref(),
-            active_only,
-            limit,
-        )
-        .await
-        {
-            Ok(sessions) => Ok(json_result(&sessions)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(coordination::handle_list_sessions(self, params.0).await)
     }
 
     // ===== HANDOFF TOOLS =====
@@ -2961,45 +490,7 @@ impl OpsBrain {
         &self,
         params: Parameters<coordination::CreateHandoffParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let priority = p.priority.as_deref().unwrap_or("normal");
-
-        if let Err(msg) = crate::validation::validate_required(
-            priority,
-            "priority",
-            crate::validation::HANDOFF_PRIORITIES,
-        ) {
-            return Ok(error_result(&msg));
-        }
-
-        // Resolve optional session ID
-        let from_session_id = match &p.from_session_id {
-            Some(id_str) => match uuid::Uuid::parse_str(id_str) {
-                Ok(id) => Some(id),
-                Err(_) => return Ok(error_result(&format!("Invalid session UUID: {id_str}"))),
-            },
-            None => None,
-        };
-
-        match crate::repo::handoff_repo::create_handoff(
-            &self.pool,
-            from_session_id,
-            &p.from_machine,
-            p.to_machine.as_deref(),
-            priority,
-            &p.title,
-            &p.body,
-            p.context.as_ref(),
-        )
-        .await
-        {
-            Ok(handoff) => {
-                let text = crate::embeddings::prepare_handoff_text(&handoff);
-                self.embed_and_store("handoffs", handoff.id, &text).await;
-                Ok(json_result(&handoff))
-            }
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(coordination::handle_create_handoff(self, params.0).await)
     }
 
     #[tool(
@@ -3010,30 +501,7 @@ impl OpsBrain {
         &self,
         params: Parameters<coordination::UpdateHandoffStatusParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let id = match uuid::Uuid::parse_str(&p.handoff_id) {
-            Ok(id) => id,
-            Err(_) => return Ok(error_result(&format!("Invalid UUID: {}", p.handoff_id))),
-        };
-
-        // Verify it's pending
-        match crate::repo::handoff_repo::get_handoff(&self.pool, id).await {
-            Ok(Some(h)) if h.status == "pending" => {}
-            Ok(Some(h)) => {
-                return Ok(error_result(&format!(
-                    "Handoff is already '{}', cannot accept",
-                    h.status
-                )))
-            }
-            Ok(None) => return Ok(not_found("Handoff", &p.handoff_id)),
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        }
-
-        match crate::repo::handoff_repo::update_handoff_status(&self.pool, id, "accepted").await {
-            Ok(handoff) => Ok(json_result(&handoff)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(coordination::handle_accept_handoff(self, params.0).await)
     }
 
     #[tool(name = "complete_handoff", description = "Mark a handoff as completed")]
@@ -3041,27 +509,7 @@ impl OpsBrain {
         &self,
         params: Parameters<coordination::UpdateHandoffStatusParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        let id = match uuid::Uuid::parse_str(&p.handoff_id) {
-            Ok(id) => id,
-            Err(_) => return Ok(error_result(&format!("Invalid UUID: {}", p.handoff_id))),
-        };
-
-        // Verify it exists and is not already completed
-        match crate::repo::handoff_repo::get_handoff(&self.pool, id).await {
-            Ok(Some(h)) if h.status == "completed" => {
-                return Ok(error_result("Handoff is already completed"))
-            }
-            Ok(Some(_)) => {}
-            Ok(None) => return Ok(not_found("Handoff", &p.handoff_id)),
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        }
-
-        match crate::repo::handoff_repo::update_handoff_status(&self.pool, id, "completed").await {
-            Ok(handoff) => Ok(json_result(&handoff)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(coordination::handle_complete_handoff(self, params.0).await)
     }
 
     #[tool(
@@ -3072,29 +520,7 @@ impl OpsBrain {
         &self,
         params: Parameters<coordination::ListHandoffsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let limit = p.limit.unwrap_or(20);
-
-        if let Err(msg) = crate::validation::validate_option(
-            p.status.as_deref(),
-            "status",
-            crate::validation::HANDOFF_STATUSES,
-        ) {
-            return Ok(error_result(&msg));
-        }
-
-        match crate::repo::handoff_repo::list_handoffs(
-            &self.pool,
-            p.status.as_deref(),
-            p.to_machine.as_deref(),
-            p.from_machine.as_deref(),
-            limit,
-        )
-        .await
-        {
-            Ok(handoffs) => Ok(json_result(&handoffs)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(coordination::handle_list_handoffs(self, params.0).await)
     }
 
     #[tool(
@@ -3106,38 +532,7 @@ impl OpsBrain {
         &self,
         params: Parameters<coordination::SearchHandoffsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let mode = p.mode.as_deref().unwrap_or("fts");
-        if let Err(msg) =
-            crate::validation::validate_required(mode, "mode", crate::validation::SEARCH_MODES)
-        {
-            return Ok(error_result(&msg));
-        }
-        let result = match mode {
-            "semantic" => {
-                let Some(emb) = self.get_query_embedding(&p.query).await else {
-                    return Ok(error_result(
-                        "Semantic search unavailable (OPENAI_API_KEY not set)",
-                    ));
-                };
-                crate::repo::embedding_repo::vector_search_handoffs(&self.pool, &emb, 20).await
-            }
-            "hybrid" => {
-                let emb = self.get_query_embedding(&p.query).await;
-                crate::repo::embedding_repo::hybrid_search_handoffs(
-                    &self.pool,
-                    &p.query,
-                    emb.as_deref(),
-                    20,
-                )
-                .await
-            }
-            _ => crate::repo::handoff_repo::search_handoffs(&self.pool, &p.query).await,
-        };
-        match result {
-            Ok(handoffs) => Ok(json_result(&handoffs)),
-            Err(e) => Ok(error_result(&format!("Search error: {e}"))),
-        }
+        Ok(coordination::handle_search_handoffs(self, params.0).await)
     }
 
     // ===== SEMANTIC SEARCH TOOLS =====
@@ -3153,201 +548,7 @@ impl OpsBrain {
         &self,
         params: Parameters<search::SemanticSearchParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let limit = p.limit.unwrap_or(5);
-        let tables = p.tables.unwrap_or_else(|| {
-            vec![
-                "runbooks".to_string(),
-                "knowledge".to_string(),
-                "incidents".to_string(),
-                "handoffs".to_string(),
-            ]
-        });
-
-        // Resolve optional client_slug for cross-client gate
-        let requesting_client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-        let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
-
-        let query_embedding = self.get_query_embedding(&p.query).await;
-        let emb_ref = query_embedding.as_deref();
-
-        let mut results = serde_json::Map::new();
-        let client_lookup = self.build_client_lookup().await;
-        let mut all_withheld: Vec<serde_json::Value> = Vec::new();
-
-        // Run searches for requested tables — gate runbooks and knowledge
-        if tables.iter().any(|t| t == "runbooks") {
-            match crate::repo::embedding_repo::hybrid_search_runbooks(
-                &self.pool, &p.query, emb_ref, limit,
-            )
-            .await
-            {
-                Ok(items) => {
-                    let json_items: Vec<serde_json::Value> = items
-                        .iter()
-                        .filter_map(|r| serde_json::to_value(r).ok())
-                        .collect();
-                    let filtered = filter_cross_client(
-                        json_items,
-                        "runbook",
-                        requesting_client_id,
-                        acknowledge,
-                        &client_lookup,
-                    );
-                    results.insert(
-                        "runbooks".to_string(),
-                        serde_json::to_value(&filtered.allowed).unwrap_or_default(),
-                    );
-                    all_withheld.extend(filtered.withheld_notices);
-                    self.log_audit_entries(
-                        "semantic_search",
-                        requesting_client_id,
-                        "runbook",
-                        &filtered.audit_entries,
-                    )
-                    .await;
-                }
-                Err(e) => {
-                    results.insert(
-                        "runbooks_error".to_string(),
-                        serde_json::Value::String(e.to_string()),
-                    );
-                }
-            }
-        }
-        if tables.iter().any(|t| t == "knowledge") {
-            match crate::repo::embedding_repo::hybrid_search_knowledge(
-                &self.pool, &p.query, emb_ref, limit,
-            )
-            .await
-            {
-                Ok(items) => {
-                    let json_items: Vec<serde_json::Value> = items
-                        .iter()
-                        .filter_map(|k| serde_json::to_value(k).ok())
-                        .collect();
-                    let filtered = filter_cross_client(
-                        json_items,
-                        "knowledge",
-                        requesting_client_id,
-                        acknowledge,
-                        &client_lookup,
-                    );
-                    results.insert(
-                        "knowledge".to_string(),
-                        serde_json::to_value(&filtered.allowed).unwrap_or_default(),
-                    );
-                    all_withheld.extend(filtered.withheld_notices);
-                    self.log_audit_entries(
-                        "semantic_search",
-                        requesting_client_id,
-                        "knowledge",
-                        &filtered.audit_entries,
-                    )
-                    .await;
-                }
-                Err(e) => {
-                    results.insert(
-                        "knowledge_error".to_string(),
-                        serde_json::Value::String(e.to_string()),
-                    );
-                }
-            }
-        }
-        // Incidents are gated — HIPAA/IRS §7216 cross-client isolation
-        if tables.iter().any(|t| t == "incidents") {
-            match crate::repo::embedding_repo::hybrid_search_incidents(
-                &self.pool, &p.query, emb_ref, limit,
-            )
-            .await
-            {
-                Ok(items) => {
-                    let json_items: Vec<serde_json::Value> = items
-                        .iter()
-                        .filter_map(|i| serde_json::to_value(i).ok())
-                        .collect();
-                    let filtered = filter_cross_client(
-                        json_items,
-                        "incident",
-                        requesting_client_id,
-                        acknowledge,
-                        &client_lookup,
-                    );
-                    results.insert(
-                        "incidents".to_string(),
-                        serde_json::to_value(&filtered.allowed).unwrap_or_default(),
-                    );
-                    all_withheld.extend(filtered.withheld_notices);
-                    self.log_audit_entries(
-                        "semantic_search",
-                        requesting_client_id,
-                        "incident",
-                        &filtered.audit_entries,
-                    )
-                    .await;
-                }
-                Err(e) => {
-                    results.insert(
-                        "incidents_error".to_string(),
-                        serde_json::Value::String(e.to_string()),
-                    );
-                }
-            }
-        }
-        if tables.iter().any(|t| t == "handoffs") {
-            match crate::repo::embedding_repo::hybrid_search_handoffs(
-                &self.pool, &p.query, emb_ref, limit,
-            )
-            .await
-            {
-                Ok(items) => {
-                    results.insert(
-                        "handoffs".to_string(),
-                        serde_json::to_value(&items).unwrap_or_default(),
-                    );
-                }
-                Err(e) => {
-                    results.insert(
-                        "handoffs_error".to_string(),
-                        serde_json::Value::String(e.to_string()),
-                    );
-                }
-            }
-        }
-
-        if !all_withheld.is_empty() {
-            results.insert(
-                "cross_client_withheld".to_string(),
-                serde_json::to_value(&all_withheld).unwrap_or_default(),
-            );
-        }
-
-        if query_embedding.is_none() && self.embedding_client.is_some() {
-            results.insert(
-                "_note".to_string(),
-                serde_json::Value::String(
-                    "Embedding API call failed — results are FTS-only".to_string(),
-                ),
-            );
-        } else if self.embedding_client.is_none() {
-            results.insert(
-                "_note".to_string(),
-                serde_json::Value::String(
-                    "OPENAI_API_KEY not set — results are FTS-only".to_string(),
-                ),
-            );
-        }
-
-        Ok(json_result(&serde_json::Value::Object(results)))
+        Ok(search::handle_semantic_search(self, params.0).await)
     }
 
     #[tool(
@@ -3360,203 +561,7 @@ impl OpsBrain {
         &self,
         params: Parameters<search::BackfillEmbeddingsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let Some(ref client) = self.embedding_client else {
-            return Ok(error_result(
-                "OPENAI_API_KEY not set — cannot generate embeddings",
-            ));
-        };
-
-        let p = params.0;
-        let batch_size = p.batch_size.unwrap_or(10);
-        let tables: Vec<&str> = match &p.table {
-            Some(t) => vec![t.as_str()],
-            None => vec!["runbooks", "knowledge", "incidents", "handoffs"],
-        };
-
-        let mut summary = serde_json::Map::new();
-
-        for table in &tables {
-            let mut processed = 0i64;
-            let mut failed = 0i64;
-
-            match *table {
-                "runbooks" => {
-                    if let Ok(rows) = crate::repo::embedding_repo::get_runbooks_without_embeddings(
-                        &self.pool, batch_size,
-                    )
-                    .await
-                    {
-                        let texts: Vec<String> = rows
-                            .iter()
-                            .map(crate::embeddings::prepare_runbook_text)
-                            .collect();
-                        match client.embed_texts(&texts).await {
-                            Ok(embeddings) => {
-                                for (row, emb) in rows.iter().zip(embeddings.iter()) {
-                                    if crate::repo::embedding_repo::store_runbook_embedding(
-                                        &self.pool, row.id, emb,
-                                    )
-                                    .await
-                                    .is_ok()
-                                    {
-                                        processed += 1;
-                                    } else {
-                                        failed += 1;
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                summary.insert(
-                                    format!("{table}_error"),
-                                    serde_json::Value::String(e.to_string()),
-                                );
-                            }
-                        }
-                    }
-                }
-                "knowledge" => {
-                    if let Ok(rows) = crate::repo::embedding_repo::get_knowledge_without_embeddings(
-                        &self.pool, batch_size,
-                    )
-                    .await
-                    {
-                        let texts: Vec<String> = rows
-                            .iter()
-                            .map(crate::embeddings::prepare_knowledge_text)
-                            .collect();
-                        match client.embed_texts(&texts).await {
-                            Ok(embeddings) => {
-                                for (row, emb) in rows.iter().zip(embeddings.iter()) {
-                                    if crate::repo::embedding_repo::store_knowledge_embedding(
-                                        &self.pool, row.id, emb,
-                                    )
-                                    .await
-                                    .is_ok()
-                                    {
-                                        processed += 1;
-                                    } else {
-                                        failed += 1;
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                summary.insert(
-                                    format!("{table}_error"),
-                                    serde_json::Value::String(e.to_string()),
-                                );
-                            }
-                        }
-                    }
-                }
-                "incidents" => {
-                    if let Ok(rows) = crate::repo::embedding_repo::get_incidents_without_embeddings(
-                        &self.pool, batch_size,
-                    )
-                    .await
-                    {
-                        let texts: Vec<String> = rows
-                            .iter()
-                            .map(crate::embeddings::prepare_incident_text)
-                            .collect();
-                        match client.embed_texts(&texts).await {
-                            Ok(embeddings) => {
-                                for (row, emb) in rows.iter().zip(embeddings.iter()) {
-                                    if crate::repo::embedding_repo::store_incident_embedding(
-                                        &self.pool, row.id, emb,
-                                    )
-                                    .await
-                                    .is_ok()
-                                    {
-                                        processed += 1;
-                                    } else {
-                                        failed += 1;
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                summary.insert(
-                                    format!("{table}_error"),
-                                    serde_json::Value::String(e.to_string()),
-                                );
-                            }
-                        }
-                    }
-                }
-                "handoffs" => {
-                    if let Ok(rows) = crate::repo::embedding_repo::get_handoffs_without_embeddings(
-                        &self.pool, batch_size,
-                    )
-                    .await
-                    {
-                        let texts: Vec<String> = rows
-                            .iter()
-                            .map(crate::embeddings::prepare_handoff_text)
-                            .collect();
-                        match client.embed_texts(&texts).await {
-                            Ok(embeddings) => {
-                                for (row, emb) in rows.iter().zip(embeddings.iter()) {
-                                    if crate::repo::embedding_repo::store_handoff_embedding(
-                                        &self.pool, row.id, emb,
-                                    )
-                                    .await
-                                    .is_ok()
-                                    {
-                                        processed += 1;
-                                    } else {
-                                        failed += 1;
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                summary.insert(
-                                    format!("{table}_error"),
-                                    serde_json::Value::String(e.to_string()),
-                                );
-                            }
-                        }
-                    }
-                }
-                _ => {
-                    summary.insert(
-                        format!("{table}_error"),
-                        serde_json::Value::String("Unknown table".to_string()),
-                    );
-                    continue;
-                }
-            }
-
-            summary.insert(
-                format!("{table}_processed"),
-                serde_json::Value::Number(processed.into()),
-            );
-            summary.insert(
-                format!("{table}_failed"),
-                serde_json::Value::Number(failed.into()),
-            );
-        }
-
-        // Get remaining counts
-        if let Ok(counts) = crate::repo::embedding_repo::count_missing_embeddings(&self.pool).await
-        {
-            summary.insert(
-                "remaining_runbooks".to_string(),
-                serde_json::Value::Number(counts.runbooks.into()),
-            );
-            summary.insert(
-                "remaining_knowledge".to_string(),
-                serde_json::Value::Number(counts.knowledge.into()),
-            );
-            summary.insert(
-                "remaining_incidents".to_string(),
-                serde_json::Value::Number(counts.incidents.into()),
-            );
-            summary.insert(
-                "remaining_handoffs".to_string(),
-                serde_json::Value::Number(counts.handoffs.into()),
-            );
-        }
-
-        Ok(json_result(&serde_json::Value::Object(summary)))
+        Ok(search::handle_backfill_embeddings(self, params.0).await)
     }
 
     // ===== MONITORING TOOLS =====
@@ -3570,57 +575,7 @@ impl OpsBrain {
         &self,
         params: Parameters<monitoring::ListMonitorsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let kuma_config = match &self.kuma_config {
-            Some(c) => c,
-            None => {
-                return Ok(error_result(
-                    "Uptime Kuma not configured (set UPTIME_KUMA_URL)",
-                ))
-            }
-        };
-
-        let summary = match crate::metrics::fetch_metrics(kuma_config).await {
-            Ok(s) => s,
-            Err(e) => return Ok(error_result(&format!("Failed to fetch metrics: {e}"))),
-        };
-
-        // Get all monitor mappings from DB
-        let mappings = crate::repo::monitor_repo::list_monitors(&self.pool)
-            .await
-            .unwrap_or_default();
-
-        let mut results: Vec<serde_json::Value> = Vec::new();
-        for monitor in &summary.monitors {
-            // Apply status filter
-            if let Some(ref status_filter) = p.status {
-                if monitor.status_text != *status_filter {
-                    continue;
-                }
-            }
-
-            let mapping = mappings.iter().find(|m| m.monitor_name == monitor.name);
-            let mut val = serde_json::to_value(monitor).unwrap_or_default();
-            if let Some(mapping) = mapping {
-                val["linked_server_id"] =
-                    serde_json::to_value(mapping.server_id).unwrap_or_default();
-                val["linked_service_id"] =
-                    serde_json::to_value(mapping.service_id).unwrap_or_default();
-                val["mapping_notes"] = serde_json::to_value(&mapping.notes).unwrap_or_default();
-            }
-            results.push(val);
-        }
-
-        let output = serde_json::json!({
-            "total": summary.total,
-            "up": summary.up,
-            "down": summary.down,
-            "pending": summary.pending,
-            "maintenance": summary.maintenance,
-            "filtered_count": results.len(),
-            "monitors": results,
-        });
-        Ok(json_result(&output))
+        Ok(monitoring::handle_list_monitors(self, params.0).await)
     }
 
     #[tool(
@@ -3632,53 +587,7 @@ impl OpsBrain {
         &self,
         params: Parameters<monitoring::GetMonitorStatusParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let kuma_config = match &self.kuma_config {
-            Some(c) => c,
-            None => {
-                return Ok(error_result(
-                    "Uptime Kuma not configured (set UPTIME_KUMA_URL)",
-                ))
-            }
-        };
-
-        let summary = match crate::metrics::fetch_metrics(kuma_config).await {
-            Ok(s) => s,
-            Err(e) => return Ok(error_result(&format!("Failed to fetch metrics: {e}"))),
-        };
-
-        let monitor = match summary.monitors.iter().find(|m| m.name == p.monitor_name) {
-            Some(m) => m,
-            None => return Ok(not_found("Monitor", &p.monitor_name)),
-        };
-
-        let mapping = crate::repo::monitor_repo::get_monitor_by_name(&self.pool, &p.monitor_name)
-            .await
-            .ok()
-            .flatten();
-
-        let mut result = serde_json::to_value(monitor).unwrap_or_default();
-
-        // Enrich with linked entities
-        if let Some(ref mapping) = mapping {
-            if let Some(server_id) = mapping.server_id {
-                if let Ok(Some(server)) =
-                    crate::repo::server_repo::get_server(&self.pool, server_id).await
-                {
-                    result["linked_server"] = serde_json::to_value(&server).unwrap_or_default();
-                }
-            }
-            if let Some(service_id) = mapping.service_id {
-                if let Ok(Some(service)) =
-                    crate::repo::service_repo::get_service(&self.pool, service_id).await
-                {
-                    result["linked_service"] = serde_json::to_value(&service).unwrap_or_default();
-                }
-            }
-            result["mapping_notes"] = serde_json::to_value(&mapping.notes).unwrap_or_default();
-        }
-
-        Ok(json_result(&result))
+        Ok(monitoring::handle_get_monitor_status(self, params.0).await)
     }
 
     #[tool(
@@ -3690,34 +599,7 @@ impl OpsBrain {
         &self,
         _params: Parameters<monitoring::GetMonitoringSummaryParams>,
     ) -> Result<CallToolResult, McpError> {
-        let kuma_config = match &self.kuma_config {
-            Some(c) => c,
-            None => {
-                return Ok(error_result(
-                    "Uptime Kuma not configured (set UPTIME_KUMA_URL)",
-                ))
-            }
-        };
-
-        let summary = match crate::metrics::fetch_metrics(kuma_config).await {
-            Ok(s) => s,
-            Err(e) => return Ok(error_result(&format!("Failed to fetch metrics: {e}"))),
-        };
-
-        // Highlight anything that's down
-        let down_monitors: Vec<&crate::metrics::MonitorStatus> =
-            summary.monitors.iter().filter(|m| m.status == 0).collect();
-
-        let result = serde_json::json!({
-            "status": if summary.down == 0 { "ALL_CLEAR" } else { "DEGRADED" },
-            "total": summary.total,
-            "up": summary.up,
-            "down": summary.down,
-            "pending": summary.pending,
-            "maintenance": summary.maintenance,
-            "down_monitors": down_monitors,
-        });
-        Ok(json_result(&result))
+        Ok(monitoring::handle_get_monitoring_summary(self, _params.0).await)
     }
 
     #[tool(
@@ -3730,50 +612,7 @@ impl OpsBrain {
         &self,
         params: Parameters<monitoring::LinkMonitorParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        // Resolve server slug to ID
-        let server_id = match &p.server_slug {
-            Some(slug) => {
-                match crate::repo::server_repo::get_server_by_slug(&self.pool, slug).await {
-                    Ok(Some(s)) => Some(s.id),
-                    Ok(None) => return Ok(not_found("Server", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        // Resolve service slug to ID
-        let service_id = match &p.service_slug {
-            Some(slug) => {
-                match crate::repo::service_repo::get_service_by_slug(&self.pool, slug).await {
-                    Ok(Some(s)) => Some(s.id),
-                    Ok(None) => return Ok(not_found("Service", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        if server_id.is_none() && service_id.is_none() && p.notes.is_none() {
-            return Ok(error_result(
-                "Provide at least one of: server_slug, service_slug, or notes",
-            ));
-        }
-
-        match crate::repo::monitor_repo::upsert_monitor(
-            &self.pool,
-            &p.monitor_name,
-            server_id,
-            service_id,
-            p.notes.as_deref(),
-        )
-        .await
-        {
-            Ok(monitor) => Ok(json_result(&monitor)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(monitoring::handle_link_monitor(self, params.0).await)
     }
 
     #[tool(
@@ -3785,15 +624,7 @@ impl OpsBrain {
         &self,
         params: Parameters<monitoring::UnlinkMonitorParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        match crate::repo::monitor_repo::delete_monitor(&self.pool, &p.monitor_name).await {
-            Ok(true) => Ok(CallToolResult::success(vec![Content::text(format!(
-                "Monitor mapping removed: {}",
-                p.monitor_name
-            ))])),
-            Ok(false) => Ok(not_found("Monitor mapping", &p.monitor_name)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(monitoring::handle_unlink_monitor(self, params.0).await)
     }
 
     #[tool(
@@ -3806,42 +637,7 @@ impl OpsBrain {
         &self,
         params: Parameters<monitoring::ListWatchdogIncidentsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let limit = p.limit.unwrap_or(20);
-        let prefix_pattern = format!("{}%", crate::watchdog::INCIDENT_PREFIX);
-
-        let query = match &p.status {
-            Some(status) => {
-                sqlx::query_as::<_, Incident>(
-                    "SELECT * FROM incidents WHERE title LIKE $1 AND status = $2 ORDER BY reported_at DESC LIMIT $3",
-                )
-                .bind(&prefix_pattern)
-                .bind(status)
-                .bind(limit)
-                .fetch_all(&self.pool)
-                .await
-            }
-            None => {
-                sqlx::query_as::<_, Incident>(
-                    "SELECT * FROM incidents WHERE title LIKE $1 ORDER BY reported_at DESC LIMIT $2",
-                )
-                .bind(&prefix_pattern)
-                .bind(limit)
-                .fetch_all(&self.pool)
-                .await
-            }
-        };
-
-        match query {
-            Ok(incidents) => {
-                let result = serde_json::json!({
-                    "count": incidents.len(),
-                    "incidents": incidents,
-                });
-                Ok(json_result(&result))
-            }
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(monitoring::handle_list_watchdog_incidents(self, params.0).await)
     }
 
     // ===== ZAMMAD TICKET TOOLS =====
@@ -3854,52 +650,7 @@ impl OpsBrain {
         &self,
         params: Parameters<zammad::ListTicketsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let zammad = match &self.zammad_config {
-            Some(c) => c,
-            None => {
-                return Ok(error_result(
-                    "Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)",
-                ))
-            }
-        };
-        let p = params.0;
-
-        let client =
-            match crate::repo::client_repo::get_client_by_slug(&self.pool, &p.client_slug).await {
-                Ok(Some(c)) => c,
-                Ok(None) => return Ok(not_found("Client", &p.client_slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        let org_id = match client.zammad_org_id {
-            Some(id) => id,
-            None => return Ok(error_result(&format!(
-                "Client '{}' has no Zammad org ID configured. Use upsert_client to set zammad_org_id.",
-                p.client_slug
-            ))),
-        };
-
-        let mut query_parts = vec![format!("organization.id:{org_id}")];
-        if let Some(ref state) = p.state {
-            query_parts.push(format!("state.name:{state}"));
-        }
-        if let Some(ref priority) = p.priority {
-            query_parts.push(format!("priority.name:\"{priority}\""));
-        }
-        let query = query_parts.join(" AND ");
-        let limit = p.limit.unwrap_or(20);
-
-        match crate::zammad::search_tickets(zammad, &query, limit).await {
-            Ok(tickets) => {
-                let result = serde_json::json!({
-                    "count": tickets.len(),
-                    "client": p.client_slug,
-                    "tickets": tickets,
-                });
-                Ok(json_result(&result))
-            }
-            Err(e) => Ok(error_result(&e)),
-        }
+        Ok(zammad::handle_list_tickets(self, params.0).await)
     }
 
     #[tool(
@@ -3910,38 +661,7 @@ impl OpsBrain {
         &self,
         params: Parameters<zammad::GetTicketParams>,
     ) -> Result<CallToolResult, McpError> {
-        let zammad = match &self.zammad_config {
-            Some(c) => c,
-            None => {
-                return Ok(error_result(
-                    "Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)",
-                ))
-            }
-        };
-        let p = params.0;
-
-        let ticket = match crate::zammad::get_ticket(zammad, p.ticket_id).await {
-            Ok(t) => t,
-            Err(e) => return Ok(error_result(&e)),
-        };
-
-        let articles = match crate::zammad::get_ticket_articles(zammad, p.ticket_id).await {
-            Ok(a) => a,
-            Err(e) => return Ok(error_result(&e)),
-        };
-
-        let link =
-            crate::repo::ticket_link_repo::get_link_by_ticket_id(&self.pool, p.ticket_id as i32)
-                .await
-                .ok()
-                .flatten();
-
-        let result = serde_json::json!({
-            "ticket": ticket,
-            "articles": articles,
-            "ops_brain_link": link,
-        });
-        Ok(json_result(&result))
+        Ok(zammad::handle_get_ticket(self, params.0).await)
     }
 
     #[tool(
@@ -3952,95 +672,7 @@ impl OpsBrain {
         &self,
         params: Parameters<zammad::CreateTicketParams>,
     ) -> Result<CallToolResult, McpError> {
-        let zammad = match &self.zammad_config {
-            Some(c) => c,
-            None => {
-                return Ok(error_result(
-                    "Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)",
-                ))
-            }
-        };
-        let p = params.0;
-
-        let client =
-            match crate::repo::client_repo::get_client_by_slug(&self.pool, &p.client_slug).await {
-                Ok(Some(c)) => c,
-                Ok(None) => return Ok(not_found("Client", &p.client_slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        let (group_id, customer_id, org_id) = match (client.zammad_group_id, client.zammad_customer_id, client.zammad_org_id) {
-            (Some(g), Some(c), org) => (g as i64, c as i64, org.map(|o| o as i64)),
-            _ => return Ok(error_result(&format!(
-                "Client '{}' missing Zammad IDs. Set zammad_group_id and zammad_customer_id via upsert_client.",
-                p.client_slug
-            ))),
-        };
-
-        let state_id = match &p.state {
-            Some(s) => match crate::zammad::state_name_to_id(s) {
-                Some(id) => Some(id),
-                None => {
-                    return Ok(error_result(&format!(
-                        "Unknown state: '{s}'. Use: new, open, pending_reminder, closed"
-                    )))
-                }
-            },
-            None => None,
-        };
-
-        let priority_id = match &p.priority {
-            Some(pr) => match crate::zammad::priority_name_to_id(pr) {
-                Some(id) => Some(id),
-                None => {
-                    return Ok(error_result(&format!(
-                        "Unknown priority: '{pr}'. Use: low, normal, high"
-                    )))
-                }
-            },
-            None => None,
-        };
-
-        let payload = crate::zammad::CreateTicketPayload {
-            title: p.title,
-            group_id,
-            customer_id,
-            organization_id: org_id,
-            state_id,
-            priority_id,
-            owner_id: Some(3), // Eduardo
-            tags: p.tags,
-            article: crate::zammad::CreateArticleInline {
-                body: p.body,
-                content_type: Some("text/plain".to_string()),
-                article_type: Some("note".to_string()),
-                internal: Some(false),
-                time_unit: p.time_unit,
-                time_accounting_type_id: p.time_accounting_type_id,
-            },
-        };
-
-        let ticket = match crate::zammad::create_ticket(zammad, &payload).await {
-            Ok(t) => t,
-            Err(e) => return Ok(error_result(&e)),
-        };
-
-        // Auto-link to incident if provided
-        if let Some(ref incident_id_str) = p.incident_id {
-            if let Ok(incident_id) = uuid::Uuid::parse_str(incident_id_str) {
-                let _ = crate::repo::ticket_link_repo::create_link(
-                    &self.pool,
-                    ticket.id as i32,
-                    Some(incident_id),
-                    None,
-                    None,
-                    None,
-                )
-                .await;
-            }
-        }
-
-        Ok(json_result(&ticket))
+        Ok(zammad::handle_create_ticket(self, params.0).await)
     }
 
     #[tool(
@@ -4051,51 +683,7 @@ impl OpsBrain {
         &self,
         params: Parameters<zammad::UpdateTicketParams>,
     ) -> Result<CallToolResult, McpError> {
-        let zammad = match &self.zammad_config {
-            Some(c) => c,
-            None => {
-                return Ok(error_result(
-                    "Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)",
-                ))
-            }
-        };
-        let p = params.0;
-
-        let state_id = match &p.state {
-            Some(s) => match crate::zammad::state_name_to_id(s) {
-                Some(id) => Some(id),
-                None => {
-                    return Ok(error_result(&format!(
-                        "Unknown state: '{s}'. Use: new, open, pending_reminder, closed"
-                    )))
-                }
-            },
-            None => None,
-        };
-
-        let priority_id = match &p.priority {
-            Some(pr) => match crate::zammad::priority_name_to_id(pr) {
-                Some(id) => Some(id),
-                None => {
-                    return Ok(error_result(&format!(
-                        "Unknown priority: '{pr}'. Use: low, normal, high"
-                    )))
-                }
-            },
-            None => None,
-        };
-
-        let payload = crate::zammad::UpdateTicketPayload {
-            title: p.title,
-            state_id,
-            priority_id,
-            owner_id: None,
-        };
-
-        match crate::zammad::update_ticket(zammad, p.ticket_id, &payload).await {
-            Ok(ticket) => Ok(json_result(&ticket)),
-            Err(e) => Ok(error_result(&e)),
-        }
+        Ok(zammad::handle_update_ticket(self, params.0).await)
     }
 
     #[tool(
@@ -4106,30 +694,7 @@ impl OpsBrain {
         &self,
         params: Parameters<zammad::AddTicketNoteParams>,
     ) -> Result<CallToolResult, McpError> {
-        let zammad = match &self.zammad_config {
-            Some(c) => c,
-            None => {
-                return Ok(error_result(
-                    "Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)",
-                ))
-            }
-        };
-        let p = params.0;
-
-        let payload = crate::zammad::CreateArticlePayload {
-            ticket_id: p.ticket_id,
-            body: p.body,
-            content_type: Some("text/plain".to_string()),
-            article_type: Some("note".to_string()),
-            internal: Some(p.internal.unwrap_or(true)),
-            time_unit: p.time_unit,
-            time_accounting_type_id: p.time_accounting_type_id,
-        };
-
-        match crate::zammad::add_ticket_article(zammad, &payload).await {
-            Ok(article) => Ok(json_result(&article)),
-            Err(e) => Ok(error_result(&e)),
-        }
+        Ok(zammad::handle_add_ticket_note(self, params.0).await)
     }
 
     #[tool(
@@ -4140,28 +705,7 @@ impl OpsBrain {
         &self,
         params: Parameters<zammad::SearchTicketsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let zammad = match &self.zammad_config {
-            Some(c) => c,
-            None => {
-                return Ok(error_result(
-                    "Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)",
-                ))
-            }
-        };
-        let p = params.0;
-        let limit = p.limit.unwrap_or(20);
-
-        match crate::zammad::search_tickets(zammad, &p.query, limit).await {
-            Ok(tickets) => {
-                let result = serde_json::json!({
-                    "count": tickets.len(),
-                    "query": p.query,
-                    "tickets": tickets,
-                });
-                Ok(json_result(&result))
-            }
-            Err(e) => Ok(error_result(&e)),
-        }
+        Ok(zammad::handle_search_tickets(self, params.0).await)
     }
 
     #[tool(
@@ -4172,61 +716,7 @@ impl OpsBrain {
         &self,
         params: Parameters<zammad::LinkTicketParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        if p.incident_id.is_none() && p.server_slug.is_none() && p.service_slug.is_none() {
-            return Ok(error_result(
-                "At least one of incident_id, server_slug, or service_slug must be provided",
-            ));
-        }
-
-        let incident_id = match &p.incident_id {
-            Some(id_str) => match uuid::Uuid::parse_str(id_str) {
-                Ok(id) => match crate::repo::incident_repo::get_incident(&self.pool, id).await {
-                    Ok(Some(_)) => Some(id),
-                    Ok(None) => return Ok(not_found("Incident", id_str)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                },
-                Err(_) => return Ok(error_result(&format!("Invalid incident UUID: {}", id_str))),
-            },
-            None => None,
-        };
-
-        let server_id = match &p.server_slug {
-            Some(slug) => {
-                match crate::repo::server_repo::get_server_by_slug(&self.pool, slug).await {
-                    Ok(Some(s)) => Some(s.id),
-                    Ok(None) => return Ok(not_found("Server", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        let service_id = match &p.service_slug {
-            Some(slug) => {
-                match crate::repo::service_repo::get_service_by_slug(&self.pool, slug).await {
-                    Ok(Some(s)) => Some(s.id),
-                    Ok(None) => return Ok(not_found("Service", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        match crate::repo::ticket_link_repo::create_link(
-            &self.pool,
-            p.zammad_ticket_id as i32,
-            incident_id,
-            server_id,
-            service_id,
-            p.notes.as_deref(),
-        )
-        .await
-        {
-            Ok(link) => Ok(json_result(&link)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(zammad::handle_link_ticket(self, params.0).await)
     }
 
     #[tool(
@@ -4237,23 +727,7 @@ impl OpsBrain {
         &self,
         params: Parameters<zammad::UnlinkTicketParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        match crate::repo::ticket_link_repo::delete_link(&self.pool, p.zammad_ticket_id as i32)
-            .await
-        {
-            Ok(true) => {
-                let result = serde_json::json!({
-                    "status": "unlinked",
-                    "zammad_ticket_id": p.zammad_ticket_id,
-                });
-                Ok(json_result(&result))
-            }
-            Ok(false) => Ok(error_result(&format!(
-                "No link found for Zammad ticket {}",
-                p.zammad_ticket_id
-            ))),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(zammad::handle_unlink_ticket(self, params.0).await)
     }
 
     // ===== BRIEFING TOOLS =====
@@ -4269,39 +743,7 @@ impl OpsBrain {
         &self,
         params: Parameters<briefings::GenerateBriefingParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-
-        if let Err(msg) = crate::validation::validate_required(
-            &p.briefing_type,
-            "briefing_type",
-            crate::validation::BRIEFING_TYPES,
-        ) {
-            return Ok(error_result(&msg));
-        }
-
-        let client = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        match crate::api::generate_briefing_inner(
-            &self.pool,
-            &self.kuma_config,
-            &self.zammad_config,
-            &p.briefing_type.to_lowercase(),
-            client.as_ref(),
-        )
-        .await
-        {
-            Ok(output) => Ok(json_result(&output)),
-            Err(e) => Ok(error_result(&e)),
-        }
+        Ok(briefings::handle_generate_briefing(self, params.0).await)
     }
 
     #[tool(
@@ -4313,45 +755,7 @@ impl OpsBrain {
         &self,
         params: Parameters<briefings::ListBriefingsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let limit = p.limit.unwrap_or(10);
-
-        if let Err(msg) = crate::validation::validate_option(
-            p.briefing_type.as_deref(),
-            "briefing_type",
-            crate::validation::BRIEFING_TYPES,
-        ) {
-            return Ok(error_result(&msg));
-        }
-
-        let client_id = match &p.client_slug {
-            Some(slug) => {
-                match crate::repo::client_repo::get_client_by_slug(&self.pool, slug).await {
-                    Ok(Some(c)) => Some(c.id),
-                    Ok(None) => return Ok(not_found("Client", slug)),
-                    Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-                }
-            }
-            None => None,
-        };
-
-        match crate::repo::briefing_repo::list_briefings(
-            &self.pool,
-            p.briefing_type.as_deref(),
-            client_id,
-            limit,
-        )
-        .await
-        {
-            Ok(briefings) => {
-                let result = serde_json::json!({
-                    "count": briefings.len(),
-                    "briefings": briefings,
-                });
-                Ok(json_result(&result))
-            }
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(briefings::handle_list_briefings(self, params.0).await)
     }
 
     #[tool(
@@ -4362,17 +766,7 @@ impl OpsBrain {
         &self,
         params: Parameters<briefings::GetBriefingParams>,
     ) -> Result<CallToolResult, McpError> {
-        let p = params.0;
-        let id = match uuid::Uuid::parse_str(&p.id) {
-            Ok(id) => id,
-            Err(_) => return Ok(error_result(&format!("Invalid UUID: {}", p.id))),
-        };
-
-        match crate::repo::briefing_repo::get_briefing(&self.pool, id).await {
-            Ok(Some(briefing)) => Ok(json_result(&briefing)),
-            Ok(None) => Ok(not_found("Briefing", &p.id)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(briefings::handle_get_briefing(self, params.0).await)
     }
 
     // ── Delete tools (inventory cleanup) ──────────────────────────────
@@ -4387,56 +781,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::DeleteServerParams>,
     ) -> Result<CallToolResult, McpError> {
-        let params = params.0;
-        let server =
-            match crate::repo::server_repo::get_server_by_slug(&self.pool, &params.slug).await {
-                Ok(Some(s)) => s,
-                Ok(None) => return Ok(not_found("Server", &params.slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        let refs =
-            match crate::repo::server_repo::count_server_references(&self.pool, server.id).await {
-                Ok(r) => r,
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        if params.confirm != Some(true) {
-            let mut preview = serde_json::json!({
-                "action": "delete_server",
-                "server": server.hostname,
-                "slug": server.slug,
-                "status": server.status,
-                "confirmed": false,
-                "message": "Pass confirm=true to proceed with deletion.",
-            });
-            if !refs.is_empty() {
-                let ref_map: serde_json::Map<String, serde_json::Value> = refs
-                    .iter()
-                    .map(|(k, v)| (k.clone(), serde_json::Value::from(*v)))
-                    .collect();
-                preview["linked_entities"] = serde_json::Value::Object(ref_map);
-                preview["warning"] =
-                    "Junction table links will be CASCADE-deleted or SET NULL.".into();
-            } else {
-                preview["linked_entities"] = serde_json::json!("none");
-            }
-            return Ok(json_result(&preview));
-        }
-
-        match crate::repo::server_repo::delete_server(&self.pool, server.id).await {
-            Ok(true) => Ok(json_result(&serde_json::json!({
-                "deleted": true,
-                "server": server.hostname,
-                "slug": server.slug,
-                "cascade_summary": refs.iter()
-                    .map(|(k, v)| format!("{k}: {v}"))
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            }))),
-            Ok(false) => Ok(not_found("Server", &params.slug)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_delete_server(self, params.0).await)
     }
 
     #[tool(
@@ -4448,56 +793,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::DeleteServiceParams>,
     ) -> Result<CallToolResult, McpError> {
-        let params = params.0;
-        let service =
-            match crate::repo::service_repo::get_service_by_slug(&self.pool, &params.slug).await {
-                Ok(Some(s)) => s,
-                Ok(None) => return Ok(not_found("Service", &params.slug)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        let refs = match crate::repo::service_repo::count_service_references(&self.pool, service.id)
-            .await
-        {
-            Ok(r) => r,
-            Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-        };
-
-        if params.confirm != Some(true) {
-            let mut preview = serde_json::json!({
-                "action": "delete_service",
-                "service": service.name,
-                "slug": service.slug,
-                "confirmed": false,
-                "message": "Pass confirm=true to proceed with deletion.",
-            });
-            if !refs.is_empty() {
-                let ref_map: serde_json::Map<String, serde_json::Value> = refs
-                    .iter()
-                    .map(|(k, v)| (k.clone(), serde_json::Value::from(*v)))
-                    .collect();
-                preview["linked_entities"] = serde_json::Value::Object(ref_map);
-                preview["warning"] =
-                    "Junction table links will be CASCADE-deleted or SET NULL.".into();
-            } else {
-                preview["linked_entities"] = serde_json::json!("none");
-            }
-            return Ok(json_result(&preview));
-        }
-
-        match crate::repo::service_repo::delete_service(&self.pool, service.id).await {
-            Ok(true) => Ok(json_result(&serde_json::json!({
-                "deleted": true,
-                "service": service.name,
-                "slug": service.slug,
-                "cascade_summary": refs.iter()
-                    .map(|(k, v)| format!("{k}: {v}"))
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            }))),
-            Ok(false) => Ok(not_found("Service", &params.slug)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_delete_service(self, params.0).await)
     }
 
     #[tool(
@@ -4509,55 +805,7 @@ impl OpsBrain {
         &self,
         params: Parameters<inventory::DeleteVendorParams>,
     ) -> Result<CallToolResult, McpError> {
-        let params = params.0;
-        let vendor =
-            match crate::repo::vendor_repo::get_vendor_by_name(&self.pool, &params.name).await {
-                Ok(Some(v)) => v,
-                Ok(None) => return Ok(not_found("Vendor", &params.name)),
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        let refs =
-            match crate::repo::vendor_repo::count_vendor_references(&self.pool, vendor.id).await {
-                Ok(r) => r,
-                Err(e) => return Ok(error_result(&format!("Database error: {e}"))),
-            };
-
-        if params.confirm != Some(true) {
-            let mut preview = serde_json::json!({
-                "action": "delete_vendor",
-                "vendor": vendor.name,
-                "id": vendor.id.to_string(),
-                "confirmed": false,
-                "message": "Pass confirm=true to proceed with deletion.",
-            });
-            if !refs.is_empty() {
-                let ref_map: serde_json::Map<String, serde_json::Value> = refs
-                    .iter()
-                    .map(|(k, v)| (k.clone(), serde_json::Value::from(*v)))
-                    .collect();
-                preview["linked_entities"] = serde_json::Value::Object(ref_map);
-                preview["warning"] =
-                    "Client links and incident links will be CASCADE-deleted.".into();
-            } else {
-                preview["linked_entities"] = serde_json::json!("none");
-            }
-            return Ok(json_result(&preview));
-        }
-
-        match crate::repo::vendor_repo::delete_vendor(&self.pool, vendor.id).await {
-            Ok(true) => Ok(json_result(&serde_json::json!({
-                "deleted": true,
-                "vendor": vendor.name,
-                "id": vendor.id.to_string(),
-                "cascade_summary": refs.iter()
-                    .map(|(k, v)| format!("{k}: {v}"))
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            }))),
-            Ok(false) => Ok(not_found("Vendor", &params.name)),
-            Err(e) => Ok(error_result(&format!("Database error: {e}"))),
-        }
+        Ok(inventory::handle_delete_vendor(self, params.0).await)
     }
 }
 
@@ -4591,7 +839,7 @@ impl ServerHandler for OpsBrain {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::helpers::*;
     use std::collections::HashMap;
     use uuid::Uuid;
 
@@ -4644,7 +892,6 @@ mod tests {
         assert_eq!(result.allowed.len(), 1);
         assert!(result.withheld_notices.is_empty());
         assert!(result.audit_entries.is_empty());
-        // Provenance should show "Global"
         assert_eq!(result.allowed[0]["_client_name"], "Global");
         assert!(result.allowed[0]["_client_slug"].is_null());
     }
@@ -4660,7 +907,6 @@ mod tests {
         assert_eq!(result.allowed.len(), 1);
         assert!(result.withheld_notices.is_empty());
         assert!(result.audit_entries.is_empty());
-        // Provenance should show the client
         assert_eq!(result.allowed[0]["_client_slug"], "hsr");
         assert_eq!(result.allowed[0]["_client_name"], "Hospice");
     }
@@ -4669,14 +915,12 @@ mod tests {
     fn filter_cross_client_safe_allowed() {
         let (hsr_id, cpa_id, lookup) = make_lookup();
         let item_id = Uuid::now_v7();
-        // HSR item marked as cross_client_safe, requesting from CPA
         let items = vec![make_item(item_id, Some(hsr_id), true)];
 
         let result = filter_cross_client(items, "runbook", Some(cpa_id), false, &lookup);
 
         assert_eq!(result.allowed.len(), 1);
         assert!(result.withheld_notices.is_empty());
-        // Audit entry should record "released_safe"
         assert_eq!(result.audit_entries.len(), 1);
         assert_eq!(result.audit_entries[0].0, item_id);
         assert_eq!(result.audit_entries[0].1, Some(hsr_id));
@@ -4687,14 +931,12 @@ mod tests {
     fn filter_cross_client_acknowledged_released() {
         let (hsr_id, cpa_id, lookup) = make_lookup();
         let item_id = Uuid::now_v7();
-        // HSR item NOT safe, but acknowledge=true
         let items = vec![make_item(item_id, Some(hsr_id), false)];
 
         let result = filter_cross_client(items, "runbook", Some(cpa_id), true, &lookup);
 
         assert_eq!(result.allowed.len(), 1);
         assert!(result.withheld_notices.is_empty());
-        // Audit entry should record "released"
         assert_eq!(result.audit_entries.len(), 1);
         assert_eq!(result.audit_entries[0].2, "released");
     }
@@ -4703,7 +945,6 @@ mod tests {
     fn filter_cross_client_withheld() {
         let (hsr_id, cpa_id, lookup) = make_lookup();
         let item_id = Uuid::now_v7();
-        // HSR item, NOT safe, NOT acknowledged, requesting from CPA
         let items = vec![make_item(item_id, Some(hsr_id), false)];
 
         let result = filter_cross_client(items, "runbook", Some(cpa_id), false, &lookup);
@@ -4713,7 +954,6 @@ mod tests {
         assert_eq!(result.withheld_notices[0]["count"], 1);
         assert_eq!(result.withheld_notices[0]["owning_client_slug"], "hsr");
         assert_eq!(result.withheld_notices[0]["entity_type"], "runbook");
-        // Audit entry should record "withheld"
         assert_eq!(result.audit_entries.len(), 1);
         assert_eq!(result.audit_entries[0].2, "withheld");
     }
@@ -4729,7 +969,6 @@ mod tests {
         let result = filter_cross_client(items, "knowledge", Some(cpa_id), false, &lookup);
 
         assert!(result.allowed.is_empty());
-        // Should be grouped into one notice (both from HSR)
         assert_eq!(result.withheld_notices.len(), 1);
         assert_eq!(result.withheld_notices[0]["count"], 2);
         assert_eq!(result.audit_entries.len(), 2);
@@ -4750,7 +989,6 @@ mod tests {
         assert_eq!(result.allowed.len(), 3);
         assert_eq!(result.withheld_notices.len(), 1);
         assert_eq!(result.withheld_notices[0]["count"], 1);
-        // 1 released_safe + 1 withheld
         assert_eq!(result.audit_entries.len(), 2);
     }
 
@@ -4760,7 +998,6 @@ mod tests {
     fn filter_incident_cross_client_withheld() {
         let (hsr_id, cpa_id, lookup) = make_lookup();
         let item_id = Uuid::now_v7();
-        // HSR incident, NOT safe, NOT acknowledged, requesting from CPA context
         let items = vec![make_item(item_id, Some(hsr_id), false)];
 
         let result = filter_cross_client(items, "incident", Some(cpa_id), false, &lookup);
@@ -4777,7 +1014,6 @@ mod tests {
     fn filter_incident_cross_client_safe_allowed() {
         let (hsr_id, cpa_id, lookup) = make_lookup();
         let item_id = Uuid::now_v7();
-        // HSR incident marked cross_client_safe, requesting from CPA
         let items = vec![make_item(item_id, Some(hsr_id), true)];
 
         let result = filter_cross_client(items, "incident", Some(cpa_id), false, &lookup);
@@ -4841,7 +1077,6 @@ mod tests {
 
         inject_provenance(&mut item, &lookup);
 
-        // Unknown client_id — no provenance injected (no crash)
         assert!(item.get("_client_slug").is_none());
     }
 
@@ -4866,8 +1101,8 @@ mod tests {
         assert!(compacted.get("title").is_some());
         assert!(compacted.get("slug").is_some());
         assert!(compacted.get("category").is_some());
-        assert!(compacted.get("content").is_none()); // stripped
-        assert!(compacted.get("created_at").is_none()); // stripped
+        assert!(compacted.get("content").is_none());
+        assert!(compacted.get("created_at").is_none());
     }
 
     #[test]
@@ -4889,10 +1124,10 @@ mod tests {
         assert!(compacted.get("title").is_some());
         assert!(compacted.get("severity").is_some());
         assert!(compacted.get("status").is_some());
-        assert!(compacted.get("symptoms").is_none()); // stripped
-        assert!(compacted.get("root_cause").is_none()); // stripped
-        assert!(compacted.get("resolution").is_none()); // stripped
-        assert!(compacted.get("notes").is_none()); // stripped
+        assert!(compacted.get("symptoms").is_none());
+        assert!(compacted.get("root_cause").is_none());
+        assert!(compacted.get("resolution").is_none());
+        assert!(compacted.get("notes").is_none());
     }
 
     #[test]

--- a/src/tools/monitoring.rs
+++ b/src/tools/monitoring.rs
@@ -1,6 +1,10 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use super::helpers::{error_result, json_result, not_found};
+use crate::models::incident::Incident;
+use rmcp::model::*;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListMonitorsParams {
     /// Filter by status: "up", "down", "pending", "maintenance" (optional)
@@ -40,4 +44,259 @@ pub struct ListWatchdogIncidentsParams {
     pub status: Option<String>,
     /// Maximum number of incidents to return (default: 20)
     pub limit: Option<i64>,
+}
+
+/// Inject a diagnostic hint for push-type monitors that are DOWN.
+/// Push monitors report "down" when their heartbeat expires (cron/script issue),
+/// not necessarily when the underlying service is actually down.
+fn inject_push_diagnostic_hint(
+    val: &mut serde_json::Value,
+    monitor: &crate::metrics::MonitorStatus,
+) {
+    if monitor.monitor_type == "push" && monitor.status == 0 {
+        val["diagnostic_hint"] = serde_json::Value::String(
+            "Push monitor — DOWN usually means heartbeat expired (cron/script issue), \
+             not service failure. Check cron schedule and script logs on the target server."
+                .to_string(),
+        );
+    }
+}
+
+// ===== HANDLERS =====
+
+pub(crate) async fn handle_list_monitors(
+    brain: &super::OpsBrain,
+    p: ListMonitorsParams,
+) -> CallToolResult {
+    let kuma_config = match &brain.kuma_config {
+        Some(c) => c,
+        None => return error_result("Uptime Kuma not configured (set UPTIME_KUMA_URL)"),
+    };
+
+    let summary = match crate::metrics::fetch_metrics(kuma_config).await {
+        Ok(s) => s,
+        Err(e) => return error_result(&format!("Failed to fetch metrics: {e}")),
+    };
+
+    // Get all monitor mappings from DB
+    let mappings = crate::repo::monitor_repo::list_monitors(&brain.pool)
+        .await
+        .unwrap_or_default();
+
+    let mut results: Vec<serde_json::Value> = Vec::new();
+    for monitor in &summary.monitors {
+        // Apply status filter
+        if let Some(ref status_filter) = p.status {
+            if monitor.status_text != *status_filter {
+                continue;
+            }
+        }
+
+        let mapping = mappings.iter().find(|m| m.monitor_name == monitor.name);
+        let mut val = serde_json::to_value(monitor).unwrap_or_default();
+        if let Some(mapping) = mapping {
+            val["linked_server_id"] = serde_json::to_value(mapping.server_id).unwrap_or_default();
+            val["linked_service_id"] = serde_json::to_value(mapping.service_id).unwrap_or_default();
+            val["mapping_notes"] = serde_json::to_value(&mapping.notes).unwrap_or_default();
+        }
+        inject_push_diagnostic_hint(&mut val, monitor);
+        results.push(val);
+    }
+
+    let output = serde_json::json!({
+        "total": summary.total,
+        "up": summary.up,
+        "down": summary.down,
+        "pending": summary.pending,
+        "maintenance": summary.maintenance,
+        "filtered_count": results.len(),
+        "monitors": results,
+    });
+    json_result(&output)
+}
+
+pub(crate) async fn handle_get_monitor_status(
+    brain: &super::OpsBrain,
+    p: GetMonitorStatusParams,
+) -> CallToolResult {
+    let kuma_config = match &brain.kuma_config {
+        Some(c) => c,
+        None => return error_result("Uptime Kuma not configured (set UPTIME_KUMA_URL)"),
+    };
+
+    let summary = match crate::metrics::fetch_metrics(kuma_config).await {
+        Ok(s) => s,
+        Err(e) => return error_result(&format!("Failed to fetch metrics: {e}")),
+    };
+
+    let monitor = match summary.monitors.iter().find(|m| m.name == p.monitor_name) {
+        Some(m) => m,
+        None => return not_found("Monitor", &p.monitor_name),
+    };
+
+    let mapping = crate::repo::monitor_repo::get_monitor_by_name(&brain.pool, &p.monitor_name)
+        .await
+        .ok()
+        .flatten();
+
+    let mut result = serde_json::to_value(monitor).unwrap_or_default();
+    inject_push_diagnostic_hint(&mut result, monitor);
+
+    // Enrich with linked entities
+    if let Some(ref mapping) = mapping {
+        if let Some(server_id) = mapping.server_id {
+            if let Ok(Some(server)) =
+                crate::repo::server_repo::get_server(&brain.pool, server_id).await
+            {
+                result["linked_server"] = serde_json::to_value(&server).unwrap_or_default();
+            }
+        }
+        if let Some(service_id) = mapping.service_id {
+            if let Ok(Some(service)) =
+                crate::repo::service_repo::get_service(&brain.pool, service_id).await
+            {
+                result["linked_service"] = serde_json::to_value(&service).unwrap_or_default();
+            }
+        }
+        result["mapping_notes"] = serde_json::to_value(&mapping.notes).unwrap_or_default();
+    }
+
+    json_result(&result)
+}
+
+pub(crate) async fn handle_get_monitoring_summary(
+    brain: &super::OpsBrain,
+    _p: GetMonitoringSummaryParams,
+) -> CallToolResult {
+    let kuma_config = match &brain.kuma_config {
+        Some(c) => c,
+        None => return error_result("Uptime Kuma not configured (set UPTIME_KUMA_URL)"),
+    };
+
+    let summary = match crate::metrics::fetch_metrics(kuma_config).await {
+        Ok(s) => s,
+        Err(e) => return error_result(&format!("Failed to fetch metrics: {e}")),
+    };
+
+    // Highlight anything that's down, with diagnostic hints for push monitors
+    let down_monitors: Vec<serde_json::Value> = summary
+        .monitors
+        .iter()
+        .filter(|m| m.status == 0)
+        .map(|m| {
+            let mut val = serde_json::to_value(m).unwrap_or_default();
+            inject_push_diagnostic_hint(&mut val, m);
+            val
+        })
+        .collect();
+
+    let result = serde_json::json!({
+        "status": if summary.down == 0 { "ALL_CLEAR" } else { "DEGRADED" },
+        "total": summary.total,
+        "up": summary.up,
+        "down": summary.down,
+        "pending": summary.pending,
+        "maintenance": summary.maintenance,
+        "down_monitors": down_monitors,
+    });
+    json_result(&result)
+}
+
+pub(crate) async fn handle_link_monitor(
+    brain: &super::OpsBrain,
+    p: LinkMonitorParams,
+) -> CallToolResult {
+    // Resolve server slug to ID
+    let server_id = match &p.server_slug {
+        Some(slug) => match crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await {
+            Ok(Some(s)) => Some(s.id),
+            Ok(None) => return not_found("Server", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    // Resolve service slug to ID
+    let service_id = match &p.service_slug {
+        Some(slug) => {
+            match crate::repo::service_repo::get_service_by_slug(&brain.pool, slug).await {
+                Ok(Some(s)) => Some(s.id),
+                Ok(None) => return not_found("Service", slug),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            }
+        }
+        None => None,
+    };
+
+    if server_id.is_none() && service_id.is_none() && p.notes.is_none() {
+        return error_result("Provide at least one of: server_slug, service_slug, or notes");
+    }
+
+    match crate::repo::monitor_repo::upsert_monitor(
+        &brain.pool,
+        &p.monitor_name,
+        server_id,
+        service_id,
+        p.notes.as_deref(),
+    )
+    .await
+    {
+        Ok(monitor) => json_result(&monitor),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_unlink_monitor(
+    brain: &super::OpsBrain,
+    p: UnlinkMonitorParams,
+) -> CallToolResult {
+    match crate::repo::monitor_repo::delete_monitor(&brain.pool, &p.monitor_name).await {
+        Ok(true) => CallToolResult::success(vec![Content::text(format!(
+            "Monitor mapping removed: {}",
+            p.monitor_name
+        ))]),
+        Ok(false) => not_found("Monitor mapping", &p.monitor_name),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_list_watchdog_incidents(
+    brain: &super::OpsBrain,
+    p: ListWatchdogIncidentsParams,
+) -> CallToolResult {
+    let limit = p.limit.unwrap_or(20);
+    let prefix_pattern = format!("{}%", crate::watchdog::INCIDENT_PREFIX);
+
+    let query = match &p.status {
+        Some(status) => {
+            sqlx::query_as::<_, Incident>(
+                "SELECT * FROM incidents WHERE title LIKE $1 AND status = $2 ORDER BY reported_at DESC LIMIT $3",
+            )
+            .bind(&prefix_pattern)
+            .bind(status)
+            .bind(limit)
+            .fetch_all(&brain.pool)
+            .await
+        }
+        None => {
+            sqlx::query_as::<_, Incident>(
+                "SELECT * FROM incidents WHERE title LIKE $1 ORDER BY reported_at DESC LIMIT $2",
+            )
+            .bind(&prefix_pattern)
+            .bind(limit)
+            .fetch_all(&brain.pool)
+            .await
+        }
+    };
+
+    match query {
+        Ok(incidents) => {
+            let result = serde_json::json!({
+                "count": incidents.len(),
+                "incidents": incidents,
+            });
+            json_result(&result)
+        }
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
 }

--- a/src/tools/runbooks.rs
+++ b/src/tools/runbooks.rs
@@ -1,6 +1,10 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use super::helpers::{error_result, filter_cross_client, json_result, not_found};
+use super::shared::{build_client_lookup, embed_and_store, get_query_embedding, log_audit_entries};
+use rmcp::model::*;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetRunbookParams {
     /// Runbook slug
@@ -57,4 +61,236 @@ pub struct UpdateRunbookParams {
     pub notes: Option<String>,
     /// Allow this runbook to surface in other clients' contexts
     pub cross_client_safe: Option<bool>,
+}
+
+// ===== HANDLERS =====
+
+pub(crate) async fn handle_get_runbook(
+    brain: &super::OpsBrain,
+    p: GetRunbookParams,
+) -> CallToolResult {
+    match crate::repo::runbook_repo::get_runbook_by_slug(&brain.pool, &p.slug).await {
+        Ok(Some(runbook)) => json_result(&runbook),
+        Ok(None) => not_found("Runbook", &p.slug),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_list_runbooks(
+    brain: &super::OpsBrain,
+    p: ListRunbooksParams,
+) -> CallToolResult {
+    // Resolve optional client_slug
+    let client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    // Resolve optional service_slug
+    let service_id = match &p.service_slug {
+        Some(slug) => {
+            match crate::repo::service_repo::get_service_by_slug(&brain.pool, slug).await {
+                Ok(Some(s)) => Some(s.id),
+                Ok(None) => return not_found("Service", slug),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            }
+        }
+        None => None,
+    };
+
+    // Resolve optional server_slug
+    let server_id = match &p.server_slug {
+        Some(slug) => match crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await {
+            Ok(Some(s)) => Some(s.id),
+            Ok(None) => return not_found("Server", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    match crate::repo::runbook_repo::list_runbooks(
+        &brain.pool,
+        p.category.as_deref(),
+        service_id,
+        server_id,
+        p.tag.as_deref(),
+        client_id,
+    )
+    .await
+    {
+        Ok(runbooks) => json_result(&runbooks),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_search_runbooks(
+    brain: &super::OpsBrain,
+    p: SearchRunbooksParams,
+) -> CallToolResult {
+    let mode = p.mode.as_deref().unwrap_or("fts");
+    if let Err(msg) =
+        crate::validation::validate_required(mode, "mode", crate::validation::SEARCH_MODES)
+    {
+        return error_result(&msg);
+    }
+
+    // Resolve optional client_slug for cross-client gate
+    let requesting_client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+    let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
+
+    let result = match mode {
+        "semantic" => {
+            let Some(emb) = get_query_embedding(&brain.embedding_client, &p.query).await else {
+                return error_result("Semantic search unavailable (OPENAI_API_KEY not set)");
+            };
+            crate::repo::embedding_repo::vector_search_runbooks(&brain.pool, &emb, 20).await
+        }
+        "hybrid" => {
+            let emb = get_query_embedding(&brain.embedding_client, &p.query).await;
+            crate::repo::embedding_repo::hybrid_search_runbooks(
+                &brain.pool,
+                &p.query,
+                emb.as_deref(),
+                20,
+            )
+            .await
+        }
+        _ => crate::repo::search_repo::search_runbooks(&brain.pool, &p.query).await,
+    };
+    match result {
+        Ok(runbooks) => {
+            let items: Vec<serde_json::Value> = runbooks
+                .iter()
+                .filter_map(|r| serde_json::to_value(r).ok())
+                .collect();
+            let client_lookup = build_client_lookup(&brain.pool).await;
+            let filtered = filter_cross_client(
+                items,
+                "runbook",
+                requesting_client_id,
+                acknowledge,
+                &client_lookup,
+            );
+
+            // Log audit entries
+            log_audit_entries(
+                &brain.pool,
+                "search_runbooks",
+                requesting_client_id,
+                "runbook",
+                &filtered.audit_entries,
+            )
+            .await;
+
+            let mut response = serde_json::json!({ "runbooks": filtered.allowed });
+            if !filtered.withheld_notices.is_empty() {
+                response["cross_client_withheld"] = serde_json::json!(filtered.withheld_notices);
+            }
+            json_result(&response)
+        }
+        Err(e) => error_result(&format!("Search error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_create_runbook(
+    brain: &super::OpsBrain,
+    p: CreateRunbookParams,
+) -> CallToolResult {
+    let tags = p.tags.unwrap_or_default();
+    let requires_reboot = p.requires_reboot.unwrap_or(false);
+    let cross_client_safe = p.cross_client_safe.unwrap_or(false);
+
+    // Resolve optional client_slug
+    let client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    match crate::repo::runbook_repo::create_runbook(
+        &brain.pool,
+        &p.title,
+        &p.slug,
+        p.category.as_deref(),
+        &p.content,
+        &tags,
+        p.estimated_minutes,
+        requires_reboot,
+        p.notes.as_deref(),
+        client_id,
+        cross_client_safe,
+    )
+    .await
+    {
+        Ok(runbook) => {
+            let text = crate::embeddings::prepare_runbook_text(&runbook);
+            embed_and_store(
+                &brain.pool,
+                &brain.embedding_client,
+                "runbooks",
+                runbook.id,
+                &text,
+            )
+            .await;
+            json_result(&runbook)
+        }
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_update_runbook(
+    brain: &super::OpsBrain,
+    p: UpdateRunbookParams,
+) -> CallToolResult {
+    let runbook = match crate::repo::runbook_repo::get_runbook_by_slug(&brain.pool, &p.slug).await {
+        Ok(Some(r)) => r,
+        Ok(None) => return not_found("Runbook", &p.slug),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+
+    // Wrap estimated_minutes in Option<Option<i32>> for COALESCE
+    let estimated_minutes: Option<Option<i32>> = p.estimated_minutes.map(Some);
+
+    match crate::repo::runbook_repo::update_runbook(
+        &brain.pool,
+        runbook.id,
+        p.title.as_deref(),
+        p.category.as_deref(),
+        p.content.as_deref(),
+        p.tags.as_deref(),
+        estimated_minutes,
+        p.requires_reboot,
+        p.notes.as_deref(),
+        p.cross_client_safe,
+    )
+    .await
+    {
+        Ok(updated) => {
+            let text = crate::embeddings::prepare_runbook_text(&updated);
+            embed_and_store(
+                &brain.pool,
+                &brain.embedding_client,
+                "runbooks",
+                updated.id,
+                &text,
+            )
+            .await;
+            json_result(&updated)
+        }
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
 }

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -1,6 +1,10 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use super::helpers::{error_result, filter_cross_client, json_result, not_found};
+use super::shared::{build_client_lookup, get_query_embedding, log_audit_entries};
+use rmcp::model::*;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SemanticSearchParams {
     /// Natural language search query
@@ -21,4 +25,428 @@ pub struct BackfillEmbeddingsParams {
     pub table: Option<String>,
     /// Records per batch (default 10)
     pub batch_size: Option<i64>,
+}
+
+// ===== HANDLERS =====
+
+pub(crate) async fn handle_semantic_search(
+    brain: &super::OpsBrain,
+    p: SemanticSearchParams,
+) -> CallToolResult {
+    let limit = p.limit.unwrap_or(5);
+    let tables = p.tables.unwrap_or_else(|| {
+        vec![
+            "runbooks".to_string(),
+            "knowledge".to_string(),
+            "incidents".to_string(),
+            "handoffs".to_string(),
+        ]
+    });
+
+    // Resolve optional client_slug for cross-client gate
+    let requesting_client_id = match &p.client_slug {
+        Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
+            Ok(Some(c)) => Some(c.id),
+            Ok(None) => return not_found("Client", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+    let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
+
+    let query_embedding = get_query_embedding(&brain.embedding_client, &p.query).await;
+    let emb_ref = query_embedding.as_deref();
+
+    let mut results = serde_json::Map::new();
+    let client_lookup = build_client_lookup(&brain.pool).await;
+    let mut all_withheld: Vec<serde_json::Value> = Vec::new();
+
+    // Run searches for requested tables — gate runbooks, knowledge, and incidents
+    if tables.iter().any(|t| t == "runbooks") {
+        match crate::repo::embedding_repo::hybrid_search_runbooks(
+            &brain.pool,
+            &p.query,
+            emb_ref,
+            limit,
+        )
+        .await
+        {
+            Ok(items) => {
+                let json_items: Vec<serde_json::Value> = items
+                    .iter()
+                    .filter_map(|r| serde_json::to_value(r).ok())
+                    .collect();
+                let filtered = filter_cross_client(
+                    json_items,
+                    "runbook",
+                    requesting_client_id,
+                    acknowledge,
+                    &client_lookup,
+                );
+                results.insert(
+                    "runbooks".to_string(),
+                    serde_json::to_value(&filtered.allowed).unwrap_or_default(),
+                );
+                all_withheld.extend(filtered.withheld_notices);
+                log_audit_entries(
+                    &brain.pool,
+                    "semantic_search",
+                    requesting_client_id,
+                    "runbook",
+                    &filtered.audit_entries,
+                )
+                .await;
+            }
+            Err(e) => {
+                results.insert(
+                    "runbooks_error".to_string(),
+                    serde_json::Value::String(e.to_string()),
+                );
+            }
+        }
+    }
+    if tables.iter().any(|t| t == "knowledge") {
+        match crate::repo::embedding_repo::hybrid_search_knowledge(
+            &brain.pool,
+            &p.query,
+            emb_ref,
+            limit,
+        )
+        .await
+        {
+            Ok(items) => {
+                let json_items: Vec<serde_json::Value> = items
+                    .iter()
+                    .filter_map(|k| serde_json::to_value(k).ok())
+                    .collect();
+                let filtered = filter_cross_client(
+                    json_items,
+                    "knowledge",
+                    requesting_client_id,
+                    acknowledge,
+                    &client_lookup,
+                );
+                results.insert(
+                    "knowledge".to_string(),
+                    serde_json::to_value(&filtered.allowed).unwrap_or_default(),
+                );
+                all_withheld.extend(filtered.withheld_notices);
+                log_audit_entries(
+                    &brain.pool,
+                    "semantic_search",
+                    requesting_client_id,
+                    "knowledge",
+                    &filtered.audit_entries,
+                )
+                .await;
+            }
+            Err(e) => {
+                results.insert(
+                    "knowledge_error".to_string(),
+                    serde_json::Value::String(e.to_string()),
+                );
+            }
+        }
+    }
+    // Incidents are gated — HIPAA/IRS cross-client isolation
+    if tables.iter().any(|t| t == "incidents") {
+        match crate::repo::embedding_repo::hybrid_search_incidents(
+            &brain.pool,
+            &p.query,
+            emb_ref,
+            limit,
+        )
+        .await
+        {
+            Ok(items) => {
+                let json_items: Vec<serde_json::Value> = items
+                    .iter()
+                    .filter_map(|i| serde_json::to_value(i).ok())
+                    .collect();
+                let filtered = filter_cross_client(
+                    json_items,
+                    "incident",
+                    requesting_client_id,
+                    acknowledge,
+                    &client_lookup,
+                );
+                results.insert(
+                    "incidents".to_string(),
+                    serde_json::to_value(&filtered.allowed).unwrap_or_default(),
+                );
+                all_withheld.extend(filtered.withheld_notices);
+                log_audit_entries(
+                    &brain.pool,
+                    "semantic_search",
+                    requesting_client_id,
+                    "incident",
+                    &filtered.audit_entries,
+                )
+                .await;
+            }
+            Err(e) => {
+                results.insert(
+                    "incidents_error".to_string(),
+                    serde_json::Value::String(e.to_string()),
+                );
+            }
+        }
+    }
+    if tables.iter().any(|t| t == "handoffs") {
+        match crate::repo::embedding_repo::hybrid_search_handoffs(
+            &brain.pool,
+            &p.query,
+            emb_ref,
+            limit,
+        )
+        .await
+        {
+            Ok(items) => {
+                results.insert(
+                    "handoffs".to_string(),
+                    serde_json::to_value(&items).unwrap_or_default(),
+                );
+            }
+            Err(e) => {
+                results.insert(
+                    "handoffs_error".to_string(),
+                    serde_json::Value::String(e.to_string()),
+                );
+            }
+        }
+    }
+
+    if !all_withheld.is_empty() {
+        results.insert(
+            "cross_client_withheld".to_string(),
+            serde_json::to_value(&all_withheld).unwrap_or_default(),
+        );
+    }
+
+    if query_embedding.is_none() && brain.embedding_client.is_some() {
+        results.insert(
+            "_note".to_string(),
+            serde_json::Value::String(
+                "Embedding API call failed — results are FTS-only".to_string(),
+            ),
+        );
+    } else if brain.embedding_client.is_none() {
+        results.insert(
+            "_note".to_string(),
+            serde_json::Value::String("OPENAI_API_KEY not set — results are FTS-only".to_string()),
+        );
+    }
+
+    json_result(&serde_json::Value::Object(results))
+}
+
+pub(crate) async fn handle_backfill_embeddings(
+    brain: &super::OpsBrain,
+    p: BackfillEmbeddingsParams,
+) -> CallToolResult {
+    let Some(ref client) = brain.embedding_client else {
+        return error_result("OPENAI_API_KEY not set — cannot generate embeddings");
+    };
+
+    let batch_size = p.batch_size.unwrap_or(10);
+    let tables: Vec<&str> = match &p.table {
+        Some(t) => vec![t.as_str()],
+        None => vec!["runbooks", "knowledge", "incidents", "handoffs"],
+    };
+
+    let mut summary = serde_json::Map::new();
+
+    for table in &tables {
+        let mut processed = 0i64;
+        let mut failed = 0i64;
+
+        match *table {
+            "runbooks" => {
+                if let Ok(rows) = crate::repo::embedding_repo::get_runbooks_without_embeddings(
+                    &brain.pool,
+                    batch_size,
+                )
+                .await
+                {
+                    let texts: Vec<String> = rows
+                        .iter()
+                        .map(crate::embeddings::prepare_runbook_text)
+                        .collect();
+                    match client.embed_texts(&texts).await {
+                        Ok(embeddings) => {
+                            for (row, emb) in rows.iter().zip(embeddings.iter()) {
+                                if crate::repo::embedding_repo::store_runbook_embedding(
+                                    &brain.pool,
+                                    row.id,
+                                    emb,
+                                )
+                                .await
+                                .is_ok()
+                                {
+                                    processed += 1;
+                                } else {
+                                    failed += 1;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            summary.insert(
+                                format!("{table}_error"),
+                                serde_json::Value::String(e.to_string()),
+                            );
+                        }
+                    }
+                }
+            }
+            "knowledge" => {
+                if let Ok(rows) = crate::repo::embedding_repo::get_knowledge_without_embeddings(
+                    &brain.pool,
+                    batch_size,
+                )
+                .await
+                {
+                    let texts: Vec<String> = rows
+                        .iter()
+                        .map(crate::embeddings::prepare_knowledge_text)
+                        .collect();
+                    match client.embed_texts(&texts).await {
+                        Ok(embeddings) => {
+                            for (row, emb) in rows.iter().zip(embeddings.iter()) {
+                                if crate::repo::embedding_repo::store_knowledge_embedding(
+                                    &brain.pool,
+                                    row.id,
+                                    emb,
+                                )
+                                .await
+                                .is_ok()
+                                {
+                                    processed += 1;
+                                } else {
+                                    failed += 1;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            summary.insert(
+                                format!("{table}_error"),
+                                serde_json::Value::String(e.to_string()),
+                            );
+                        }
+                    }
+                }
+            }
+            "incidents" => {
+                if let Ok(rows) = crate::repo::embedding_repo::get_incidents_without_embeddings(
+                    &brain.pool,
+                    batch_size,
+                )
+                .await
+                {
+                    let texts: Vec<String> = rows
+                        .iter()
+                        .map(crate::embeddings::prepare_incident_text)
+                        .collect();
+                    match client.embed_texts(&texts).await {
+                        Ok(embeddings) => {
+                            for (row, emb) in rows.iter().zip(embeddings.iter()) {
+                                if crate::repo::embedding_repo::store_incident_embedding(
+                                    &brain.pool,
+                                    row.id,
+                                    emb,
+                                )
+                                .await
+                                .is_ok()
+                                {
+                                    processed += 1;
+                                } else {
+                                    failed += 1;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            summary.insert(
+                                format!("{table}_error"),
+                                serde_json::Value::String(e.to_string()),
+                            );
+                        }
+                    }
+                }
+            }
+            "handoffs" => {
+                if let Ok(rows) = crate::repo::embedding_repo::get_handoffs_without_embeddings(
+                    &brain.pool,
+                    batch_size,
+                )
+                .await
+                {
+                    let texts: Vec<String> = rows
+                        .iter()
+                        .map(crate::embeddings::prepare_handoff_text)
+                        .collect();
+                    match client.embed_texts(&texts).await {
+                        Ok(embeddings) => {
+                            for (row, emb) in rows.iter().zip(embeddings.iter()) {
+                                if crate::repo::embedding_repo::store_handoff_embedding(
+                                    &brain.pool,
+                                    row.id,
+                                    emb,
+                                )
+                                .await
+                                .is_ok()
+                                {
+                                    processed += 1;
+                                } else {
+                                    failed += 1;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            summary.insert(
+                                format!("{table}_error"),
+                                serde_json::Value::String(e.to_string()),
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {
+                summary.insert(
+                    format!("{table}_error"),
+                    serde_json::Value::String("Unknown table".to_string()),
+                );
+                continue;
+            }
+        }
+
+        summary.insert(
+            format!("{table}_processed"),
+            serde_json::Value::Number(processed.into()),
+        );
+        summary.insert(
+            format!("{table}_failed"),
+            serde_json::Value::Number(failed.into()),
+        );
+    }
+
+    // Get remaining counts
+    if let Ok(counts) = crate::repo::embedding_repo::count_missing_embeddings(&brain.pool).await {
+        summary.insert(
+            "remaining_runbooks".to_string(),
+            serde_json::Value::Number(counts.runbooks.into()),
+        );
+        summary.insert(
+            "remaining_knowledge".to_string(),
+            serde_json::Value::Number(counts.knowledge.into()),
+        );
+        summary.insert(
+            "remaining_incidents".to_string(),
+            serde_json::Value::Number(counts.incidents.into()),
+        );
+        summary.insert(
+            "remaining_handoffs".to_string(),
+            serde_json::Value::Number(counts.handoffs.into()),
+        );
+    }
+
+    json_result(&serde_json::Value::Object(summary))
 }

--- a/src/tools/shared.rs
+++ b/src/tools/shared.rs
@@ -1,0 +1,95 @@
+use sqlx::PgPool;
+use std::collections::HashMap;
+
+use crate::embeddings::EmbeddingClient;
+
+/// Best-effort embed and store: logs warning on failure, never blocks the caller.
+pub(crate) async fn embed_and_store(
+    pool: &PgPool,
+    embedding_client: &Option<EmbeddingClient>,
+    table: &str,
+    id: uuid::Uuid,
+    text: &str,
+) {
+    let Some(ref client) = embedding_client else {
+        return;
+    };
+    match client.embed_text(text).await {
+        Ok(embedding) => {
+            let result = match table {
+                "runbooks" => {
+                    crate::repo::embedding_repo::store_runbook_embedding(pool, id, &embedding).await
+                }
+                "knowledge" => {
+                    crate::repo::embedding_repo::store_knowledge_embedding(pool, id, &embedding)
+                        .await
+                }
+                "incidents" => {
+                    crate::repo::embedding_repo::store_incident_embedding(pool, id, &embedding)
+                        .await
+                }
+                "handoffs" => {
+                    crate::repo::embedding_repo::store_handoff_embedding(pool, id, &embedding).await
+                }
+                _ => return,
+            };
+            if let Err(e) = result {
+                tracing::warn!("Failed to store embedding for {table}/{id}: {e}");
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Failed to generate embedding for {table}/{id}: {e}");
+        }
+    }
+}
+
+/// Helper to get query embedding, returning None if embedding client unavailable.
+pub(crate) async fn get_query_embedding(
+    embedding_client: &Option<EmbeddingClient>,
+    text: &str,
+) -> Option<Vec<f32>> {
+    let client = embedding_client.as_ref()?;
+    match client.embed_text(text).await {
+        Ok(emb) => Some(emb),
+        Err(e) => {
+            tracing::warn!("Failed to embed query: {e}");
+            None
+        }
+    }
+}
+
+/// Build a client_id -> (slug, name) lookup from the database.
+pub(crate) async fn build_client_lookup(pool: &PgPool) -> HashMap<uuid::Uuid, (String, String)> {
+    match crate::repo::client_repo::list_clients(pool).await {
+        Ok(clients) => clients
+            .into_iter()
+            .map(|c| (c.id, (c.slug, c.name)))
+            .collect(),
+        Err(e) => {
+            tracing::warn!("Failed to build client lookup: {e}");
+            HashMap::new()
+        }
+    }
+}
+
+/// Write audit log entries for cross-client filtering results.
+pub(crate) async fn log_audit_entries(
+    pool: &PgPool,
+    tool_name: &str,
+    requesting_client_id: Option<uuid::Uuid>,
+    entity_type: &str,
+    entries: &[(uuid::Uuid, Option<uuid::Uuid>, String)],
+) {
+    for (entity_id, owning_client_id, action) in entries {
+        crate::repo::audit_log_repo::log_access(
+            pool,
+            tool_name,
+            requesting_client_id,
+            entity_type,
+            *entity_id,
+            *owning_client_id,
+            action,
+        )
+        .await;
+    }
+}

--- a/src/tools/zammad.rs
+++ b/src/tools/zammad.rs
@@ -1,6 +1,9 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+use super::helpers::{error_result, json_result, not_found};
+use rmcp::model::*;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListTicketsParams {
     /// Client slug to filter tickets by Zammad organization
@@ -93,4 +96,345 @@ pub struct LinkTicketParams {
 pub struct UnlinkTicketParams {
     /// Zammad ticket ID to unlink
     pub zammad_ticket_id: i64,
+}
+
+// ===== HANDLERS =====
+
+pub(crate) async fn handle_list_tickets(
+    brain: &super::OpsBrain,
+    p: ListTicketsParams,
+) -> CallToolResult {
+    let zammad = match &brain.zammad_config {
+        Some(c) => c,
+        None => return error_result("Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)"),
+    };
+
+    let client =
+        match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug).await {
+            Ok(Some(c)) => c,
+            Ok(None) => return not_found("Client", &p.client_slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        };
+
+    let org_id = match client.zammad_org_id {
+        Some(id) => id,
+        None => {
+            return error_result(&format!(
+            "Client '{}' has no Zammad org ID configured. Use upsert_client to set zammad_org_id.",
+            p.client_slug
+        ))
+        }
+    };
+
+    let mut query_parts = vec![format!("organization.id:{org_id}")];
+    if let Some(ref state) = p.state {
+        query_parts.push(format!("state.name:{state}"));
+    }
+    if let Some(ref priority) = p.priority {
+        query_parts.push(format!("priority.name:\"{priority}\""));
+    }
+    let query = query_parts.join(" AND ");
+    let limit = p.limit.unwrap_or(20);
+
+    match crate::zammad::search_tickets(zammad, &query, limit).await {
+        Ok(tickets) => {
+            let result = serde_json::json!({
+                "count": tickets.len(),
+                "client": p.client_slug,
+                "tickets": tickets,
+            });
+            json_result(&result)
+        }
+        Err(e) => error_result(&e),
+    }
+}
+
+pub(crate) async fn handle_get_ticket(
+    brain: &super::OpsBrain,
+    p: GetTicketParams,
+) -> CallToolResult {
+    let zammad = match &brain.zammad_config {
+        Some(c) => c,
+        None => return error_result("Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)"),
+    };
+
+    let ticket = match crate::zammad::get_ticket(zammad, p.ticket_id).await {
+        Ok(t) => t,
+        Err(e) => return error_result(&e),
+    };
+
+    let articles = match crate::zammad::get_ticket_articles(zammad, p.ticket_id).await {
+        Ok(a) => a,
+        Err(e) => return error_result(&e),
+    };
+
+    let link =
+        crate::repo::ticket_link_repo::get_link_by_ticket_id(&brain.pool, p.ticket_id as i32)
+            .await
+            .ok()
+            .flatten();
+
+    let result = serde_json::json!({
+        "ticket": ticket,
+        "articles": articles,
+        "ops_brain_link": link,
+    });
+    json_result(&result)
+}
+
+pub(crate) async fn handle_create_ticket(
+    brain: &super::OpsBrain,
+    p: CreateTicketParams,
+) -> CallToolResult {
+    let zammad = match &brain.zammad_config {
+        Some(c) => c,
+        None => return error_result("Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)"),
+    };
+
+    let client =
+        match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug).await {
+            Ok(Some(c)) => c,
+            Ok(None) => return not_found("Client", &p.client_slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        };
+
+    let (group_id, customer_id, org_id) = match (client.zammad_group_id, client.zammad_customer_id, client.zammad_org_id) {
+        (Some(g), Some(c), org) => (g as i64, c as i64, org.map(|o| o as i64)),
+        _ => return error_result(&format!(
+            "Client '{}' missing Zammad IDs. Set zammad_group_id and zammad_customer_id via upsert_client.",
+            p.client_slug
+        )),
+    };
+
+    let state_id = match &p.state {
+        Some(s) => match crate::zammad::state_name_to_id(s) {
+            Some(id) => Some(id),
+            None => {
+                return error_result(&format!(
+                    "Unknown state: '{s}'. Use: new, open, pending_reminder, closed"
+                ))
+            }
+        },
+        None => None,
+    };
+
+    let priority_id = match &p.priority {
+        Some(pr) => match crate::zammad::priority_name_to_id(pr) {
+            Some(id) => Some(id),
+            None => {
+                return error_result(&format!("Unknown priority: '{pr}'. Use: low, normal, high"))
+            }
+        },
+        None => None,
+    };
+
+    let payload = crate::zammad::CreateTicketPayload {
+        title: p.title,
+        group_id,
+        customer_id,
+        organization_id: org_id,
+        state_id,
+        priority_id,
+        owner_id: Some(3), // Eduardo
+        tags: p.tags,
+        article: crate::zammad::CreateArticleInline {
+            body: p.body,
+            content_type: Some("text/plain".to_string()),
+            article_type: Some("note".to_string()),
+            internal: Some(false),
+            time_unit: p.time_unit,
+            time_accounting_type_id: p.time_accounting_type_id,
+        },
+    };
+
+    let ticket = match crate::zammad::create_ticket(zammad, &payload).await {
+        Ok(t) => t,
+        Err(e) => return error_result(&e),
+    };
+
+    // Auto-link to incident if provided
+    if let Some(ref incident_id_str) = p.incident_id {
+        if let Ok(incident_id) = uuid::Uuid::parse_str(incident_id_str) {
+            let _ = crate::repo::ticket_link_repo::create_link(
+                &brain.pool,
+                ticket.id as i32,
+                Some(incident_id),
+                None,
+                None,
+                None,
+            )
+            .await;
+        }
+    }
+
+    json_result(&ticket)
+}
+
+pub(crate) async fn handle_update_ticket(
+    brain: &super::OpsBrain,
+    p: UpdateTicketParams,
+) -> CallToolResult {
+    let zammad = match &brain.zammad_config {
+        Some(c) => c,
+        None => return error_result("Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)"),
+    };
+
+    let state_id = match &p.state {
+        Some(s) => match crate::zammad::state_name_to_id(s) {
+            Some(id) => Some(id),
+            None => {
+                return error_result(&format!(
+                    "Unknown state: '{s}'. Use: new, open, pending_reminder, closed"
+                ))
+            }
+        },
+        None => None,
+    };
+
+    let priority_id = match &p.priority {
+        Some(pr) => match crate::zammad::priority_name_to_id(pr) {
+            Some(id) => Some(id),
+            None => {
+                return error_result(&format!("Unknown priority: '{pr}'. Use: low, normal, high"))
+            }
+        },
+        None => None,
+    };
+
+    let payload = crate::zammad::UpdateTicketPayload {
+        title: p.title,
+        state_id,
+        priority_id,
+        owner_id: None,
+    };
+
+    match crate::zammad::update_ticket(zammad, p.ticket_id, &payload).await {
+        Ok(ticket) => json_result(&ticket),
+        Err(e) => error_result(&e),
+    }
+}
+
+pub(crate) async fn handle_add_ticket_note(
+    brain: &super::OpsBrain,
+    p: AddTicketNoteParams,
+) -> CallToolResult {
+    let zammad = match &brain.zammad_config {
+        Some(c) => c,
+        None => return error_result("Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)"),
+    };
+
+    let payload = crate::zammad::CreateArticlePayload {
+        ticket_id: p.ticket_id,
+        body: p.body,
+        content_type: Some("text/plain".to_string()),
+        article_type: Some("note".to_string()),
+        internal: Some(p.internal.unwrap_or(true)),
+        time_unit: p.time_unit,
+        time_accounting_type_id: p.time_accounting_type_id,
+    };
+
+    match crate::zammad::add_ticket_article(zammad, &payload).await {
+        Ok(article) => json_result(&article),
+        Err(e) => error_result(&e),
+    }
+}
+
+pub(crate) async fn handle_search_tickets(
+    brain: &super::OpsBrain,
+    p: SearchTicketsParams,
+) -> CallToolResult {
+    let zammad = match &brain.zammad_config {
+        Some(c) => c,
+        None => return error_result("Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)"),
+    };
+    let limit = p.limit.unwrap_or(20);
+
+    match crate::zammad::search_tickets(zammad, &p.query, limit).await {
+        Ok(tickets) => {
+            let result = serde_json::json!({
+                "count": tickets.len(),
+                "query": p.query,
+                "tickets": tickets,
+            });
+            json_result(&result)
+        }
+        Err(e) => error_result(&e),
+    }
+}
+
+pub(crate) async fn handle_link_ticket(
+    brain: &super::OpsBrain,
+    p: LinkTicketParams,
+) -> CallToolResult {
+    if p.incident_id.is_none() && p.server_slug.is_none() && p.service_slug.is_none() {
+        return error_result(
+            "At least one of incident_id, server_slug, or service_slug must be provided",
+        );
+    }
+
+    let incident_id = match &p.incident_id {
+        Some(id_str) => match uuid::Uuid::parse_str(id_str) {
+            Ok(id) => match crate::repo::incident_repo::get_incident(&brain.pool, id).await {
+                Ok(Some(_)) => Some(id),
+                Ok(None) => return not_found("Incident", id_str),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            },
+            Err(_) => return error_result(&format!("Invalid incident UUID: {}", id_str)),
+        },
+        None => None,
+    };
+
+    let server_id = match &p.server_slug {
+        Some(slug) => match crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await {
+            Ok(Some(s)) => Some(s.id),
+            Ok(None) => return not_found("Server", slug),
+            Err(e) => return error_result(&format!("Database error: {e}")),
+        },
+        None => None,
+    };
+
+    let service_id = match &p.service_slug {
+        Some(slug) => {
+            match crate::repo::service_repo::get_service_by_slug(&brain.pool, slug).await {
+                Ok(Some(s)) => Some(s.id),
+                Ok(None) => return not_found("Service", slug),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            }
+        }
+        None => None,
+    };
+
+    match crate::repo::ticket_link_repo::create_link(
+        &brain.pool,
+        p.zammad_ticket_id as i32,
+        incident_id,
+        server_id,
+        service_id,
+        p.notes.as_deref(),
+    )
+    .await
+    {
+        Ok(link) => json_result(&link),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub(crate) async fn handle_unlink_ticket(
+    brain: &super::OpsBrain,
+    p: UnlinkTicketParams,
+) -> CallToolResult {
+    match crate::repo::ticket_link_repo::delete_link(&brain.pool, p.zammad_ticket_id as i32).await {
+        Ok(true) => {
+            let result = serde_json::json!({
+                "status": "unlinked",
+                "zammad_ticket_id": p.zammad_ticket_id,
+            });
+            json_result(&result)
+        }
+        Ok(false) => error_result(&format!(
+            "No link found for Zammad ticket {}",
+            p.zammad_ticket_id
+        )),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
 }


### PR DESCRIPTION
## Summary
- **P9**: Split the 4948-line `tools/mod.rs` monolith into 14 focused files using the delegate pattern. Each `#[tool]` method is now a thin stub that delegates to a `handle_*` function in its category module. mod.rs reduced from 4948 → 1183 lines (76% reduction).
- **P4**: Push-type monitors that are DOWN now include a `diagnostic_hint` field explaining that "down" usually means heartbeat expired (cron/script issue), not service failure.

### New file structure
| File | Lines | Purpose |
|------|-------|---------|
| `mod.rs` | 1,183 | Struct + 64 thin stubs + tests |
| `helpers.rs` | 278 | Cross-client filter, compact mode, JSON helpers |
| `shared.rs` | 95 | embed_and_store, get_query_embedding, etc. |
| `context.rs` | 1,144 | Situational awareness, client overview, server context |
| `inventory.rs` | 676 | 18 inventory tools |
| `incidents.rs` | 487 | 6 incident tools |
| `search.rs` | 452 | Semantic search + backfill |
| `zammad.rs` | 440 | 8 ticket tools |
| `coordination.rs` | 295 | Sessions + handoffs |
| `runbooks.rs` | 296 | 5 runbook tools |
| `monitoring.rs` | 276 | 6 monitoring tools + diagnostic hints |
| `knowledge.rs` | 254 | 5 knowledge tools |
| `briefings.rs` | 179 | 3 briefing tools |

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] All 81 unit tests pass
- [x] All 20 integration tests pass
- [x] Zero behavior changes — pure refactor + one additive field
- [ ] Deploy to kensai.cloud and verify tools work via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)