### PR TITLE
feat: runbook staleness, duplicate detection, global compact pref

### DIFF
--- a/migrations/20260327300001_staleness_preferences_backlog.sql
+++ b/migrations/20260327300001_staleness_preferences_backlog.sql
@@ -1,0 +1,16 @@
+-- Backlog improvements: runbook staleness tracking + global preferences
+
+-- 1. Runbook staleness tracking
+-- last_verified_at is set when log_runbook_execution records a successful execution.
+-- NULL means "never verified" — useful for detecting stale runbooks.
+ALTER TABLE runbooks ADD COLUMN IF NOT EXISTS last_verified_at TIMESTAMPTZ;
+
+-- 2. Preferences table for global/machine/client-scoped defaults
+-- Allows CCs to set defaults (e.g. compact=true) that all tools respect.
+CREATE TABLE IF NOT EXISTS preferences (
+    scope TEXT NOT NULL,       -- 'global', 'machine:stealth', 'client:hsr'
+    key TEXT NOT NULL,         -- e.g. 'compact'
+    value JSONB NOT NULL,      -- e.g. true
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (scope, key)
+);

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -137,6 +137,7 @@ mod tests {
             notes: Some("Use RSAT tools on RDS server".to_string()),
             client_id: None,
             cross_client_safe: false,
+            last_verified_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -162,6 +163,7 @@ mod tests {
             notes: None,
             client_id: None,
             cross_client_safe: false,
+            last_verified_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod incident;
 pub mod knowledge;
 pub mod monitor;
 pub mod network;
+pub mod preference;
 pub mod runbook;
 pub mod runbook_execution;
 pub mod server;

--- a/src/models/preference.rs
+++ b/src/models/preference.rs
@@ -1,0 +1,10 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct Preference {
+    pub scope: String,
+    pub key: String,
+    pub value: serde_json::Value,
+    pub updated_at: DateTime<Utc>,
+}

--- a/src/models/runbook.rs
+++ b/src/models/runbook.rs
@@ -16,6 +16,7 @@ pub struct Runbook {
     pub notes: Option<String>,
     pub client_id: Option<Uuid>,
     pub cross_client_safe: bool,
+    pub last_verified_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/src/repo/embedding_repo.rs
+++ b/src/repo/embedding_repo.rs
@@ -381,6 +381,37 @@ pub async fn vector_search_knowledge(
     .await
 }
 
+/// Find knowledge entries similar to the given embedding within a cosine distance threshold.
+/// Returns (id, title, category, cosine_distance) for duplicate detection.
+pub async fn find_similar_knowledge(
+    pool: &PgPool,
+    query_embedding: &[f32],
+    max_distance: f64,
+    limit: i64,
+) -> Result<Vec<SimilarEntry>, sqlx::Error> {
+    let vec = Vector::from(query_embedding.to_vec());
+    sqlx::query_as::<_, SimilarEntry>(
+        "SELECT id, title, category, (embedding <=> $1)::float8 AS distance
+         FROM knowledge
+         WHERE embedding IS NOT NULL AND (embedding <=> $1) < $2
+         ORDER BY distance
+         LIMIT $3",
+    )
+    .bind(vec)
+    .bind(max_distance)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+}
+
+#[derive(Debug, sqlx::FromRow, serde::Serialize)]
+pub struct SimilarEntry {
+    pub id: Uuid,
+    pub title: String,
+    pub category: Option<String>,
+    pub distance: f64,
+}
+
 pub async fn vector_search_incidents(
     pool: &PgPool,
     query_embedding: &[f32],

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -28,6 +28,7 @@ pub mod incident_repo;
 pub mod knowledge_repo;
 pub mod monitor_repo;
 pub mod network_repo;
+pub mod preference_repo;
 pub mod runbook_execution_repo;
 pub mod runbook_repo;
 pub mod search_repo;

--- a/src/repo/preference_repo.rs
+++ b/src/repo/preference_repo.rs
@@ -1,0 +1,68 @@
+use sqlx::PgPool;
+
+use crate::models::preference::Preference;
+
+/// Get a preference by scope and key.
+pub async fn get_preference(
+    pool: &PgPool,
+    scope: &str,
+    key: &str,
+) -> Result<Option<Preference>, sqlx::Error> {
+    sqlx::query_as::<_, Preference>("SELECT * FROM preferences WHERE scope = $1 AND key = $2")
+        .bind(scope)
+        .bind(key)
+        .fetch_optional(pool)
+        .await
+}
+
+/// Set a preference (upsert). Returns the upserted row.
+pub async fn set_preference(
+    pool: &PgPool,
+    scope: &str,
+    key: &str,
+    value: &serde_json::Value,
+) -> Result<Preference, sqlx::Error> {
+    sqlx::query_as::<_, Preference>(
+        "INSERT INTO preferences (scope, key, value)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (scope, key) DO UPDATE SET value = $3, updated_at = now()
+         RETURNING *",
+    )
+    .bind(scope)
+    .bind(key)
+    .bind(value)
+    .fetch_one(pool)
+    .await
+}
+
+/// List all preferences, optionally filtered by scope.
+pub async fn list_preferences(
+    pool: &PgPool,
+    scope: Option<&str>,
+) -> Result<Vec<Preference>, sqlx::Error> {
+    match scope {
+        Some(s) => {
+            sqlx::query_as::<_, Preference>(
+                "SELECT * FROM preferences WHERE scope = $1 ORDER BY key",
+            )
+            .bind(s)
+            .fetch_all(pool)
+            .await
+        }
+        None => {
+            sqlx::query_as::<_, Preference>("SELECT * FROM preferences ORDER BY scope, key")
+                .fetch_all(pool)
+                .await
+        }
+    }
+}
+
+/// Delete a preference by scope and key. Returns true if a row was deleted.
+pub async fn delete_preference(pool: &PgPool, scope: &str, key: &str) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM preferences WHERE scope = $1 AND key = $2")
+        .bind(scope)
+        .bind(key)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}

--- a/src/repo/runbook_repo.rs
+++ b/src/repo/runbook_repo.rs
@@ -163,6 +163,34 @@ pub async fn update_runbook(
     .await
 }
 
+/// Update last_verified_at timestamp when a runbook is successfully executed.
+pub async fn update_last_verified_at(pool: &PgPool, runbook_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE runbooks SET last_verified_at = now() WHERE id = $1")
+        .bind(runbook_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// List runbooks that have never been verified or were last verified before the given threshold.
+pub async fn list_stale_runbooks(
+    pool: &PgPool,
+    stale_days: i32,
+    limit: i64,
+) -> Result<Vec<Runbook>, sqlx::Error> {
+    sqlx::query_as::<_, Runbook>(
+        "SELECT * FROM runbooks
+         WHERE last_verified_at IS NULL
+            OR last_verified_at < now() - ($1 || ' days')::interval
+         ORDER BY last_verified_at ASC NULLS FIRST
+         LIMIT $2",
+    )
+    .bind(stale_days)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+}
+
 pub async fn link_runbook_service(
     pool: &PgPool,
     runbook_id: Uuid,

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -5,7 +5,7 @@ use super::helpers::{
     compact_value, compact_vec, error_result, filter_cross_client, json_result,
     not_found_with_suggestions, section_included,
 };
-use super::shared::{build_client_lookup, get_query_embedding, log_audit_entries};
+use super::shared::{build_client_lookup, get_query_embedding, log_audit_entries, resolve_compact};
 use crate::models::handoff::Handoff;
 use crate::models::incident::Incident;
 use rmcp::model::*;
@@ -99,7 +99,7 @@ pub(crate) async fn handle_get_situational_awareness(
         return error_result("Provide at least one of: server_slug, service_slug, or client_slug");
     }
 
-    let compact = p.compact.unwrap_or(false);
+    let compact = resolve_compact(&brain.pool, p.compact, false).await;
     let sections = p.sections;
     let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
 
@@ -825,7 +825,7 @@ pub(crate) async fn handle_get_server_context(
     p: GetServerContextParams,
 ) -> CallToolResult {
     let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
-    let compact = p.compact.unwrap_or(false);
+    let compact = resolve_compact(&brain.pool, p.compact, false).await;
     let sections = p.sections;
     let mut warnings: Vec<String> = Vec::new();
 

--- a/src/tools/coordination.rs
+++ b/src/tools/coordination.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use crate::validation::deserialize_flexible_i64;
 
 use super::helpers::{error_result, json_result, not_found};
-use super::shared::{embed_and_store, get_query_embedding};
+use super::shared::{embed_and_store, get_query_embedding, resolve_compact};
 use rmcp::model::*;
 
 // ===== SESSION PARAMS =====
@@ -261,7 +261,7 @@ pub(crate) async fn handle_list_handoffs(
     p: ListHandoffsParams,
 ) -> CallToolResult {
     let limit = p.limit.unwrap_or(20);
-    let compact = p.compact.unwrap_or(true);
+    let compact = resolve_compact(&brain.pool, p.compact, true).await;
 
     if let Err(msg) = crate::validation::validate_option(
         p.status.as_deref(),
@@ -363,7 +363,7 @@ pub(crate) async fn handle_get_catchup(
         }
     };
     let limit = p.limit.unwrap_or(20);
-    let compact = p.compact.unwrap_or(true);
+    let compact = resolve_compact(&brain.pool, p.compact, true).await;
 
     let mut results = serde_json::Map::new();
 
@@ -551,6 +551,40 @@ pub(crate) async fn handle_get_catchup(
         }
     }
 
+    // Stale runbooks: not verified in 30+ days (or never verified)
+    match crate::repo::runbook_repo::list_stale_runbooks(&brain.pool, 30, 10).await {
+        Ok(stale) if !stale.is_empty() => {
+            let items: Vec<serde_json::Value> = stale
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "slug": r.slug,
+                        "title": r.title,
+                        "category": r.category,
+                        "last_verified_at": r.last_verified_at,
+                        "updated_at": r.updated_at,
+                    })
+                })
+                .collect();
+            results.insert(
+                "stale_runbooks".to_string(),
+                serde_json::json!({
+                    "count": items.len(),
+                    "threshold_days": 30,
+                    "items": items,
+                    "_tip": "Runbooks not verified in 30+ days. Use log_runbook_execution with result='success' to mark as verified.",
+                }),
+            );
+        }
+        Ok(_) => {} // no stale runbooks — don't clutter the response
+        Err(e) => {
+            results.insert(
+                "stale_runbooks_error".to_string(),
+                serde_json::Value::String(e.to_string()),
+            );
+        }
+    }
+
     results.insert("since".to_string(), serde_json::Value::String(p.since));
     if compact {
         results.insert(
@@ -564,4 +598,43 @@ pub(crate) async fn handle_get_catchup(
     }
 
     json_result(&serde_json::Value::Object(results))
+}
+
+// ===== PREFERENCE PARAMS + HANDLER =====
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetPreferenceParams {
+    /// Preference key (e.g. "compact")
+    pub key: String,
+    /// Preference value (e.g. true, false, "hybrid")
+    pub value: serde_json::Value,
+    /// Scope: "global" (default), "machine:<hostname>", or "client:<slug>"
+    pub scope: Option<String>,
+}
+
+pub(crate) async fn handle_set_preference(
+    brain: &super::OpsBrain,
+    p: SetPreferenceParams,
+) -> CallToolResult {
+    let scope = p.scope.as_deref().unwrap_or("global");
+
+    let valid_keys = ["compact"];
+    if !valid_keys.contains(&p.key.as_str()) {
+        return error_result(&format!(
+            "Unknown preference key '{}'. Valid keys: {}",
+            p.key,
+            valid_keys.join(", ")
+        ));
+    }
+
+    match crate::repo::preference_repo::set_preference(&brain.pool, scope, &p.key, &p.value).await {
+        Ok(pref) => json_result(&serde_json::json!({
+            "scope": pref.scope,
+            "key": pref.key,
+            "value": pref.value,
+            "updated_at": pref.updated_at,
+            "_tip": "This preference will be used as the default when the parameter is not explicitly set in tool calls.",
+        })),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
 }

--- a/src/tools/knowledge.rs
+++ b/src/tools/knowledge.rs
@@ -6,7 +6,9 @@ use crate::validation::deserialize_flexible_i64;
 use super::helpers::{
     error_result, filter_cross_client, json_result, not_found, not_found_with_suggestions,
 };
-use super::shared::{build_client_lookup, embed_and_store, get_query_embedding, log_audit_entries};
+use super::shared::{
+    build_client_lookup, embed_and_store, get_query_embedding, log_audit_entries, resolve_compact,
+};
 use rmcp::model::*;
 
 /// Compact a search result item: keep key metadata fields + a content snippet.
@@ -126,6 +128,8 @@ pub struct AddKnowledgeParams {
     pub client_slug: Option<String>,
     /// Allow this entry to surface in other clients' contexts (default: false)
     pub cross_client_safe: Option<bool>,
+    /// Skip duplicate detection check. Set to true if you've already seen the warning and want to create anyway.
+    pub force: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -188,6 +192,7 @@ pub(crate) async fn handle_add_knowledge(
 ) -> CallToolResult {
     let tags = p.tags.unwrap_or_default();
     let cross_client_safe = p.cross_client_safe.unwrap_or(false);
+    let force = p.force.unwrap_or(false);
 
     // Resolve optional client_slug
     let client_id = match &p.client_slug {
@@ -198,6 +203,43 @@ pub(crate) async fn handle_add_knowledge(
         },
         None => None,
     };
+
+    // Duplicate detection: compute embedding and check for similar entries
+    if !force {
+        if let Some(ref client) = brain.embedding_client {
+            let candidate_text = format!("{}\n{}\n\n{}", p.title, p.title, p.content);
+            if let Ok(embedding) = client.embed_text(&candidate_text).await {
+                // Cosine distance < 0.15 means similarity > 0.85
+                if let Ok(similar) = crate::repo::embedding_repo::find_similar_knowledge(
+                    &brain.pool,
+                    &embedding,
+                    0.15,
+                    3,
+                )
+                .await
+                {
+                    if !similar.is_empty() {
+                        let matches: Vec<serde_json::Value> = similar
+                            .iter()
+                            .map(|s| {
+                                serde_json::json!({
+                                    "id": s.id.to_string(),
+                                    "title": s.title,
+                                    "category": s.category,
+                                    "similarity": format!("{:.1}%", (1.0 - s.distance) * 100.0),
+                                })
+                            })
+                            .collect();
+                        return json_result(&serde_json::json!({
+                            "_warning": "Similar knowledge entries already exist. Set force=true to create anyway, or update the existing entry instead.",
+                            "similar_entries": matches,
+                            "your_title": p.title,
+                        }));
+                    }
+                }
+            }
+        }
+    }
 
     match crate::repo::knowledge_repo::add_knowledge(
         &brain.pool,
@@ -298,6 +340,7 @@ pub(crate) async fn handle_search_knowledge(
     let browse_mode = query_trimmed.is_empty() || query_trimmed == "*";
 
     if browse_mode {
+        let compact = resolve_compact(&brain.pool, p.compact, true).await;
         return browse_recent_entries(
             brain,
             &tables,
@@ -305,7 +348,7 @@ pub(crate) async fn handle_search_knowledge(
             p.client_slug.as_deref(),
             p.acknowledge_cross_client.unwrap_or(false),
             p.limit.unwrap_or(20),
-            p.compact.unwrap_or(true),
+            compact,
         )
         .await;
     }
@@ -342,7 +385,7 @@ pub(crate) async fn handle_search_knowledge(
     let limit = p.limit.unwrap_or(20);
 
     // Compact mode: default true for multi-table, false for single-table
-    let compact = p.compact.unwrap_or(multi_table);
+    let compact = resolve_compact(&brain.pool, p.compact, multi_table).await;
 
     // Single-table knowledge search (original behavior)
     if !multi_table {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -891,6 +891,21 @@ impl OpsBrain {
     ) -> Result<CallToolResult, McpError> {
         Ok(inventory::handle_delete_vendor(self, params.0).await)
     }
+
+    // ===== PREFERENCE TOOLS =====
+
+    #[tool(
+        name = "set_preference",
+        description = "Set a global preference that affects tool defaults. Currently supported keys: \
+        'compact' (bool) — when true, tools that accept a compact parameter will default to compact mode. \
+        Scope: 'global' (default). Explicit tool parameters always override preferences."
+    )]
+    async fn set_preference(
+        &self,
+        params: Parameters<coordination::SetPreferenceParams>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(coordination::handle_set_preference(self, params.0).await)
+    }
 }
 
 #[tool_handler]

--- a/src/tools/runbooks.rs
+++ b/src/tools/runbooks.rs
@@ -390,6 +390,18 @@ pub(crate) async fn handle_log_runbook_execution(
     .await
     {
         Ok(execution) => {
+            // Update last_verified_at on successful execution
+            if result_str == "success" {
+                if let Err(e) =
+                    crate::repo::runbook_repo::update_last_verified_at(&brain.pool, runbook.id)
+                        .await
+                {
+                    tracing::warn!(
+                        "Failed to update last_verified_at for runbook {}: {e}",
+                        runbook.id
+                    );
+                }
+            }
             let mut response = serde_json::to_value(&execution).unwrap_or_default();
             response["runbook_title"] = serde_json::Value::String(runbook.title);
             response["runbook_slug"] = serde_json::Value::String(runbook.slug);

--- a/src/tools/shared.rs
+++ b/src/tools/shared.rs
@@ -58,6 +58,17 @@ pub(crate) async fn get_query_embedding(
     }
 }
 
+/// Resolve compact preference: explicit param > global preference > default.
+pub(crate) async fn resolve_compact(pool: &PgPool, explicit: Option<bool>, default: bool) -> bool {
+    if let Some(v) = explicit {
+        return v;
+    }
+    match crate::repo::preference_repo::get_preference(pool, "global", "compact").await {
+        Ok(Some(pref)) => pref.value.as_bool().unwrap_or(default),
+        _ => default,
+    }
+}
+
 /// Build a client_id -> (slug, name) lookup from the database.
 pub(crate) async fn build_client_lookup(pool: &PgPool) -> HashMap<uuid::Uuid, (String, String)> {
     match crate::repo::client_repo::list_clients(pool).await {


### PR DESCRIPTION
## Summary
Three P3/P4 backlog improvements bundled:

- **Runbook staleness tracking**: `last_verified_at` column on runbooks. Auto-set when `log_runbook_execution` records a success. `get_catchup` now surfaces stale runbooks (>30 days unverified or never verified) with slug, title, and last verified date.

- **Duplicate knowledge detection**: `add_knowledge` computes cosine similarity against existing entries before inserting. If similarity > 85% (distance < 0.15), returns a warning with matching entries instead of creating a duplicate. `force=true` bypasses the check.

- **Global compact preference**: New `preferences` table (scope + key + JSONB value) + `set_preference` tool (72nd tool). CCs can `set_preference key=compact value=true` so all 6 compact-accepting tools default to compact mode. Explicit params always override. Uses `resolve_compact()` helper in shared.rs.

### Files changed (15)
- 1 new migration (34th), 2 new modules (preference model + repo)
- 12 modified: embeddings, models, repos, tools (context, coordination, knowledge, runbooks, shared, mod)

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean  
- [x] 107 unit tests pass
- [x] 24 integration tests pass
- [ ] Post-deploy: `backfill_embeddings` for embedding truncation fix (PR #18)
- [ ] Post-deploy: `set_preference key=compact value=true` to verify preference propagation
- [ ] Post-deploy: `get_catchup since=2026-03-01T00:00:00Z` to verify stale_runbooks section

🤖 Generated with [Claude Code](https://claude.com/claude-code)