### PR TITLE
feat: replace N+1 incident queries with UNION (P5)

### DIFF
--- a/src/repo/incident_repo.rs
+++ b/src/repo/incident_repo.rs
@@ -219,6 +219,69 @@ pub async fn link_incident_vendor(
     Ok(())
 }
 
+/// Get related incidents from all sources in a single query.
+///
+/// Combines client-level, server-linked, and service-linked incidents using
+/// UNION, deduplicating via DISTINCT. Replaces 2-3 separate queries + app-level dedup.
+pub async fn get_related_incidents(
+    pool: &PgPool,
+    client_id: Option<Uuid>,
+    server_id: Option<Uuid>,
+    service_id: Option<Uuid>,
+    limit: i64,
+) -> Result<Vec<Incident>, sqlx::Error> {
+    // Build UNION branches based on which IDs are present
+    let mut unions: Vec<String> = Vec::new();
+    let mut param_idx = 1u32;
+    let mut binds: Vec<Uuid> = Vec::new();
+
+    if let Some(cid) = client_id {
+        unions.push(format!(
+            "SELECT * FROM incidents WHERE client_id = ${param_idx}"
+        ));
+        param_idx += 1;
+        binds.push(cid);
+    }
+    if let Some(sid) = server_id {
+        unions.push(format!(
+            "SELECT i.* FROM incidents i \
+             JOIN incident_servers isv ON i.id = isv.incident_id \
+             WHERE isv.server_id = ${param_idx}"
+        ));
+        param_idx += 1;
+        binds.push(sid);
+    }
+    if let Some(svc_id) = service_id {
+        unions.push(format!(
+            "SELECT i.* FROM incidents i \
+             JOIN incident_services iss ON i.id = iss.incident_id \
+             WHERE iss.service_id = ${param_idx}"
+        ));
+        param_idx += 1;
+        binds.push(svc_id);
+    }
+
+    if unions.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let query = format!(
+        "SELECT DISTINCT ON (id) * FROM ({}) sub \
+         ORDER BY id, reported_at DESC",
+        unions.join(" UNION ALL ")
+    );
+    // Wrap to apply final ordering + limit
+    let query =
+        format!("SELECT * FROM ({query}) deduped ORDER BY reported_at DESC LIMIT ${param_idx}");
+
+    let mut q = sqlx::query_as::<_, Incident>(&query);
+    for id in &binds {
+        q = q.bind(id);
+    }
+    q = q.bind(limit);
+    q.fetch_all(pool).await
+}
+
 /// Get incidents linked to a specific server
 pub async fn get_incidents_for_server(
     pool: &PgPool,

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -271,20 +271,6 @@ pub(crate) async fn handle_get_situational_awareness(
                 .collect();
         }
 
-        // Get recent incidents for this client
-        let incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
-            "SELECT * FROM incidents WHERE client_id = $1 ORDER BY reported_at DESC LIMIT 10",
-        )
-        .bind(cid)
-        .fetch_all(&brain.pool)
-        .await
-        .unwrap_or_default();
-
-        awareness.recent_incidents = incidents
-            .iter()
-            .filter_map(|i| serde_json::to_value(i).ok())
-            .collect();
-
         // Get knowledge for this client
         if let Ok(entries) =
             crate::repo::knowledge_repo::list_knowledge(&brain.pool, None, Some(cid)).await
@@ -296,57 +282,20 @@ pub(crate) async fn handle_get_situational_awareness(
         }
     }
 
-    // If we have a server, also get incidents linked to that server
-    if let Some(srv_id) = server_id {
-        let server_incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
-            "SELECT i.* FROM incidents i \
-             JOIN incident_servers isv ON i.id = isv.incident_id \
-             WHERE isv.server_id = $1 \
-             ORDER BY i.reported_at DESC LIMIT 10",
+    // Get all related incidents in a single UNION query (client + server + service)
+    if section_included(&sections, "incidents") {
+        awareness.recent_incidents = crate::repo::incident_repo::get_related_incidents(
+            &brain.pool,
+            client_id,
+            server_id,
+            service_id,
+            10,
         )
-        .bind(srv_id)
-        .fetch_all(&brain.pool)
         .await
-        .unwrap_or_default();
-
-        // Merge with existing incidents (avoid duplicates by ID)
-        for inc in &server_incidents {
-            if let Ok(val) = serde_json::to_value(inc) {
-                if !awareness
-                    .recent_incidents
-                    .iter()
-                    .any(|existing| existing.get("id") == val.get("id"))
-                {
-                    awareness.recent_incidents.push(val);
-                }
-            }
-        }
-    }
-
-    // If we have a service, also get incidents linked to that service
-    if let Some(svc_id) = service_id {
-        let service_incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
-            "SELECT i.* FROM incidents i \
-             JOIN incident_services iss ON i.id = iss.incident_id \
-             WHERE iss.service_id = $1 \
-             ORDER BY i.reported_at DESC LIMIT 10",
-        )
-        .bind(svc_id)
-        .fetch_all(&brain.pool)
-        .await
-        .unwrap_or_default();
-
-        for inc in &service_incidents {
-            if let Ok(val) = serde_json::to_value(inc) {
-                if !awareness
-                    .recent_incidents
-                    .iter()
-                    .any(|existing| existing.get("id") == val.get("id"))
-                {
-                    awareness.recent_incidents.push(val);
-                }
-            }
-        }
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|i| serde_json::to_value(i).ok())
+        .collect();
     }
 
     // Get pending handoffs
@@ -799,41 +748,20 @@ pub(crate) async fn handle_get_server_context(
         Vec::new()
     };
 
-    // Get incidents linked to this server
-    let incidents: Vec<Incident> = sqlx::query_as::<_, Incident>(
-        "SELECT i.* FROM incidents i \
-         JOIN incident_servers isv ON i.id = isv.incident_id \
-         WHERE isv.server_id = $1 \
-         ORDER BY i.reported_at DESC LIMIT 10",
-    )
-    .bind(server.id)
-    .fetch_all(&brain.pool)
-    .await
-    .unwrap_or_default();
-
-    // Also get client-level incidents
-    let client_incidents: Vec<Incident> = if let Some(cid) = client_id {
-        sqlx::query_as::<_, Incident>(
-            "SELECT * FROM incidents WHERE client_id = $1 ORDER BY reported_at DESC LIMIT 10",
+    // Get all related incidents in a single UNION query (client + server)
+    let mut all_incidents: Vec<serde_json::Value> =
+        crate::repo::incident_repo::get_related_incidents(
+            &brain.pool,
+            client_id,
+            Some(server.id),
+            None,
+            10,
         )
-        .bind(cid)
-        .fetch_all(&brain.pool)
         .await
         .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
-
-    // Merge incidents, dedup by id
-    let mut all_incidents: Vec<serde_json::Value> = Vec::new();
-    let mut seen_ids = std::collections::HashSet::new();
-    for inc in incidents.iter().chain(client_incidents.iter()) {
-        if seen_ids.insert(inc.id) {
-            if let Ok(val) = serde_json::to_value(inc) {
-                all_incidents.push(val);
-            }
-        }
-    }
+        .iter()
+        .filter_map(|i| serde_json::to_value(i).ok())
+        .collect();
 
     // Get runbooks linked to this server
     let runbooks = crate::repo::runbook_repo::list_runbooks(


### PR DESCRIPTION
## Summary

- Replaces 3 separate incident queries + O(n²) JSON dedup in `get_situational_awareness` with a single `UNION ALL` + `DISTINCT ON` query
- Replaces 2 queries + HashSet dedup in `get_server_context` with the same
- New `get_related_incidents()` repo function builds a dynamic UNION query combining client-level, server-linked, and service-linked incidents

## Changes

- **`src/repo/incident_repo.rs`**: new `get_related_incidents(client_id, server_id, service_id, limit)` — builds UNION branches for whichever IDs are present, deduplicates via `DISTINCT ON (id)`, returns ordered by `reported_at DESC`
- **`src/tools/context.rs`**: `handle_get_situational_awareness` drops ~40 lines (3 queries + O(n²) dedup → 1 call), `handle_get_server_context` drops ~20 lines (2 queries + HashSet → 1 call). Also wraps the new call in `section_included()` check so incidents aren't queried at all when excluded via `sections` param

## Origin

P5 from kensai-cloud CC handoff `019d2780-860a-7c33-bfb3-829d7430c871`.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — 182 tests pass (81+81 unit + 20 integration)
- [ ] Deploy and call `get_situational_awareness(server_slug: "kensai-cloud")` — verify incidents still appear
- [ ] Call with `sections: ["incidents"]` — verify only incidents returned
- [ ] Call with `sections: ["server"]` — verify no incident query fired (check logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)