### PR TITLE
feat: runbook-incident bi-directional linkage

### DIFF
--- a/migrations/20260327400001_add_incident_id_to_runbook_executions.sql
+++ b/migrations/20260327400001_add_incident_id_to_runbook_executions.sql
@@ -1,0 +1,5 @@
+-- Runbook-incident bi-directional linkage: track which incident
+-- prompted a runbook execution. Enables "resolved using runbook X"
+-- on incidents and "last used for incident Y" on runbooks.
+ALTER TABLE runbook_executions ADD COLUMN IF NOT EXISTS incident_id UUID REFERENCES incidents(id);
+CREATE INDEX IF NOT EXISTS idx_runbook_executions_incident_id ON runbook_executions(incident_id) WHERE incident_id IS NOT NULL;

--- a/src/models/runbook_execution.rs
+++ b/src/models/runbook_execution.rs
@@ -13,4 +13,5 @@ pub struct RunbookExecution {
     pub executed_at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
     pub client_slug: Option<String>,
+    pub incident_id: Option<Uuid>,
 }

--- a/src/repo/runbook_execution_repo.rs
+++ b/src/repo/runbook_execution_repo.rs
@@ -13,11 +13,12 @@ pub async fn log_execution(
     duration_minutes: Option<i32>,
     executed_at: Option<chrono::DateTime<chrono::Utc>>,
     client_slug: Option<&str>,
+    incident_id: Option<Uuid>,
 ) -> Result<RunbookExecution, sqlx::Error> {
     let now = executed_at.unwrap_or_else(chrono::Utc::now);
     sqlx::query_as::<_, RunbookExecution>(
-        "INSERT INTO runbook_executions (id, runbook_id, executor, result, notes, duration_minutes, executed_at, client_slug)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        "INSERT INTO runbook_executions (id, runbook_id, executor, result, notes, duration_minutes, executed_at, client_slug, incident_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
          RETURNING *",
     )
     .bind(Uuid::now_v7())
@@ -28,7 +29,23 @@ pub async fn log_execution(
     .bind(duration_minutes)
     .bind(now)
     .bind(client_slug)
+    .bind(incident_id)
     .fetch_one(pool)
+    .await
+}
+
+/// List executions linked to a specific incident.
+pub async fn list_executions_for_incident(
+    pool: &PgPool,
+    incident_id: Uuid,
+    limit: i64,
+) -> Result<Vec<RunbookExecution>, sqlx::Error> {
+    sqlx::query_as::<_, RunbookExecution>(
+        "SELECT * FROM runbook_executions WHERE incident_id = $1 ORDER BY executed_at DESC LIMIT $2",
+    )
+    .bind(incident_id)
+    .bind(limit)
+    .fetch_all(pool)
     .await
 }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -318,7 +318,9 @@ impl OpsBrain {
         name = "log_runbook_execution",
         description = "Record that a runbook was executed. Creates an audit trail entry with who ran it, \
         the result (success/failure/partial/skipped), duration, notes, and optional client_slug for \
-        HIPAA audit trails. Useful for compliance audits (e.g. 'when was the last DR test?')."
+        HIPAA audit trails. Optionally link to an incident via incident_id for bi-directional tracking \
+        (incident shows which runbooks resolved it, runbook shows which incidents it was used for). \
+        Successful executions update the runbook's last_verified_at timestamp."
     )]
     async fn log_runbook_execution(
         &self,

--- a/src/tools/runbooks.rs
+++ b/src/tools/runbooks.rs
@@ -3,7 +3,9 @@ use serde::Deserialize;
 
 use crate::validation::deserialize_flexible_i64;
 
-use super::helpers::{error_result, filter_cross_client, json_result, not_found_with_suggestions};
+use super::helpers::{
+    error_result, filter_cross_client, json_result, not_found, not_found_with_suggestions,
+};
 use super::shared::{build_client_lookup, embed_and_store, get_query_embedding, log_audit_entries};
 use rmcp::model::*;
 
@@ -88,6 +90,9 @@ pub struct LogRunbookExecutionParams {
     /// Client context for this execution (e.g. "hsr", "cpa"). For HIPAA audit trails
     /// when a cross-client runbook is executed for a specific client.
     pub client_slug: Option<String>,
+    /// Link this execution to an incident (UUID). Creates a bi-directional link:
+    /// the incident shows which runbooks were used, the runbook shows which incidents it resolved.
+    pub incident_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -377,6 +382,19 @@ pub(crate) async fn handle_log_runbook_execution(
         }
     }
 
+    // Parse and validate optional incident_id
+    let incident_id = match &p.incident_id {
+        Some(id_str) => match uuid::Uuid::parse_str(id_str) {
+            Ok(id) => match crate::repo::incident_repo::get_incident(&brain.pool, id).await {
+                Ok(Some(_)) => Some(id),
+                Ok(None) => return not_found("Incident", id_str),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            },
+            Err(_) => return error_result(&format!("Invalid incident UUID: {id_str}")),
+        },
+        None => None,
+    };
+
     match crate::repo::runbook_execution_repo::log_execution(
         &brain.pool,
         runbook.id,
@@ -386,6 +404,7 @@ pub(crate) async fn handle_log_runbook_execution(
         p.duration_minutes,
         executed_at,
         p.client_slug.as_deref(),
+        incident_id,
     )
     .await
     {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1199,6 +1199,7 @@ mod runbook_execution_tests {
             Some(45),
             None,
             Some("hsr"),
+            None,
         )
         .await
         .unwrap();
@@ -1221,6 +1222,7 @@ mod runbook_execution_tests {
             "failure",
             Some("Network issue during step 3"),
             Some(15),
+            None,
             None,
             None,
         )


### PR DESCRIPTION
## Summary
- Adds optional `incident_id` param to `log_runbook_execution` — links a runbook execution to the incident it helped resolve
- New `list_executions_for_incident()` repo function for reverse lookups (incident → runbooks used)
- Migration 35: `incident_id UUID` column + partial index on `runbook_executions`
- Incident validation: verifies incident exists before creating the link
- Updated tool description to document the new linkage + staleness behavior

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] 107 unit tests pass
- [x] 24 integration tests pass (updated for new param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)