### PR TITLE
feat: search relevance tuning (websearch_to_tsquery + OR fallback + title boost)

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -75,9 +75,11 @@ impl EmbeddingClient {
 
 // ===== TEXT PREPARATION =====
 // Each function produces the text that gets embedded for a given record.
+// Title is repeated to boost its weight in the embedding vector — semantic
+// search will more strongly match queries that align with the title.
 
 pub fn prepare_runbook_text(r: &Runbook) -> String {
-    let mut text = format!("{}\n\n{}", r.title, r.content);
+    let mut text = format!("{}\n{}\n\n{}", r.title, r.title, r.content);
     if let Some(notes) = &r.notes {
         text.push_str("\n\n");
         text.push_str(notes);
@@ -86,11 +88,11 @@ pub fn prepare_runbook_text(r: &Runbook) -> String {
 }
 
 pub fn prepare_knowledge_text(k: &Knowledge) -> String {
-    format!("{}\n\n{}", k.title, k.content)
+    format!("{}\n{}\n\n{}", k.title, k.title, k.content)
 }
 
 pub fn prepare_incident_text(i: &Incident) -> String {
-    let mut text = i.title.clone();
+    let mut text = format!("{}\n{}", i.title, i.title);
     if let Some(symptoms) = &i.symptoms {
         text.push_str("\n\nSymptoms: ");
         text.push_str(symptoms);
@@ -111,7 +113,7 @@ pub fn prepare_incident_text(i: &Incident) -> String {
 }
 
 pub fn prepare_handoff_text(h: &Handoff) -> String {
-    format!("{}\n\n{}", h.title, h.body)
+    format!("{}\n{}\n\n{}", h.title, h.title, h.body)
 }
 
 #[cfg(test)]
@@ -165,7 +167,7 @@ mod tests {
         };
 
         let text = prepare_runbook_text(&runbook);
-        assert_eq!(text, "Title\n\nContent");
+        assert_eq!(text, "Title\nTitle\n\nContent");
     }
 
     #[test]
@@ -183,7 +185,10 @@ mod tests {
         };
 
         let text = prepare_knowledge_text(&knowledge);
-        assert_eq!(text, "VPN Setup Guide\n\nConfigure WireGuard tunnel");
+        assert_eq!(
+            text,
+            "VPN Setup Guide\nVPN Setup Guide\n\nConfigure WireGuard tunnel"
+        );
     }
 
     #[test]
@@ -241,7 +246,7 @@ mod tests {
         };
 
         let text = prepare_incident_text(&incident);
-        assert_eq!(text, "Minor Issue");
+        assert_eq!(text, "Minor Issue\nMinor Issue");
     }
 
     #[test]
@@ -263,7 +268,7 @@ mod tests {
         let text = prepare_handoff_text(&handoff);
         assert_eq!(
             text,
-            "Continue DNS migration\n\nNeed to update remaining A records"
+            "Continue DNS migration\nContinue DNS migration\n\nNeed to update remaining A records"
         );
     }
 }

--- a/src/repo/embedding_repo.rs
+++ b/src/repo/embedding_repo.rs
@@ -66,8 +66,8 @@ pub async fn store_handoff_embedding(
 }
 
 // ===== HYBRID RRF SEARCH =====
-// Combines FTS (plainto_tsquery) with vector cosine similarity via Reciprocal Rank Fusion.
-// Falls back to FTS-only when query_embedding is None.
+// Combines FTS (websearch_to_tsquery) with vector cosine similarity via Reciprocal Rank Fusion.
+// Falls back to FTS-only (with OR relaxation) when query_embedding is None.
 
 pub async fn hybrid_search_runbooks(
     pool: &PgPool,
@@ -80,9 +80,9 @@ pub async fn hybrid_search_runbooks(
             let vec = Vector::from(emb.to_vec());
             sqlx::query_as::<_, Runbook>(
                 "WITH fts AS (
-                    SELECT id, ROW_NUMBER() OVER (ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC) AS rank
+                    SELECT id, ROW_NUMBER() OVER (ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC) AS rank
                     FROM runbooks
-                    WHERE search_vector @@ plainto_tsquery('english', $1)
+                    WHERE search_vector @@ websearch_to_tsquery('english', $1)
                     LIMIT 50
                 ),
                 vec AS (
@@ -108,16 +108,33 @@ pub async fn hybrid_search_runbooks(
             .await
         }
         None => {
-            sqlx::query_as::<_, Runbook>(
+            let results = sqlx::query_as::<_, Runbook>(
                 "SELECT * FROM runbooks
-                 WHERE search_vector @@ plainto_tsquery('english', $1)
-                 ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+                 WHERE search_vector @@ websearch_to_tsquery('english', $1)
+                 ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
                  LIMIT $2",
             )
             .bind(query_text)
             .bind(limit)
             .fetch_all(pool)
-            .await
+            .await?;
+
+            if results.is_empty() {
+                if let Some(or_text) = super::build_or_tsquery_text(query_text) {
+                    return sqlx::query_as::<_, Runbook>(
+                        "SELECT * FROM runbooks
+                         WHERE search_vector @@ to_tsquery('english', $1)
+                         ORDER BY ts_rank(search_vector, to_tsquery('english', $1)) DESC
+                         LIMIT $2",
+                    )
+                    .bind(&or_text)
+                    .bind(limit)
+                    .fetch_all(pool)
+                    .await;
+                }
+            }
+
+            Ok(results)
         }
     }
 }
@@ -133,9 +150,9 @@ pub async fn hybrid_search_knowledge(
             let vec = Vector::from(emb.to_vec());
             sqlx::query_as::<_, Knowledge>(
                 "WITH fts AS (
-                    SELECT id, ROW_NUMBER() OVER (ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC) AS rank
+                    SELECT id, ROW_NUMBER() OVER (ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC) AS rank
                     FROM knowledge
-                    WHERE search_vector @@ plainto_tsquery('english', $1)
+                    WHERE search_vector @@ websearch_to_tsquery('english', $1)
                     LIMIT 50
                 ),
                 vec AS (
@@ -161,16 +178,33 @@ pub async fn hybrid_search_knowledge(
             .await
         }
         None => {
-            sqlx::query_as::<_, Knowledge>(
+            let results = sqlx::query_as::<_, Knowledge>(
                 "SELECT * FROM knowledge
-                 WHERE search_vector @@ plainto_tsquery('english', $1)
-                 ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+                 WHERE search_vector @@ websearch_to_tsquery('english', $1)
+                 ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
                  LIMIT $2",
             )
             .bind(query_text)
             .bind(limit)
             .fetch_all(pool)
-            .await
+            .await?;
+
+            if results.is_empty() {
+                if let Some(or_text) = super::build_or_tsquery_text(query_text) {
+                    return sqlx::query_as::<_, Knowledge>(
+                        "SELECT * FROM knowledge
+                         WHERE search_vector @@ to_tsquery('english', $1)
+                         ORDER BY ts_rank(search_vector, to_tsquery('english', $1)) DESC
+                         LIMIT $2",
+                    )
+                    .bind(&or_text)
+                    .bind(limit)
+                    .fetch_all(pool)
+                    .await;
+                }
+            }
+
+            Ok(results)
         }
     }
 }
@@ -186,9 +220,9 @@ pub async fn hybrid_search_incidents(
             let vec = Vector::from(emb.to_vec());
             sqlx::query_as::<_, Incident>(
                 "WITH fts AS (
-                    SELECT id, ROW_NUMBER() OVER (ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC) AS rank
+                    SELECT id, ROW_NUMBER() OVER (ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC) AS rank
                     FROM incidents
-                    WHERE search_vector @@ plainto_tsquery('english', $1)
+                    WHERE search_vector @@ websearch_to_tsquery('english', $1)
                     LIMIT 50
                 ),
                 vec AS (
@@ -214,16 +248,33 @@ pub async fn hybrid_search_incidents(
             .await
         }
         None => {
-            sqlx::query_as::<_, Incident>(
+            let results = sqlx::query_as::<_, Incident>(
                 "SELECT * FROM incidents
-                 WHERE search_vector @@ plainto_tsquery('english', $1)
-                 ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+                 WHERE search_vector @@ websearch_to_tsquery('english', $1)
+                 ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
                  LIMIT $2",
             )
             .bind(query_text)
             .bind(limit)
             .fetch_all(pool)
-            .await
+            .await?;
+
+            if results.is_empty() {
+                if let Some(or_text) = super::build_or_tsquery_text(query_text) {
+                    return sqlx::query_as::<_, Incident>(
+                        "SELECT * FROM incidents
+                         WHERE search_vector @@ to_tsquery('english', $1)
+                         ORDER BY ts_rank(search_vector, to_tsquery('english', $1)) DESC
+                         LIMIT $2",
+                    )
+                    .bind(&or_text)
+                    .bind(limit)
+                    .fetch_all(pool)
+                    .await;
+                }
+            }
+
+            Ok(results)
         }
     }
 }
@@ -239,9 +290,9 @@ pub async fn hybrid_search_handoffs(
             let vec = Vector::from(emb.to_vec());
             sqlx::query_as::<_, Handoff>(
                 "WITH fts AS (
-                    SELECT id, ROW_NUMBER() OVER (ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC) AS rank
+                    SELECT id, ROW_NUMBER() OVER (ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC) AS rank
                     FROM handoffs
-                    WHERE search_vector @@ plainto_tsquery('english', $1)
+                    WHERE search_vector @@ websearch_to_tsquery('english', $1)
                     LIMIT 50
                 ),
                 vec AS (
@@ -267,16 +318,33 @@ pub async fn hybrid_search_handoffs(
             .await
         }
         None => {
-            sqlx::query_as::<_, Handoff>(
+            let results = sqlx::query_as::<_, Handoff>(
                 "SELECT * FROM handoffs
-                 WHERE search_vector @@ plainto_tsquery('english', $1)
-                 ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+                 WHERE search_vector @@ websearch_to_tsquery('english', $1)
+                 ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
                  LIMIT $2",
             )
             .bind(query_text)
             .bind(limit)
             .fetch_all(pool)
-            .await
+            .await?;
+
+            if results.is_empty() {
+                if let Some(or_text) = super::build_or_tsquery_text(query_text) {
+                    return sqlx::query_as::<_, Handoff>(
+                        "SELECT * FROM handoffs
+                         WHERE search_vector @@ to_tsquery('english', $1)
+                         ORDER BY ts_rank(search_vector, to_tsquery('english', $1)) DESC
+                         LIMIT $2",
+                    )
+                    .bind(&or_text)
+                    .bind(limit)
+                    .fetch_all(pool)
+                    .await;
+                }
+            }
+
+            Ok(results)
         }
     }
 }

--- a/src/repo/knowledge_repo.rs
+++ b/src/repo/knowledge_repo.rs
@@ -117,14 +117,31 @@ pub async fn search_knowledge(
     query: &str,
     limit: i64,
 ) -> Result<Vec<Knowledge>, sqlx::Error> {
-    sqlx::query_as::<_, Knowledge>(
+    let results = sqlx::query_as::<_, Knowledge>(
         "SELECT * FROM knowledge
-         WHERE search_vector @@ plainto_tsquery('english', $1)
-         ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+         WHERE search_vector @@ websearch_to_tsquery('english', $1)
+         ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
          LIMIT $2",
     )
     .bind(query)
     .bind(limit)
     .fetch_all(pool)
-    .await
+    .await?;
+
+    if results.is_empty() {
+        if let Some(or_text) = super::build_or_tsquery_text(query) {
+            return sqlx::query_as::<_, Knowledge>(
+                "SELECT * FROM knowledge
+                 WHERE search_vector @@ to_tsquery('english', $1)
+                 ORDER BY ts_rank(search_vector, to_tsquery('english', $1)) DESC
+                 LIMIT $2",
+            )
+            .bind(&or_text)
+            .bind(limit)
+            .fetch_all(pool)
+            .await;
+        }
+    }
+
+    Ok(results)
 }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -1,3 +1,24 @@
+/// Build an OR-joined tsquery string for FTS fallback.
+/// Returns None if query has <2 words (OR is pointless with 0-1 words).
+/// Used when AND-based websearch_to_tsquery returns zero results.
+pub(crate) fn build_or_tsquery_text(query: &str) -> Option<String> {
+    let words: Vec<String> = query
+        .split_whitespace()
+        .map(|w| {
+            w.chars()
+                .filter(|c| c.is_alphanumeric() || *c == '-')
+                .collect::<String>()
+        })
+        .filter(|w| !w.is_empty() && w != "-")
+        .collect();
+
+    if words.len() < 2 {
+        return None;
+    }
+
+    Some(words.join(" | "))
+}
+
 pub mod audit_log_repo;
 pub mod briefing_repo;
 pub mod client_repo;
@@ -17,3 +38,47 @@ pub mod site_repo;
 pub mod suggest_repo;
 pub mod ticket_link_repo;
 pub mod vendor_repo;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn or_tsquery_multi_word() {
+        assert_eq!(
+            build_or_tsquery_text("disk space running low"),
+            Some("disk | space | running | low".to_string())
+        );
+    }
+
+    #[test]
+    fn or_tsquery_single_word_returns_none() {
+        assert_eq!(build_or_tsquery_text("backup"), None);
+    }
+
+    #[test]
+    fn or_tsquery_empty_returns_none() {
+        assert_eq!(build_or_tsquery_text(""), None);
+    }
+
+    #[test]
+    fn or_tsquery_strips_special_chars() {
+        assert_eq!(
+            build_or_tsquery_text("how do we handle (disk) space?"),
+            Some("how | do | we | handle | disk | space".to_string())
+        );
+    }
+
+    #[test]
+    fn or_tsquery_preserves_hyphens() {
+        assert_eq!(
+            build_or_tsquery_text("cross-client safe"),
+            Some("cross-client | safe".to_string())
+        );
+    }
+
+    #[test]
+    fn or_tsquery_bare_punctuation_filtered() {
+        assert_eq!(build_or_tsquery_text("- --"), None);
+    }
+}

--- a/src/repo/search_repo.rs
+++ b/src/repo/search_repo.rs
@@ -34,8 +34,8 @@ pub async fn search_inventory(
     let (servers, services, runbooks, knowledge, incidents, handoffs) = tokio::try_join!(
         sqlx::query_as::<_, Server>(
             "SELECT * FROM servers
-             WHERE status != 'deleted' AND search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE status != 'deleted' AND search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -43,8 +43,8 @@ pub async fn search_inventory(
         .fetch_all(pool),
         sqlx::query_as::<_, Service>(
             "SELECT * FROM services
-             WHERE status != 'deleted' AND search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE status != 'deleted' AND search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -52,8 +52,8 @@ pub async fn search_inventory(
         .fetch_all(pool),
         sqlx::query_as::<_, Runbook>(
             "SELECT * FROM runbooks
-             WHERE search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -61,8 +61,8 @@ pub async fn search_inventory(
         .fetch_all(pool),
         sqlx::query_as::<_, Knowledge>(
             "SELECT * FROM knowledge
-             WHERE search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -70,8 +70,8 @@ pub async fn search_inventory(
         .fetch_all(pool),
         sqlx::query_as::<_, Incident>(
             "SELECT * FROM incidents
-             WHERE search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -79,8 +79,8 @@ pub async fn search_inventory(
         .fetch_all(pool),
         sqlx::query_as::<_, Handoff>(
             "SELECT * FROM handoffs
-             WHERE search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -91,8 +91,8 @@ pub async fn search_inventory(
     let (vendors, clients, sites, networks) = tokio::try_join!(
         sqlx::query_as::<_, Vendor>(
             "SELECT * FROM vendors
-             WHERE status != 'deleted' AND search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE status != 'deleted' AND search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -100,8 +100,8 @@ pub async fn search_inventory(
         .fetch_all(pool),
         sqlx::query_as::<_, Client>(
             "SELECT * FROM clients
-             WHERE search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -109,8 +109,8 @@ pub async fn search_inventory(
         .fetch_all(pool),
         sqlx::query_as::<_, Site>(
             "SELECT * FROM sites
-             WHERE search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -118,8 +118,8 @@ pub async fn search_inventory(
         .fetch_all(pool),
         sqlx::query_as::<_, Network>(
             "SELECT * FROM networks
-             WHERE search_vector @@ plainto_tsquery('english', $1)
-             ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+             WHERE search_vector @@ websearch_to_tsquery('english', $1)
+             ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
              LIMIT $2"
         )
         .bind(query)
@@ -146,14 +146,31 @@ pub async fn search_runbooks(
     query: &str,
     limit: i64,
 ) -> Result<Vec<Runbook>, sqlx::Error> {
-    sqlx::query_as::<_, Runbook>(
+    let results = sqlx::query_as::<_, Runbook>(
         "SELECT * FROM runbooks
-         WHERE search_vector @@ plainto_tsquery('english', $1)
-         ORDER BY ts_rank(search_vector, plainto_tsquery('english', $1)) DESC
+         WHERE search_vector @@ websearch_to_tsquery('english', $1)
+         ORDER BY ts_rank(search_vector, websearch_to_tsquery('english', $1)) DESC
          LIMIT $2",
     )
     .bind(query)
     .bind(limit)
     .fetch_all(pool)
-    .await
+    .await?;
+
+    if results.is_empty() {
+        if let Some(or_text) = super::build_or_tsquery_text(query) {
+            return sqlx::query_as::<_, Runbook>(
+                "SELECT * FROM runbooks
+                 WHERE search_vector @@ to_tsquery('english', $1)
+                 ORDER BY ts_rank(search_vector, to_tsquery('english', $1)) DESC
+                 LIMIT $2",
+            )
+            .bind(&or_text)
+            .bind(limit)
+            .fetch_all(pool)
+            .await;
+        }
+    }
+
+    Ok(results)
 }


### PR DESCRIPTION
## Summary
- **websearch_to_tsquery** replaces `plainto_tsquery` in all 40 FTS call sites — adds support for quoted phrases, `or`, and `-exclusion` while keeping AND default behavior for plain queries
- **OR fallback** for FTS-only paths: when AND returns zero results and query has 2+ words, retries with OR-joined terms via `to_tsquery` — fixes natural language queries like "how do we handle disk space running low" that previously returned nothing
- **Title boosting** in embedding prep: repeats title in `prepare_*_text()` so vector search gives stronger weight to title-matching queries

## Files changed (5 files, +234/-62)
- `src/repo/mod.rs` — `build_or_tsquery_text()` helper + 6 unit tests
- `src/repo/embedding_repo.rs` — websearch_to_tsquery swap + OR fallback in 4 FTS-only branches
- `src/repo/knowledge_repo.rs` — websearch_to_tsquery swap + OR fallback
- `src/repo/search_repo.rs` — websearch_to_tsquery swap in all search_inventory queries + OR fallback for search_runbooks
- `src/embeddings.rs` — title repeated in 4 prepare_*_text() functions + tests updated

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test` — 103 unit + 24 integration tests pass
- [ ] CI green (fmt + clippy + test + security audit)
- [ ] After deploy: run `backfill_embeddings` to regenerate vectors with boosted titles
- [ ] Verify `search_knowledge` with a natural language query returns results (OR fallback)
- [ ] Verify `search_knowledge` with quoted phrase returns phrase matches (websearch_to_tsquery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)