### PR TITLE
feat: fuzzy slug suggestions (P2 — did you mean?)

### DIFF
--- a/migrations/20260326100001_add_trigram_slug_indexes.sql
+++ b/migrations/20260326100001_add_trigram_slug_indexes.sql
@@ -1,0 +1,12 @@
+-- P2: Fuzzy slug suggestions ("did you mean?")
+-- Enable pg_trgm for trigram similarity matching on slugs/names.
+-- GIN indexes accelerate similarity queries on slug columns.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_servers_slug_trgm ON servers USING gin (slug gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_services_slug_trgm ON services USING gin (slug gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_sites_slug_trgm ON sites USING gin (slug gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_clients_slug_trgm ON clients USING gin (slug gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_runbooks_slug_trgm ON runbooks USING gin (slug gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_vendors_name_trgm ON vendors USING gin (name gin_trgm_ops);

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -13,5 +13,6 @@ pub mod server_repo;
 pub mod service_repo;
 pub mod session_repo;
 pub mod site_repo;
+pub mod suggest_repo;
 pub mod ticket_link_repo;
 pub mod vendor_repo;

--- a/src/repo/suggest_repo.rs
+++ b/src/repo/suggest_repo.rs
@@ -1,0 +1,43 @@
+use sqlx::PgPool;
+
+/// Suggest similar slugs from a table using pg_trgm trigram similarity.
+///
+/// Tries similarity match first (threshold 0.2), then falls back to ILIKE substring.
+/// Returns up to 3 suggestions ordered by similarity score.
+pub async fn suggest_similar_slugs(pool: &PgPool, table: &str, attempted: &str) -> Vec<String> {
+    // Whitelist table names to prevent SQL injection
+    let column = "slug";
+    let table = match table {
+        "servers" | "services" | "sites" | "clients" | "runbooks" => table,
+        _ => return Vec::new(),
+    };
+
+    let query = format!(
+        "SELECT {column} FROM {table} \
+         WHERE similarity({column}, $1) > 0.2 \
+            OR {column} ILIKE '%' || $1 || '%' \
+         ORDER BY similarity({column}, $1) DESC \
+         LIMIT 3"
+    );
+
+    sqlx::query_scalar::<_, String>(&query)
+        .bind(attempted)
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default()
+}
+
+/// Suggest similar vendor names using pg_trgm trigram similarity.
+pub async fn suggest_similar_vendor_names(pool: &PgPool, attempted: &str) -> Vec<String> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT name FROM vendors \
+         WHERE similarity(name, $1) > 0.2 \
+            OR name ILIKE '%' || $1 || '%' \
+         ORDER BY similarity(name, $1) DESC \
+         LIMIT 3",
+    )
+    .bind(attempted)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+}

--- a/src/tools/briefings.rs
+++ b/src/tools/briefings.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::helpers::{error_result, json_result, not_found};
+use super::helpers::{error_result, json_result, not_found, not_found_with_suggestions};
 use rmcp::model::*;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -100,7 +100,7 @@ pub(crate) async fn handle_generate_briefing(
     let client = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -137,7 +137,7 @@ pub(crate) async fn handle_list_briefings(
     let client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -2,8 +2,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::helpers::{
-    compact_value, compact_vec, error_result, filter_cross_client, json_result, not_found,
-    section_included,
+    compact_value, compact_vec, error_result, filter_cross_client, json_result,
+    not_found_with_suggestions, section_included,
 };
 use super::shared::{build_client_lookup, get_query_embedding, log_audit_entries};
 use crate::models::handoff::Handoff;
@@ -182,7 +182,7 @@ pub(crate) async fn handle_get_situational_awareness(
                     .collect();
             }
         } else {
-            return not_found("Server", slug);
+            return not_found_with_suggestions(&brain.pool, "Server", slug).await;
         }
     }
 
@@ -244,7 +244,7 @@ pub(crate) async fn handle_get_situational_awareness(
                 }
             }
         } else {
-            return not_found("Service", slug);
+            return not_found_with_suggestions(&brain.pool, "Service", slug).await;
         }
     }
 
@@ -256,7 +256,7 @@ pub(crate) async fn handle_get_situational_awareness(
             client_id = Some(client.id);
             awareness.client = serde_json::to_value(&client).ok();
         } else {
-            return not_found("Client", slug);
+            return not_found_with_suggestions(&brain.pool, "Client", slug).await;
         }
     }
 
@@ -639,12 +639,13 @@ pub(crate) async fn handle_get_client_overview(
     brain: &super::OpsBrain,
     p: GetClientOverviewParams,
 ) -> CallToolResult {
-    let client =
-        match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug).await {
-            Ok(Some(c)) => c,
-            Ok(None) => return not_found("Client", &p.client_slug),
-            Err(e) => return error_result(&format!("Database error: {e}")),
-        };
+    let client = match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug)
+        .await
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", &p.client_slug).await,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
 
     let sites = crate::repo::site_repo::list_sites(&brain.pool, Some(client.id))
         .await
@@ -760,12 +761,13 @@ pub(crate) async fn handle_get_server_context(
     let compact = p.compact.unwrap_or(false);
     let sections = p.sections;
 
-    let server =
-        match crate::repo::server_repo::get_server_by_slug(&brain.pool, &p.server_slug).await {
-            Ok(Some(s)) => s,
-            Ok(None) => return not_found("Server", &p.server_slug),
-            Err(e) => return error_result(&format!("Database error: {e}")),
-        };
+    let server = match crate::repo::server_repo::get_server_by_slug(&brain.pool, &p.server_slug)
+        .await
+    {
+        Ok(Some(s)) => s,
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Server", &p.server_slug).await,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
 
     let services = crate::repo::service_repo::get_services_for_server(&brain.pool, server.id)
         .await

--- a/src/tools/helpers.rs
+++ b/src/tools/helpers.rs
@@ -18,6 +18,47 @@ pub(crate) fn not_found(entity: &str, key: &str) -> CallToolResult {
     CallToolResult::error(vec![Content::text(format!("{entity} not found: {key}"))])
 }
 
+/// Like `not_found`, but queries pg_trgm for similar slugs and appends "Did you mean: ..." suggestions.
+pub(crate) async fn not_found_with_suggestions(
+    pool: &sqlx::PgPool,
+    entity: &str,
+    key: &str,
+) -> CallToolResult {
+    let table = match entity {
+        "Server" | "Hypervisor server" => "servers",
+        "Service" => "services",
+        "Site" => "sites",
+        "Client" => "clients",
+        "Runbook" => "runbooks",
+        _ => return not_found(entity, key),
+    };
+    let suggestions = crate::repo::suggest_repo::suggest_similar_slugs(pool, table, key).await;
+    if suggestions.is_empty() {
+        not_found(entity, key)
+    } else {
+        CallToolResult::error(vec![Content::text(format!(
+            "{entity} not found: {key}. Did you mean: {}?",
+            suggestions.join(", ")
+        ))])
+    }
+}
+
+/// Like `not_found`, but queries pg_trgm for similar vendor names.
+pub(crate) async fn not_found_vendor_with_suggestions(
+    pool: &sqlx::PgPool,
+    key: &str,
+) -> CallToolResult {
+    let suggestions = crate::repo::suggest_repo::suggest_similar_vendor_names(pool, key).await;
+    if suggestions.is_empty() {
+        not_found("Vendor", key)
+    } else {
+        CallToolResult::error(vec![Content::text(format!(
+            "Vendor not found: {key}. Did you mean: {}?",
+            suggestions.join(", ")
+        ))])
+    }
+}
+
 /// Result of cross-client scope filtering.
 pub(crate) struct CrossClientFilterResult {
     /// Items that passed the gate (with _provenance fields injected)

--- a/src/tools/incidents.rs
+++ b/src/tools/incidents.rs
@@ -1,7 +1,10 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use super::helpers::{error_result, json_result, not_found};
+use super::helpers::{
+    error_result, json_result, not_found, not_found_vendor_with_suggestions,
+    not_found_with_suggestions,
+};
 use super::shared::{embed_and_store, get_query_embedding};
 use rmcp::model::*;
 
@@ -117,7 +120,7 @@ pub(crate) async fn handle_create_incident(
     let client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -306,7 +309,7 @@ pub(crate) async fn handle_list_incidents(
     let client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -395,7 +398,7 @@ pub(crate) async fn handle_link_incident(
                     }
                     linked.push(format!("server:{slug}"));
                 }
-                Ok(None) => return not_found("Server", slug),
+                Ok(None) => return not_found_with_suggestions(&brain.pool, "Server", slug).await,
                 Err(e) => return error_result(&format!("Database error: {e}")),
             }
         }
@@ -417,7 +420,7 @@ pub(crate) async fn handle_link_incident(
                     }
                     linked.push(format!("service:{slug}"));
                 }
-                Ok(None) => return not_found("Service", slug),
+                Ok(None) => return not_found_with_suggestions(&brain.pool, "Service", slug).await,
                 Err(e) => return error_result(&format!("Database error: {e}")),
             }
         }
@@ -451,7 +454,9 @@ pub(crate) async fn handle_link_incident(
                     }
                     linked.push(format!("runbook:{}", rb_link.slug));
                 }
-                Ok(None) => return not_found("Runbook", &rb_link.slug),
+                Ok(None) => {
+                    return not_found_with_suggestions(&brain.pool, "Runbook", &rb_link.slug).await
+                }
                 Err(e) => return error_result(&format!("Database error: {e}")),
             }
         }
@@ -473,7 +478,7 @@ pub(crate) async fn handle_link_incident(
                     }
                     linked.push(format!("vendor:{name}"));
                 }
-                Ok(None) => return not_found("Vendor", name),
+                Ok(None) => return not_found_vendor_with_suggestions(&brain.pool, name).await,
                 Err(e) => return error_result(&format!("Database error: {e}")),
             }
         }

--- a/src/tools/inventory.rs
+++ b/src/tools/inventory.rs
@@ -2,7 +2,10 @@ use rmcp::model::*;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use super::helpers::{error_result, json_result, not_found};
+use super::helpers::{
+    error_result, json_result, not_found, not_found_vendor_with_suggestions,
+    not_found_with_suggestions,
+};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetServerParams {
@@ -174,7 +177,7 @@ pub(crate) async fn handle_get_server(
 ) -> CallToolResult {
     let server = match crate::repo::server_repo::get_server_by_slug(&brain.pool, &p.slug).await {
         Ok(Some(s)) => s,
-        Ok(None) => return not_found("Server", &p.slug),
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Server", &p.slug).await,
         Err(e) => return error_result(&format!("Database error: {e}")),
     };
     let services = crate::repo::service_repo::get_services_for_server(&brain.pool, server.id)
@@ -204,7 +207,7 @@ pub(crate) async fn handle_list_servers(
     let client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -212,7 +215,7 @@ pub(crate) async fn handle_list_servers(
     let site_id = match &p.site_slug {
         Some(slug) => match crate::repo::site_repo::get_site_by_slug(&brain.pool, slug).await {
             Ok(Some(s)) => Some(s.id),
-            Ok(None) => return not_found("Site", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Site", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -237,7 +240,7 @@ pub(crate) async fn handle_get_service(
 ) -> CallToolResult {
     let service = match crate::repo::service_repo::get_service_by_slug(&brain.pool, &p.slug).await {
         Ok(Some(s)) => s,
-        Ok(None) => return not_found("Service", &p.slug),
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Service", &p.slug).await,
         Err(e) => return error_result(&format!("Database error: {e}")),
     };
     let servers = crate::repo::service_repo::get_servers_for_service(&brain.pool, service.id)
@@ -263,7 +266,7 @@ pub(crate) async fn handle_list_services(
 pub(crate) async fn handle_get_site(brain: &super::OpsBrain, p: GetSiteParams) -> CallToolResult {
     let site = match crate::repo::site_repo::get_site_by_slug(&brain.pool, &p.slug).await {
         Ok(Some(s)) => s,
-        Ok(None) => return not_found("Site", &p.slug),
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Site", &p.slug).await,
         Err(e) => return error_result(&format!("Database error: {e}")),
     };
     let servers =
@@ -287,7 +290,7 @@ pub(crate) async fn handle_get_client(
 ) -> CallToolResult {
     match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.slug).await {
         Ok(Some(client)) => json_result(&client),
-        Ok(None) => not_found("Client", &p.slug),
+        Ok(None) => not_found_with_suggestions(&brain.pool, "Client", &p.slug).await,
         Err(e) => error_result(&format!("Database error: {e}")),
     }
 }
@@ -310,7 +313,7 @@ pub(crate) async fn handle_get_network(
     let site_id = match &p.site_slug {
         Some(slug) => match crate::repo::site_repo::get_site_by_slug(&brain.pool, slug).await {
             Ok(Some(s)) => Some(s.id),
-            Ok(None) => return not_found("Site", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Site", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -327,7 +330,7 @@ pub(crate) async fn handle_get_vendor(
 ) -> CallToolResult {
     match crate::repo::vendor_repo::get_vendor_by_name(&brain.pool, &p.name).await {
         Ok(Some(vendor)) => json_result(&vendor),
-        Ok(None) => not_found("Vendor", &p.name),
+        Ok(None) => not_found_vendor_with_suggestions(&brain.pool, &p.name).await,
         Err(e) => error_result(&format!("Database error: {e}")),
     }
 }
@@ -366,12 +369,13 @@ pub(crate) async fn handle_upsert_site(
     brain: &super::OpsBrain,
     p: UpsertSiteParams,
 ) -> CallToolResult {
-    let client =
-        match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug).await {
-            Ok(Some(c)) => c,
-            Ok(None) => return not_found("Client", &p.client_slug),
-            Err(e) => return error_result(&format!("Database error: {e}")),
-        };
+    let client = match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug)
+        .await
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", &p.client_slug).await,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
     match crate::repo::site_repo::upsert_site(
         &brain.pool,
         client.id,
@@ -395,13 +399,15 @@ pub(crate) async fn handle_upsert_server(
 ) -> CallToolResult {
     let site = match crate::repo::site_repo::get_site_by_slug(&brain.pool, &p.site_slug).await {
         Ok(Some(s)) => s,
-        Ok(None) => return not_found("Site", &p.site_slug),
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Site", &p.site_slug).await,
         Err(e) => return error_result(&format!("Database error: {e}")),
     };
     let hypervisor_id = match &p.hypervisor_slug {
         Some(slug) => match crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await {
             Ok(Some(h)) => Some(h.id),
-            Ok(None) => return not_found("Hypervisor server", slug),
+            Ok(None) => {
+                return not_found_with_suggestions(&brain.pool, "Hypervisor server", slug).await
+            }
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -495,16 +501,19 @@ pub(crate) async fn handle_link_server_service(
     brain: &super::OpsBrain,
     p: LinkServerServiceParams,
 ) -> CallToolResult {
-    let server =
-        match crate::repo::server_repo::get_server_by_slug(&brain.pool, &p.server_slug).await {
-            Ok(Some(s)) => s,
-            Ok(None) => return not_found("Server", &p.server_slug),
-            Err(e) => return error_result(&format!("Database error: {e}")),
-        };
+    let server = match crate::repo::server_repo::get_server_by_slug(&brain.pool, &p.server_slug)
+        .await
+    {
+        Ok(Some(s)) => s,
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Server", &p.server_slug).await,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
     let service =
         match crate::repo::service_repo::get_service_by_slug(&brain.pool, &p.service_slug).await {
             Ok(Some(s)) => s,
-            Ok(None) => return not_found("Service", &p.service_slug),
+            Ok(None) => {
+                return not_found_with_suggestions(&brain.pool, "Service", &p.service_slug).await
+            }
             Err(e) => return error_result(&format!("Database error: {e}")),
         };
     match crate::repo::service_repo::link_server_service(
@@ -531,7 +540,7 @@ pub(crate) async fn handle_delete_server(
     let server = match crate::repo::server_repo::get_server_by_slug(&brain.pool, &params.slug).await
     {
         Ok(Some(s)) => s,
-        Ok(None) => return not_found("Server", &params.slug),
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Server", &params.slug).await,
         Err(e) => return error_result(&format!("Database error: {e}")),
     };
     let refs = match crate::repo::server_repo::count_server_references(&brain.pool, server.id).await
@@ -579,12 +588,13 @@ pub(crate) async fn handle_delete_service(
     brain: &super::OpsBrain,
     params: DeleteServiceParams,
 ) -> CallToolResult {
-    let service =
-        match crate::repo::service_repo::get_service_by_slug(&brain.pool, &params.slug).await {
-            Ok(Some(s)) => s,
-            Ok(None) => return not_found("Service", &params.slug),
-            Err(e) => return error_result(&format!("Database error: {e}")),
-        };
+    let service = match crate::repo::service_repo::get_service_by_slug(&brain.pool, &params.slug)
+        .await
+    {
+        Ok(Some(s)) => s,
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Service", &params.slug).await,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
     let refs =
         match crate::repo::service_repo::count_service_references(&brain.pool, service.id).await {
             Ok(r) => r,
@@ -632,7 +642,7 @@ pub(crate) async fn handle_delete_vendor(
     let vendor = match crate::repo::vendor_repo::get_vendor_by_name(&brain.pool, &params.name).await
     {
         Ok(Some(v)) => v,
-        Ok(None) => return not_found("Vendor", &params.name),
+        Ok(None) => return not_found_vendor_with_suggestions(&brain.pool, &params.name).await,
         Err(e) => return error_result(&format!("Database error: {e}")),
     };
     let refs = match crate::repo::vendor_repo::count_vendor_references(&brain.pool, vendor.id).await

--- a/src/tools/knowledge.rs
+++ b/src/tools/knowledge.rs
@@ -1,7 +1,9 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use super::helpers::{error_result, filter_cross_client, json_result, not_found};
+use super::helpers::{
+    error_result, filter_cross_client, json_result, not_found, not_found_with_suggestions,
+};
 use super::shared::{build_client_lookup, embed_and_store, get_query_embedding, log_audit_entries};
 use rmcp::model::*;
 
@@ -64,7 +66,7 @@ pub(crate) async fn handle_add_knowledge(
     let client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -171,7 +173,7 @@ pub(crate) async fn handle_search_knowledge(
     let requesting_client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -239,7 +241,7 @@ pub(crate) async fn handle_list_knowledge(
     let client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,

--- a/src/tools/monitoring.rs
+++ b/src/tools/monitoring.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use super::helpers::{error_result, json_result, not_found};
+use super::helpers::{error_result, json_result, not_found, not_found_with_suggestions};
 use crate::models::incident::Incident;
 use rmcp::model::*;
 
@@ -210,7 +210,7 @@ pub(crate) async fn handle_link_monitor(
     let server_id = match &p.server_slug {
         Some(slug) => match crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await {
             Ok(Some(s)) => Some(s.id),
-            Ok(None) => return not_found("Server", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Server", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -221,7 +221,7 @@ pub(crate) async fn handle_link_monitor(
         Some(slug) => {
             match crate::repo::service_repo::get_service_by_slug(&brain.pool, slug).await {
                 Ok(Some(s)) => Some(s.id),
-                Ok(None) => return not_found("Service", slug),
+                Ok(None) => return not_found_with_suggestions(&brain.pool, "Service", slug).await,
                 Err(e) => return error_result(&format!("Database error: {e}")),
             }
         }

--- a/src/tools/runbooks.rs
+++ b/src/tools/runbooks.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use super::helpers::{error_result, filter_cross_client, json_result, not_found};
+use super::helpers::{error_result, filter_cross_client, json_result, not_found_with_suggestions};
 use super::shared::{build_client_lookup, embed_and_store, get_query_embedding, log_audit_entries};
 use rmcp::model::*;
 
@@ -71,7 +71,7 @@ pub(crate) async fn handle_get_runbook(
 ) -> CallToolResult {
     match crate::repo::runbook_repo::get_runbook_by_slug(&brain.pool, &p.slug).await {
         Ok(Some(runbook)) => json_result(&runbook),
-        Ok(None) => not_found("Runbook", &p.slug),
+        Ok(None) => not_found_with_suggestions(&brain.pool, "Runbook", &p.slug).await,
         Err(e) => error_result(&format!("Database error: {e}")),
     }
 }
@@ -84,7 +84,7 @@ pub(crate) async fn handle_list_runbooks(
     let client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -95,7 +95,7 @@ pub(crate) async fn handle_list_runbooks(
         Some(slug) => {
             match crate::repo::service_repo::get_service_by_slug(&brain.pool, slug).await {
                 Ok(Some(s)) => Some(s.id),
-                Ok(None) => return not_found("Service", slug),
+                Ok(None) => return not_found_with_suggestions(&brain.pool, "Service", slug).await,
                 Err(e) => return error_result(&format!("Database error: {e}")),
             }
         }
@@ -106,7 +106,7 @@ pub(crate) async fn handle_list_runbooks(
     let server_id = match &p.server_slug {
         Some(slug) => match crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await {
             Ok(Some(s)) => Some(s.id),
-            Ok(None) => return not_found("Server", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Server", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -142,7 +142,7 @@ pub(crate) async fn handle_search_runbooks(
     let requesting_client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -215,7 +215,7 @@ pub(crate) async fn handle_create_runbook(
     let client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -258,7 +258,7 @@ pub(crate) async fn handle_update_runbook(
 ) -> CallToolResult {
     let runbook = match crate::repo::runbook_repo::get_runbook_by_slug(&brain.pool, &p.slug).await {
         Ok(Some(r)) => r,
-        Ok(None) => return not_found("Runbook", &p.slug),
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Runbook", &p.slug).await,
         Err(e) => return error_result(&format!("Database error: {e}")),
     };
 

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use super::helpers::{error_result, filter_cross_client, json_result, not_found};
+use super::helpers::{error_result, filter_cross_client, json_result, not_found_with_suggestions};
 use super::shared::{build_client_lookup, get_query_embedding, log_audit_entries};
 use rmcp::model::*;
 
@@ -47,7 +47,7 @@ pub(crate) async fn handle_semantic_search(
     let requesting_client_id = match &p.client_slug {
         Some(slug) => match crate::repo::client_repo::get_client_by_slug(&brain.pool, slug).await {
             Ok(Some(c)) => Some(c.id),
-            Ok(None) => return not_found("Client", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,

--- a/src/tools/zammad.rs
+++ b/src/tools/zammad.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use super::helpers::{error_result, json_result, not_found};
+use super::helpers::{error_result, json_result, not_found, not_found_with_suggestions};
 use rmcp::model::*;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -109,12 +109,13 @@ pub(crate) async fn handle_list_tickets(
         None => return error_result("Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)"),
     };
 
-    let client =
-        match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug).await {
-            Ok(Some(c)) => c,
-            Ok(None) => return not_found("Client", &p.client_slug),
-            Err(e) => return error_result(&format!("Database error: {e}")),
-        };
+    let client = match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug)
+        .await
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", &p.client_slug).await,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
 
     let org_id = match client.zammad_org_id {
         Some(id) => id,
@@ -191,12 +192,13 @@ pub(crate) async fn handle_create_ticket(
         None => return error_result("Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)"),
     };
 
-    let client =
-        match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug).await {
-            Ok(Some(c)) => c,
-            Ok(None) => return not_found("Client", &p.client_slug),
-            Err(e) => return error_result(&format!("Database error: {e}")),
-        };
+    let client = match crate::repo::client_repo::get_client_by_slug(&brain.pool, &p.client_slug)
+        .await
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => return not_found_with_suggestions(&brain.pool, "Client", &p.client_slug).await,
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    };
 
     let (group_id, customer_id, org_id) = match (client.zammad_group_id, client.zammad_customer_id, client.zammad_org_id) {
         (Some(g), Some(c), org) => (g as i64, c as i64, org.map(|o| o as i64)),
@@ -387,7 +389,7 @@ pub(crate) async fn handle_link_ticket(
     let server_id = match &p.server_slug {
         Some(slug) => match crate::repo::server_repo::get_server_by_slug(&brain.pool, slug).await {
             Ok(Some(s)) => Some(s.id),
-            Ok(None) => return not_found("Server", slug),
+            Ok(None) => return not_found_with_suggestions(&brain.pool, "Server", slug).await,
             Err(e) => return error_result(&format!("Database error: {e}")),
         },
         None => None,
@@ -397,7 +399,7 @@ pub(crate) async fn handle_link_ticket(
         Some(slug) => {
             match crate::repo::service_repo::get_service_by_slug(&brain.pool, slug).await {
                 Ok(Some(s)) => Some(s.id),
-                Ok(None) => return not_found("Service", slug),
+                Ok(None) => return not_found_with_suggestions(&brain.pool, "Service", slug).await,
                 Err(e) => return error_result(&format!("Database error: {e}")),
             }
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1000,3 +1000,163 @@ mod delete_tests {
         assert!(!result);
     }
 }
+
+// ===== Fuzzy Slug Suggestion Tests =====
+
+mod suggest_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn suggest_similar_server_slugs() {
+        let pool = pool().await;
+        let base_slug = format!("fuzzy-srv-{}", &Uuid::now_v7().to_string()[..8]);
+
+        // Create a test site + client first
+        let client = ops_brain::repo::client_repo::upsert_client(
+            &pool,
+            "Fuzzy Test Client",
+            &format!("fuzzy-client-{}", &Uuid::now_v7().to_string()[..8]),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let site = ops_brain::repo::site_repo::upsert_site(
+            &pool,
+            client.id,
+            "Fuzzy Test Site",
+            &format!("fuzzy-site-{}", &Uuid::now_v7().to_string()[..8]),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Create a server with a known slug
+        let server = ops_brain::repo::server_repo::upsert_server(
+            &pool,
+            site.id,
+            "fuzzy-test-host",
+            &base_slug,
+            None,
+            &[],
+            None,
+            &[],
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            "active",
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Typo slug should return suggestions
+        let typo = format!("{}x", &base_slug);
+        let suggestions =
+            ops_brain::repo::suggest_repo::suggest_similar_slugs(&pool, "servers", &typo).await;
+        assert!(
+            suggestions.contains(&base_slug),
+            "Expected '{}' in suggestions {:?}",
+            base_slug,
+            suggestions
+        );
+
+        // Exact slug should NOT appear when querying with something totally unrelated
+        let suggestions = ops_brain::repo::suggest_repo::suggest_similar_slugs(
+            &pool,
+            "servers",
+            "zzz-no-match-zzz",
+        )
+        .await;
+        assert!(
+            !suggestions.contains(&base_slug),
+            "Should not suggest '{}' for unrelated query",
+            base_slug
+        );
+
+        // Substring match should work
+        let partial = &base_slug[..base_slug.len() - 2];
+        let suggestions =
+            ops_brain::repo::suggest_repo::suggest_similar_slugs(&pool, "servers", partial).await;
+        assert!(
+            suggestions.contains(&base_slug),
+            "Substring '{}' should match '{}', got {:?}",
+            partial,
+            base_slug,
+            suggestions
+        );
+
+        // Cleanup
+        sqlx::query("DELETE FROM servers WHERE id = $1")
+            .bind(server.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM sites WHERE id = $1")
+            .bind(site.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM clients WHERE id = $1")
+            .bind(client.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn suggest_similar_vendor_names() {
+        let pool = pool().await;
+        let vendor_name = format!("FuzzyVendor-{}", &Uuid::now_v7().to_string()[..8]);
+
+        let vendor = ops_brain::repo::vendor_repo::upsert_vendor(
+            &pool,
+            &vendor_name,
+            Some("test"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Typo should return suggestion
+        let typo = format!("{}x", &vendor_name);
+        let suggestions =
+            ops_brain::repo::suggest_repo::suggest_similar_vendor_names(&pool, &typo).await;
+        assert!(
+            suggestions.contains(&vendor_name),
+            "Expected '{}' in suggestions {:?}",
+            vendor_name,
+            suggestions
+        );
+
+        // Cleanup
+        sqlx::query("DELETE FROM vendors WHERE id = $1")
+            .bind(vendor.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn suggest_returns_empty_for_invalid_table() {
+        let pool = pool().await;
+        let suggestions =
+            ops_brain::repo::suggest_repo::suggest_similar_slugs(&pool, "nonexistent", "test")
+                .await;
+        assert!(suggestions.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- When a slug/name lookup fails, ops-brain now suggests similar matches using **pg_trgm** trigram similarity instead of returning a bare "not found" error
- Eliminates the friction of having to call `list_*` tools to find the right slug — every CC instance hits this
- Example: `Server not found: kensai-cloudlab. Did you mean: kensai-cloud, linux-lab?`

## Changes

- **Migration**: enables `pg_trgm` extension + GIN trigram indexes on slug columns (servers, services, sites, clients, runbooks) and vendor name
- **`src/repo/suggest_repo.rs`** (new): generic `suggest_similar_slugs()` using `similarity() > 0.2` + ILIKE substring fallback, returns top 3
- **`src/tools/helpers.rs`**: `not_found_with_suggestions()` and `not_found_vendor_with_suggestions()` async helpers
- **43 slug lookup sites** across 11 tool modules updated to use fuzzy suggestions
- UUID/ID-based lookups (incidents, knowledge, handoffs, briefings) intentionally unchanged
- **3 new integration tests**: similarity match, vendor name match, invalid table safety

## Origin

P2 from kensai-cloud CC handoff `019d2780-860a-7c33-bfb3-829d7430c871` — field-tested friction point.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — 185 tests pass (81+81 unit + 23 integration)
- [ ] Deploy to kensai.cloud, verify migration creates pg_trgm extension + indexes
- [ ] Call `get_server(slug: "kensai-cloudlab")` — expect suggestion of `kensai-cloud`
- [ ] Call `get_server(slug: "kensai-cloud")` — exact match still works, no perf regression
- [ ] Call `get_vendor(name: "Microsof")` — expect suggestion of `Microsoft`

🤖 Generated with [Claude Code](https://claude.com/claude-code)