### PR TITLE
feat: multi-instance Uptime Kuma support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,13 @@ OPS_BRAIN_EMBEDDING_URL=http://localhost:11434/v1/embeddings
 OPS_BRAIN_EMBEDDING_MODEL=nomic-embed-text
 # OPS_BRAIN_EMBEDDING_API_KEY=
 
-# Uptime Kuma monitoring (optional)
+# Uptime Kuma monitoring (optional — single instance)
 # UPTIME_KUMA_URL=http://uptime-kuma:3001
 # UPTIME_KUMA_USERNAME=
 # UPTIME_KUMA_PASSWORD=
+
+# Uptime Kuma monitoring (optional — multiple instances, takes precedence over single)
+# UPTIME_KUMA_INSTANCES='[{"name":"cloud","url":"http://uptime-kuma:3001"},{"name":"lab","url":"http://10.0.0.1:3001","username":"user","password":"pass"}]'
 
 # Watchdog (optional — requires UPTIME_KUMA_URL)
 OPS_BRAIN_WATCHDOG_ENABLED=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,10 @@ sqlx migrate info          # Show migration status
 | `OPS_BRAIN_LISTEN` | `0.0.0.0:3000` | HTTP bind address |
 | `OPS_BRAIN_AUTH_TOKEN` | (none) | Bearer token for HTTP auth |
 | `OPS_BRAIN_MIGRATE` | `true` | Run migrations on startup |
-| `UPTIME_KUMA_URL` | (none) | Uptime Kuma base URL for /metrics scraping |
-| `UPTIME_KUMA_USERNAME` | (none) | Basic auth username for /metrics (if needed) |
-| `UPTIME_KUMA_PASSWORD` | (none) | Basic auth password for /metrics (if needed) |
+| `UPTIME_KUMA_URL` | (none) | Uptime Kuma base URL for /metrics scraping (single instance) |
+| `UPTIME_KUMA_USERNAME` | (none) | Basic auth username for /metrics (single instance) |
+| `UPTIME_KUMA_PASSWORD` | (none) | Basic auth password for /metrics (single instance) |
+| `UPTIME_KUMA_INSTANCES` | (none) | Multiple Kuma instances as JSON array (takes precedence over URL). Format: `[{"name":"cloud","url":"http://..."},{"name":"lab","url":"http://..."}]` |
 | `OPS_BRAIN_EMBEDDING_URL` | `http://localhost:11434/v1/embeddings` | Embedding API URL (OpenAI-compatible) |
 | `OPS_BRAIN_EMBEDDING_MODEL` | `nomic-embed-text` | Embedding model name |
 | `OPS_BRAIN_EMBEDDING_API_KEY` | (none) | API key for embedding service (not needed for ollama) |
@@ -177,10 +178,13 @@ The most important tool. Accepts `server_slug`, `service_slug`, or `client_slug`
 ## Watchdog
 
 - **Module**: `src/watchdog.rs` — background tokio task, no new dependencies
-- **Enable**: `OPS_BRAIN_WATCHDOG_ENABLED=true` + `UPTIME_KUMA_URL` must be set
+- **Enable**: `OPS_BRAIN_WATCHDOG_ENABLED=true` + at least one Uptime Kuma instance configured
+- **Instances**: Supports multiple Uptime Kuma instances via `UPTIME_KUMA_INSTANCES` JSON env var. Falls back to single `UPTIME_KUMA_URL` for backward compat.
+- **Multi-instance naming**: When >1 instance is configured, monitor names are prefixed with `instance_name/` (e.g. `linux-lab/DC Ping`). Single instance = no prefix (backward compat).
 - **Interval**: `OPS_BRAIN_WATCHDOG_INTERVAL=60` (seconds, default 60)
 - **Behavior**:
-  - Polls Uptime Kuma `/metrics` every interval
+  - Polls all configured Uptime Kuma instances via `fetch_all_metrics()` every interval
+  - Partial failure tolerant: if one instance is unreachable, monitors from other instances are still processed
   - Tracks monitor states in memory (HashMap)
   - Detects UP→DOWN: auto-creates incident `[AUTO] Monitor DOWN: {name}` with severity from server roles, symptoms from monitor data, linked server/service from monitor mappings, suggested runbooks via semantic search
   - Detects DOWN→UP: auto-resolves the incident with TTR

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,7 +16,7 @@ use crate::zammad::ZammadConfig;
 #[derive(Clone)]
 pub struct ApiState {
     pub pool: PgPool,
-    pub kuma_config: Option<UptimeKumaConfig>,
+    pub kuma_configs: Vec<UptimeKumaConfig>,
     pub zammad_config: Option<ZammadConfig>,
 }
 
@@ -56,7 +56,7 @@ pub async fn generate_briefing(
 
     match generate_briefing_inner(
         &state.pool,
-        &state.kuma_config,
+        &state.kuma_configs,
         &state.zammad_config,
         &briefing_type,
         client.as_ref(),
@@ -71,7 +71,7 @@ pub async fn generate_briefing(
 /// Core briefing generation logic shared between the MCP tool and the REST API.
 pub async fn generate_briefing_inner(
     pool: &PgPool,
-    kuma_config: &Option<UptimeKumaConfig>,
+    kuma_configs: &[UptimeKumaConfig],
     zammad_config: &Option<ZammadConfig>,
     briefing_type: &str,
     client: Option<&crate::models::client::Client>,
@@ -81,8 +81,8 @@ pub async fn generate_briefing_inner(
     let client_name = client.map(|c| c.name.as_str()).unwrap_or("All Clients");
 
     // ── Monitoring ──
-    let monitoring_data = if let Some(kuma) = kuma_config {
-        match crate::metrics::fetch_metrics(kuma).await {
+    let monitoring_data = if !kuma_configs.is_empty() {
+        match crate::metrics::fetch_all_metrics(kuma_configs).await {
             Ok(summary) => {
                 let down_names: Vec<String> = summary
                     .monitors

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,17 +23,23 @@ pub struct Config {
     #[arg(long, env = "OPS_BRAIN_MIGRATE", default_value = "true")]
     pub migrate: bool,
 
-    /// Uptime Kuma base URL for metrics scraping (e.g. http://uptime-kuma:3001 or https://uptime.example.com)
+    /// Uptime Kuma base URL for metrics scraping (e.g. http://uptime-kuma:3001 or https://uptime.example.com).
+    /// For a single instance. Use UPTIME_KUMA_INSTANCES for multiple instances.
     #[arg(long, env = "UPTIME_KUMA_URL")]
     pub uptime_kuma_url: Option<String>,
 
-    /// Optional basic auth username for Uptime Kuma /metrics endpoint
+    /// Optional basic auth username for Uptime Kuma /metrics endpoint (single-instance mode)
     #[arg(long, env = "UPTIME_KUMA_USERNAME")]
     pub uptime_kuma_username: Option<String>,
 
-    /// Optional basic auth password for Uptime Kuma /metrics endpoint
+    /// Optional basic auth password for Uptime Kuma /metrics endpoint (single-instance mode)
     #[arg(long, env = "UPTIME_KUMA_PASSWORD")]
     pub uptime_kuma_password: Option<String>,
+
+    /// Multiple Uptime Kuma instances as JSON array. Takes precedence over UPTIME_KUMA_URL.
+    /// Format: [{"name":"cloud","url":"http://kuma:3001"},{"name":"lab","url":"http://10.0.0.1:3001","username":"user","password":"pass"}]
+    #[arg(long, env = "UPTIME_KUMA_INSTANCES")]
+    pub uptime_kuma_instances: Option<String>,
 
     /// Zammad API base URL (e.g. http://zammad-railsserver:3000 or https://tickets.example.com)
     #[arg(long, env = "ZAMMAD_URL")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,14 +40,52 @@ async fn main() -> anyhow::Result<()> {
         db::run_migrations(&pool).await?;
     }
 
-    let kuma_config = config.uptime_kuma_url.as_ref().map(|url| {
-        tracing::info!("Uptime Kuma metrics configured: {}", url);
-        metrics::UptimeKumaConfig {
-            base_url: url.clone(),
-            username: config.uptime_kuma_username.clone(),
-            password: config.uptime_kuma_password.clone(),
-        }
-    });
+    let kuma_configs: Vec<metrics::UptimeKumaConfig> =
+        if let Some(ref instances_json) = config.uptime_kuma_instances {
+            // Multi-instance mode: parse JSON array
+            #[derive(serde::Deserialize)]
+            struct KumaInstance {
+                name: String,
+                url: String,
+                username: Option<String>,
+                password: Option<String>,
+            }
+            match serde_json::from_str::<Vec<KumaInstance>>(instances_json) {
+                Ok(instances) => {
+                    tracing::info!(
+                        "Uptime Kuma: {} instance(s) configured via UPTIME_KUMA_INSTANCES",
+                        instances.len()
+                    );
+                    instances
+                        .into_iter()
+                        .map(|i| {
+                            tracing::info!("  - {} → {}", i.name, i.url);
+                            metrics::UptimeKumaConfig {
+                                name: i.name,
+                                base_url: i.url,
+                                username: i.username,
+                                password: i.password,
+                            }
+                        })
+                        .collect()
+                }
+                Err(e) => {
+                    tracing::error!("Failed to parse UPTIME_KUMA_INSTANCES: {e}");
+                    vec![]
+                }
+            }
+        } else if let Some(ref url) = config.uptime_kuma_url {
+            // Single-instance mode (backward compat)
+            tracing::info!("Uptime Kuma metrics configured: {}", url);
+            vec![metrics::UptimeKumaConfig {
+                name: "default".to_string(),
+                base_url: url.clone(),
+                username: config.uptime_kuma_username.clone(),
+                password: config.uptime_kuma_password.clone(),
+            }]
+        } else {
+            vec![]
+        };
 
     let zammad_config = match (&config.zammad_url, &config.zammad_api_token) {
         (Some(url), Some(token)) => {
@@ -82,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Spawn watchdog background task if enabled and Uptime Kuma is configured
     if config.watchdog_enabled {
-        if let Some(ref kuma) = kuma_config {
+        if !kuma_configs.is_empty() {
             let watchdog_config = watchdog::WatchdogConfig {
                 interval_secs: config.watchdog_interval_secs,
                 confirm_polls: config.watchdog_confirm_polls,
@@ -93,24 +131,25 @@ async fn main() -> anyhow::Result<()> {
                 interval = watchdog_config.interval_secs,
                 confirm_polls = watchdog_config.confirm_polls,
                 cooldown_secs = watchdog_config.cooldown_secs,
+                instances = kuma_configs.len(),
                 "Starting proactive monitoring watchdog"
             );
             tokio::spawn(watchdog::run(
                 pool.clone(),
-                kuma.clone(),
+                kuma_configs.clone(),
                 embedding_client.clone(),
                 watchdog_config,
             ));
         } else {
             tracing::warn!(
-                "Watchdog enabled but UPTIME_KUMA_URL not set — watchdog will not start"
+                "Watchdog enabled but no Uptime Kuma instances configured — watchdog will not start"
             );
         }
     }
 
     let server = OpsBrain::new(
         pool.clone(),
-        kuma_config.clone(),
+        kuma_configs.clone(),
         embedding_client.clone(),
         zammad_config.clone(),
     );
@@ -132,18 +171,18 @@ async fn main() -> anyhow::Result<()> {
 
             let api_state = Arc::new(api::ApiState {
                 pool: pool.clone(),
-                kuma_config: kuma_config.clone(),
+                kuma_configs: kuma_configs.clone(),
                 zammad_config: zammad_config.clone(),
             });
 
-            let kuma_config_http = kuma_config.clone();
+            let kuma_configs_http = kuma_configs.clone();
             let embedding_client_http = embedding_client.clone();
             let zammad_config_http = zammad_config.clone();
             let mcp_service = StreamableHttpService::new(
                 move || {
                     Ok(OpsBrain::new(
                         pool.clone(),
-                        kuma_config_http.clone(),
+                        kuma_configs_http.clone(),
                         embedding_client_http.clone(),
                         zammad_config_http.clone(),
                     ))

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,6 +5,9 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Serialize)]
 pub struct MonitorStatus {
     pub name: String,
+    /// Which Uptime Kuma instance this monitor belongs to (set by fetch_all_metrics)
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub instance: String,
     pub monitor_type: String,
     pub url: String,
     pub hostname: String,
@@ -30,9 +33,11 @@ pub struct MetricsSummary {
     pub monitors: Vec<MonitorStatus>,
 }
 
-/// Configuration for connecting to Uptime Kuma
+/// Configuration for connecting to a single Uptime Kuma instance
 #[derive(Debug, Clone)]
 pub struct UptimeKumaConfig {
+    /// Instance name for display and multi-instance monitor prefixing
+    pub name: String,
     pub base_url: String,
     pub username: Option<String>,
     pub password: Option<String>,
@@ -79,6 +84,66 @@ pub async fn fetch_metrics(config: &UptimeKumaConfig) -> Result<MetricsSummary, 
     parse_prometheus_metrics(&body)
 }
 
+/// Fetch metrics from all configured Uptime Kuma instances and merge results.
+///
+/// When only one instance is configured, monitor names are returned as-is (backward compat).
+/// When multiple instances are configured, monitor names are prefixed with `instance_name/`
+/// to prevent collisions and provide clear provenance.
+///
+/// Partial failures are tolerated: if some instances are unreachable, monitors from
+/// reachable instances are still returned. Only returns an error if ALL instances fail.
+pub async fn fetch_all_metrics(configs: &[UptimeKumaConfig]) -> Result<MetricsSummary, String> {
+    if configs.is_empty() {
+        return Err("No Uptime Kuma instances configured".to_string());
+    }
+
+    let multi = configs.len() > 1;
+    let mut all_monitors: Vec<MonitorStatus> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for config in configs {
+        match fetch_metrics(config).await {
+            Ok(summary) => {
+                for mut monitor in summary.monitors {
+                    monitor.instance = config.name.clone();
+                    if multi {
+                        monitor.name = format!("{}/{}", config.name, monitor.name);
+                    }
+                    all_monitors.push(monitor);
+                }
+            }
+            Err(e) => {
+                let msg = format!("{}: {}", config.name, e);
+                tracing::warn!("Uptime Kuma instance error: {msg}");
+                errors.push(msg);
+            }
+        }
+    }
+
+    if all_monitors.is_empty() && !errors.is_empty() {
+        return Err(format!(
+            "All Uptime Kuma instances failed: {}",
+            errors.join("; ")
+        ));
+    }
+
+    all_monitors.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let up = all_monitors.iter().filter(|m| m.status == 1).count();
+    let down = all_monitors.iter().filter(|m| m.status == 0).count();
+    let pending = all_monitors.iter().filter(|m| m.status == 2).count();
+    let maintenance = all_monitors.iter().filter(|m| m.status == 3).count();
+
+    Ok(MetricsSummary {
+        total: all_monitors.len(),
+        up,
+        down,
+        pending,
+        maintenance,
+        monitors: all_monitors,
+    })
+}
+
 /// Parse Prometheus exposition format text into structured monitor data.
 ///
 /// We look for these metric families:
@@ -122,6 +187,7 @@ fn parse_prometheus_metrics(text: &str) -> Result<MetricsSummary, String> {
             let entry = monitors.entry(monitor_name.clone()).or_insert_with(|| {
                 MonitorStatus {
                     name: monitor_name,
+                    instance: String::new(),
                     monitor_type: labels.get("monitor_type").cloned().unwrap_or_default(),
                     url: labels.get("monitor_url").cloned().unwrap_or_default(),
                     hostname: labels.get("monitor_hostname").cloned().unwrap_or_default(),

--- a/src/tools/briefings.rs
+++ b/src/tools/briefings.rs
@@ -111,7 +111,7 @@ pub(crate) async fn handle_generate_briefing(
 
     match crate::api::generate_briefing_inner(
         &brain.pool,
-        &brain.kuma_config,
+        &brain.kuma_configs,
         &brain.zammad_config,
         &p.briefing_type.to_lowercase(),
         client.as_ref(),

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -543,8 +543,8 @@ pub(crate) async fn handle_get_situational_awareness(
     }
 
     // Fetch live monitoring data for linked servers/services
-    if let Some(ref kuma_config) = brain.kuma_config {
-        match crate::metrics::fetch_metrics(kuma_config).await {
+    if !brain.kuma_configs.is_empty() {
+        match crate::metrics::fetch_all_metrics(&brain.kuma_configs).await {
             Ok(metrics) => {
                 // Get monitor mappings for this server and its services
                 let mut monitor_names: std::collections::HashSet<String> =
@@ -1052,8 +1052,8 @@ pub(crate) async fn handle_get_server_context(
 
     // Fetch live monitoring data for this server and its services
     let mut monitoring: Vec<serde_json::Value> = Vec::new();
-    if let Some(ref kuma_config) = brain.kuma_config {
-        match crate::metrics::fetch_metrics(kuma_config).await {
+    if !brain.kuma_configs.is_empty() {
+        match crate::metrics::fetch_all_metrics(&brain.kuma_configs).await {
             Ok(metrics) => {
                 let mut monitor_names: std::collections::HashSet<String> =
                     std::collections::HashSet::new();

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -25,7 +25,7 @@ use crate::zammad::ZammadConfig;
 #[derive(Clone)]
 pub struct OpsBrain {
     pub(crate) pool: PgPool,
-    pub(crate) kuma_config: Option<UptimeKumaConfig>,
+    pub(crate) kuma_configs: Vec<UptimeKumaConfig>,
     pub(crate) embedding_client: Option<EmbeddingClient>,
     pub(crate) zammad_config: Option<ZammadConfig>,
     tool_router: ToolRouter<Self>,
@@ -35,13 +35,13 @@ pub struct OpsBrain {
 impl OpsBrain {
     pub fn new(
         pool: PgPool,
-        kuma_config: Option<UptimeKumaConfig>,
+        kuma_configs: Vec<UptimeKumaConfig>,
         embedding_client: Option<EmbeddingClient>,
         zammad_config: Option<ZammadConfig>,
     ) -> Self {
         Self {
             pool,
-            kuma_config,
+            kuma_configs,
             embedding_client,
             zammad_config,
             tool_router: Self::tool_router(),

--- a/src/tools/monitoring.rs
+++ b/src/tools/monitoring.rs
@@ -82,12 +82,13 @@ pub(crate) async fn handle_list_monitors(
     brain: &super::OpsBrain,
     p: ListMonitorsParams,
 ) -> CallToolResult {
-    let kuma_config = match &brain.kuma_config {
-        Some(c) => c,
-        None => return error_result("Uptime Kuma not configured (set UPTIME_KUMA_URL)"),
-    };
+    if brain.kuma_configs.is_empty() {
+        return error_result(
+            "Uptime Kuma not configured (set UPTIME_KUMA_URL or UPTIME_KUMA_INSTANCES)",
+        );
+    }
 
-    let summary = match crate::metrics::fetch_metrics(kuma_config).await {
+    let summary = match crate::metrics::fetch_all_metrics(&brain.kuma_configs).await {
         Ok(s) => s,
         Err(e) => return error_result(&format!("Failed to fetch metrics: {e}")),
     };
@@ -133,12 +134,13 @@ pub(crate) async fn handle_get_monitor_status(
     brain: &super::OpsBrain,
     p: GetMonitorStatusParams,
 ) -> CallToolResult {
-    let kuma_config = match &brain.kuma_config {
-        Some(c) => c,
-        None => return error_result("Uptime Kuma not configured (set UPTIME_KUMA_URL)"),
-    };
+    if brain.kuma_configs.is_empty() {
+        return error_result(
+            "Uptime Kuma not configured (set UPTIME_KUMA_URL or UPTIME_KUMA_INSTANCES)",
+        );
+    }
 
-    let summary = match crate::metrics::fetch_metrics(kuma_config).await {
+    let summary = match crate::metrics::fetch_all_metrics(&brain.kuma_configs).await {
         Ok(s) => s,
         Err(e) => return error_result(&format!("Failed to fetch metrics: {e}")),
     };
@@ -182,12 +184,13 @@ pub(crate) async fn handle_get_monitoring_summary(
     brain: &super::OpsBrain,
     _p: GetMonitoringSummaryParams,
 ) -> CallToolResult {
-    let kuma_config = match &brain.kuma_config {
-        Some(c) => c,
-        None => return error_result("Uptime Kuma not configured (set UPTIME_KUMA_URL)"),
-    };
+    if brain.kuma_configs.is_empty() {
+        return error_result(
+            "Uptime Kuma not configured (set UPTIME_KUMA_URL or UPTIME_KUMA_INSTANCES)",
+        );
+    }
 
-    let summary = match crate::metrics::fetch_metrics(kuma_config).await {
+    let summary = match crate::metrics::fetch_all_metrics(&brain.kuma_configs).await {
         Ok(s) => s,
         Err(e) => return error_result(&format!("Failed to fetch metrics: {e}")),
     };
@@ -384,19 +387,16 @@ pub(crate) async fn handle_check_health(
     }
 
     // Fetch live metrics
-    let kuma_config = match &brain.kuma_config {
-        Some(c) => c,
-        None => {
-            return json_result(&serde_json::json!({
-                "server": p.slug,
-                "status": "UNKNOWN",
-                "reason": "Uptime Kuma not configured (set UPTIME_KUMA_URL)",
-                "linked_monitors": linked_monitors.len(),
-            }))
-        }
-    };
+    if brain.kuma_configs.is_empty() {
+        return json_result(&serde_json::json!({
+            "server": p.slug,
+            "status": "UNKNOWN",
+            "reason": "Uptime Kuma not configured (set UPTIME_KUMA_URL or UPTIME_KUMA_INSTANCES)",
+            "linked_monitors": linked_monitors.len(),
+        }));
+    }
 
-    let summary = match crate::metrics::fetch_metrics(kuma_config).await {
+    let summary = match crate::metrics::fetch_all_metrics(&brain.kuma_configs).await {
         Ok(s) => s,
         Err(e) => return error_result(&format!("Failed to fetch metrics: {e}")),
     };

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -101,7 +101,7 @@ impl MonitorState {
 /// The watchdog background task.
 pub async fn run(
     pool: PgPool,
-    kuma_config: UptimeKumaConfig,
+    kuma_configs: Vec<UptimeKumaConfig>,
     embedding_client: Option<EmbeddingClient>,
     watchdog_config: WatchdogConfig,
 ) {
@@ -110,7 +110,9 @@ pub async fn run(
         confirm_polls = watchdog_config.confirm_polls,
         cooldown_secs = watchdog_config.cooldown_secs,
         flap_threshold = watchdog_config.flap_threshold,
-        "Watchdog started — polling every {}s (confirm: {} polls, cooldown: {}s, flap threshold: {})",
+        instances = kuma_configs.len(),
+        "Watchdog started — polling {} instance(s) every {}s (confirm: {} polls, cooldown: {}s, flap threshold: {})",
+        kuma_configs.len(),
         watchdog_config.interval_secs,
         watchdog_config.confirm_polls,
         watchdog_config.cooldown_secs,
@@ -128,7 +130,7 @@ pub async fn run(
         ))
         .await;
 
-        match metrics::fetch_metrics(&kuma_config).await {
+        match metrics::fetch_all_metrics(&kuma_configs).await {
             Ok(summary) => {
                 tracing::debug!(
                     total = summary.total,


### PR DESCRIPTION
## Summary
- Watchdog and all monitoring tools now aggregate data from multiple Uptime Kuma instances via `fetch_all_metrics()`
- Fixes the HSR monitoring blind spot: linux-lab's Uptime Kuma (18 monitors across all production services) was invisible to ops-brain
- New `UPTIME_KUMA_INSTANCES` JSON env var for multi-instance config; falls back to single `UPTIME_KUMA_URL` for backward compat
- Multi-instance prefixes monitor names with `instance_name/` to prevent collisions; single instance = no prefix (backward compat)
- Partial failure tolerant: if one Kuma instance is unreachable, monitors from other instances still process

## Files changed (11)
`metrics.rs` — `UptimeKumaConfig.name` field, `MonitorStatus.instance` field, `fetch_all_metrics()` aggregator
`config.rs` — `UPTIME_KUMA_INSTANCES` env var
`main.rs` — JSON parsing, `Vec<UptimeKumaConfig>` plumbing
`tools/mod.rs` — `OpsBrain.kuma_configs: Vec<UptimeKumaConfig>`
`watchdog.rs` — accepts Vec, polls all via `fetch_all_metrics`
`tools/monitoring.rs` — all 4 handlers updated
`tools/context.rs` — 2 usages updated (situational_awareness, server_context)
`tools/briefings.rs` + `api.rs` — briefing generation updated
`.env.example` + `CLAUDE.md` — docs

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (111 unit + 29 integration)
- [ ] Deploy to kensai-cloud with `UPTIME_KUMA_INSTANCES` pointing to both Kuma instances
- [ ] Verify `get_monitoring_summary` shows monitors from both instances
- [ ] Verify watchdog creates incidents for linux-lab monitors going DOWN

🤖 Generated with [Claude Code](https://claude.com/claude-code)