### PR TITLE
feat: staleness tracking for knowledge and services

### DIFF
--- a/migrations/20260329000002_staleness_knowledge_services.sql
+++ b/migrations/20260329000002_staleness_knowledge_services.sql
@@ -1,0 +1,4 @@
+-- Extend staleness tracking (last_verified_at) to knowledge and services.
+-- Runbooks already have this column (20260327300001).
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS last_verified_at TIMESTAMPTZ;
+ALTER TABLE services ADD COLUMN IF NOT EXISTS last_verified_at TIMESTAMPTZ;

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -201,6 +201,7 @@ mod tests {
             tags: vec![],
             client_id: None,
             cross_client_safe: false,
+            last_verified_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/src/models/knowledge.rs
+++ b/src/models/knowledge.rs
@@ -11,6 +11,7 @@ pub struct Knowledge {
     pub tags: Vec<String>,
     pub client_id: Option<Uuid>,
     pub cross_client_safe: bool,
+    pub last_verified_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/src/models/service.rs
+++ b/src/models/service.rs
@@ -12,6 +12,7 @@ pub struct Service {
     pub criticality: String,
     pub notes: Option<String>,
     pub status: String,
+    pub last_verified_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/src/repo/knowledge_repo.rs
+++ b/src/repo/knowledge_repo.rs
@@ -104,6 +104,34 @@ pub async fn update_knowledge(
     .await
 }
 
+/// Mark a knowledge entry as verified (confirms content is still accurate).
+pub async fn update_last_verified_at(pool: &PgPool, id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE knowledge SET last_verified_at = now() WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// List knowledge entries never verified or last verified before the given threshold.
+pub async fn list_stale_knowledge(
+    pool: &PgPool,
+    stale_days: i32,
+    limit: i64,
+) -> Result<Vec<Knowledge>, sqlx::Error> {
+    sqlx::query_as::<_, Knowledge>(
+        "SELECT * FROM knowledge
+         WHERE last_verified_at IS NULL
+            OR last_verified_at < now() - ($1 || ' days')::interval
+         ORDER BY last_verified_at ASC NULLS FIRST
+         LIMIT $2",
+    )
+    .bind(stale_days)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+}
+
 pub async fn delete_knowledge(pool: &PgPool, id: Uuid) -> Result<bool, sqlx::Error> {
     let result = sqlx::query("DELETE FROM knowledge WHERE id = $1")
         .bind(id)

--- a/src/repo/service_repo.rs
+++ b/src/repo/service_repo.rs
@@ -83,6 +83,35 @@ pub async fn count_service_references(
     Ok(refs)
 }
 
+/// Mark a service as verified (confirms notes/config are still accurate).
+pub async fn update_last_verified_at(pool: &PgPool, id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE services SET last_verified_at = now() WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// List services never verified or last verified before the given threshold.
+pub async fn list_stale_services(
+    pool: &PgPool,
+    stale_days: i32,
+    limit: i64,
+) -> Result<Vec<Service>, sqlx::Error> {
+    sqlx::query_as::<_, Service>(
+        "SELECT * FROM services
+         WHERE status = 'active'
+           AND (last_verified_at IS NULL
+                OR last_verified_at < now() - ($1 || ' days')::interval)
+         ORDER BY last_verified_at ASC NULLS FIRST
+         LIMIT $2",
+    )
+    .bind(stale_days)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+}
+
 pub async fn delete_service(pool: &PgPool, id: Uuid) -> Result<bool, sqlx::Error> {
     let result =
         sqlx::query("UPDATE services SET status = 'deleted', updated_at = NOW() WHERE id = $1")

--- a/src/tools/coordination.rs
+++ b/src/tools/coordination.rs
@@ -575,10 +575,78 @@ pub(crate) async fn handle_get_catchup(
                 }),
             );
         }
-        Ok(_) => {} // no stale runbooks — don't clutter the response
+        Ok(_) => {}
         Err(e) => {
             results.insert(
                 "stale_runbooks_error".to_string(),
+                serde_json::Value::String(e.to_string()),
+            );
+        }
+    }
+
+    // Stale knowledge: not verified in 60+ days (or never verified)
+    match crate::repo::knowledge_repo::list_stale_knowledge(&brain.pool, 60, 10).await {
+        Ok(stale) if !stale.is_empty() => {
+            let items: Vec<serde_json::Value> = stale
+                .iter()
+                .map(|k| {
+                    serde_json::json!({
+                        "id": k.id,
+                        "title": k.title,
+                        "category": k.category,
+                        "last_verified_at": k.last_verified_at,
+                        "updated_at": k.updated_at,
+                    })
+                })
+                .collect();
+            results.insert(
+                "stale_knowledge".to_string(),
+                serde_json::json!({
+                    "count": items.len(),
+                    "threshold_days": 60,
+                    "items": items,
+                    "_tip": "Knowledge entries not verified in 60+ days. Use update_knowledge with verified=true to confirm accuracy.",
+                }),
+            );
+        }
+        Ok(_) => {}
+        Err(e) => {
+            results.insert(
+                "stale_knowledge_error".to_string(),
+                serde_json::Value::String(e.to_string()),
+            );
+        }
+    }
+
+    // Stale services: not verified in 90+ days (or never verified)
+    match crate::repo::service_repo::list_stale_services(&brain.pool, 90, 10).await {
+        Ok(stale) if !stale.is_empty() => {
+            let items: Vec<serde_json::Value> = stale
+                .iter()
+                .map(|s| {
+                    serde_json::json!({
+                        "slug": s.slug,
+                        "name": s.name,
+                        "category": s.category,
+                        "last_verified_at": s.last_verified_at,
+                        "updated_at": s.updated_at,
+                    })
+                })
+                .collect();
+            results.insert(
+                "stale_services".to_string(),
+                serde_json::json!({
+                    "count": items.len(),
+                    "threshold_days": 90,
+                    "items": items,
+                    "_tip": "Services not verified in 90+ days. Use upsert_service with verified=true to confirm accuracy.",
+                }),
+            );
+        }
+        Ok(_) => {}
+        Err(e) => {
+            results.insert(
+                "stale_services_error".to_string(),
                 serde_json::Value::String(e.to_string()),
             );
         }

--- a/src/tools/inventory.rs
+++ b/src/tools/inventory.rs
@@ -137,6 +137,8 @@ pub struct UpsertServiceParams {
     pub description: Option<String>,
     pub criticality: Option<String>,
     pub notes: Option<String>,
+    /// Set to true to mark this service as verified (confirms notes/config are still accurate).
+    pub verified: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -712,7 +714,21 @@ pub(crate) async fn handle_upsert_service(
     )
     .await
     {
-        Ok(service) => json_result(&service),
+        Ok(service) => {
+            // Mark as verified if requested
+            if p.verified.unwrap_or(false) {
+                if let Err(e) =
+                    crate::repo::service_repo::update_last_verified_at(&brain.pool, service.id)
+                        .await
+                {
+                    tracing::warn!(
+                        "Failed to update last_verified_at for service {}: {e}",
+                        service.id
+                    );
+                }
+            }
+            json_result(&service)
+        }
         Err(e) => error_result(&format!("Database error: {e}")),
     }
 }

--- a/src/tools/knowledge.rs
+++ b/src/tools/knowledge.rs
@@ -161,6 +161,9 @@ pub struct UpdateKnowledgeParams {
     pub tags: Option<Vec<String>>,
     /// Allow this entry to surface in other clients' contexts
     pub cross_client_safe: Option<bool>,
+    /// Set to true to mark this entry as verified (confirms content is still accurate).
+    /// Sets last_verified_at to now without requiring content changes.
+    pub verified: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -277,6 +280,14 @@ pub(crate) async fn handle_update_knowledge(
         Ok(None) => return not_found("Knowledge", &p.id),
         Err(e) => return error_result(&format!("Database error: {e}")),
     };
+
+    // Mark as verified if requested
+    if p.verified.unwrap_or(false) {
+        if let Err(e) = crate::repo::knowledge_repo::update_last_verified_at(&brain.pool, id).await
+        {
+            tracing::warn!("Failed to update last_verified_at for knowledge {id}: {e}");
+        }
+    }
 
     match crate::repo::knowledge_repo::update_knowledge(
         &brain.pool,


### PR DESCRIPTION
## Summary
- Adds `last_verified_at TIMESTAMPTZ` column to `knowledge` and `services` tables (runbooks already had this)
- `update_knowledge` gains `verified: bool` param — marks entry as verified without content changes
- `upsert_service` gains `verified: bool` param — same behavior
- Catchup/briefing now surfaces stale entries at tiered thresholds: runbooks 30d, knowledge 60d, services 90d
- Repo functions: `list_stale_knowledge()`, `list_stale_services()`, `update_last_verified_at()` for both

## Context
CC-HSR assessment item #3: "Data staleness has no guardrails." The DHCP service had wrong info since seed data — no way to know how many entries are quietly wrong. This adds the guardrails.

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (111 unit + 29 integration)
- [ ] Deploy, verify columns exist
- [ ] Run catchup, verify stale entries surface (all existing entries have NULL last_verified_at)

🤖 Generated with [Claude Code](https://claude.com/claude-code)