### PR TITLE
chore: bump CI actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install mold linker
         run: sudo apt-get update && sudo apt-get install -y mold
@@ -47,7 +47,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo registry + build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -77,7 +77,7 @@ jobs:
     # Advisory-only: don't block CI on upstream vulnerabilities we can't fix
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v5 and `actions/cache` v4 → v5
- Node.js 20 deprecation: forced to Node.js 24 on June 2, removed from runners Sept 16

## Test plan
- [ ] CI passes on this PR (the actions themselves validate the bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)