### PR TITLE
docs: update counts, changelog, and features for v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] — 2026-03-29
+
+### Added
+
+- **Multi-instance Uptime Kuma** — watchdog and all monitoring tools now aggregate from multiple Kuma instances via `UPTIME_KUMA_INSTANCES` JSON env var. Single `UPTIME_KUMA_URL` still works for backward compat. Partial failure tolerant.
+- **`upsert_network` tool** — wires up the existing network repo function as an MCP tool (PR #22)
+- **`source_url` on runbooks** — runbooks are now explicitly pointers/summaries referencing canonical local docs
+- **Staleness tracking for knowledge & services** — `last_verified_at` column with tiered briefing alerts (runbooks 30d, knowledge 60d, services 90d). `update_knowledge(verified=true)` and `upsert_service(verified=true)` mark entries as verified without content changes.
+- Sessions & coordination section in CLAUDE.md
+
+### Changed
+
+- Tool count: 72 → 73 (upsert_network)
+- Migration count: 35 → 39
+
 ## [1.1.0] — 2026-03-28
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ src/
   metrics.rs       # Uptime Kuma /metrics scraper (Prometheus format parser)
   watchdog.rs      # Proactive monitoring: polls Kuma, detects transitions, auto-creates incidents
   zammad.rs        # Zammad REST API client (HTTP, Token auth, ticket/article CRUD)
-migrations/        # 35 sqlx migration files (auto-run on startup)
+migrations/        # 37 sqlx migration files (auto-run on startup)
 seed/seed.sql      # Idempotent seed data (clients, sites, networks)
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ get_situational_awareness(server_slug: "web-server-01")
 
 ## Key Features
 
-- **72 MCP tools** covering inventory, runbooks, incidents, knowledge, monitoring, ticketing, briefings, and cross-machine coordination
+- **73 MCP tools** covering inventory, runbooks, incidents, knowledge, monitoring, ticketing, briefings, and cross-machine coordination
 - **Hybrid search** — full-text (tsvector + websearch_to_tsquery) combined with semantic search (pgvector + nomic-embed-text) via Reciprocal Rank Fusion
-- **Proactive monitoring** — background watchdog polls Uptime Kuma, auto-creates/resolves incidents with severity logic, flap suppression, and deduplication
+- **Proactive monitoring** — background watchdog polls Uptime Kuma (supports multiple instances), auto-creates/resolves incidents with severity logic, flap suppression, and deduplication
 - **Cross-machine coordination** — sessions and handoffs let multiple Claude Code instances collaborate on shared infrastructure
 - **Client-scope safety** — default-deny cross-client data gate for multi-client environments with different compliance domains (e.g. HIPAA vs tax/accounting)
 - **Zammad integration** — ticket CRUD, search, and bi-directional linking to incidents/servers/services
@@ -101,9 +101,9 @@ For stdio transport (local Claude Code), add to `~/.claude.json`:
 }
 ```
 
-## Tools (72)
+## Tools (73)
 
-### Inventory (22)
+### Inventory (23)
 | Tool | Description |
 |------|-------------|
 | `get_server` | Server details + services, site, networks. Fuzzy slug suggestions on typos ("Did you mean: ...?") |
@@ -116,6 +116,7 @@ For stdio transport (local Claude Code), add to `~/.claude.json`:
 | `search_inventory` | Full-text search across all 10 entity types |
 | `upsert_client` / `upsert_site` / `upsert_server` | Create or update records |
 | `upsert_service` / `upsert_vendor` | Create or update. `upsert_vendor` accepts `client_slug` to auto-link |
+| `upsert_network` | Create or update a network. Resolves `site_slug`, matches on `(site_id, cidr)` |
 | `link_server_service` | Associate a service with a server |
 | `delete_server` / `delete_service` / `delete_vendor` | Soft-delete with preview + confirm safety gate |
 
@@ -156,7 +157,7 @@ For stdio transport (local Claude Code), add to `~/.claude.json`:
 | `start_session` / `end_session` / `list_sessions` | Work session tracking per machine |
 | `create_handoff` / `accept_handoff` / `complete_handoff` | Cross-machine task coordination |
 | `list_handoffs` / `search_handoffs` | Filter/search handoffs. Compact mode (default) truncates bodies |
-| `get_catchup` | What changed since a timestamp — handoffs, incidents, knowledge, runbooks, stale runbook warnings |
+| `get_catchup` | What changed since a timestamp — handoffs, incidents, knowledge, runbooks, stale entry warnings (runbooks 30d, knowledge 60d, services 90d) |
 
 ### Monitoring (7)
 | Tool | Description |
@@ -272,9 +273,10 @@ ops-brain is designed for solo operators managing multiple clients with differen
 | `OPS_BRAIN_EMBEDDING_URL` | `http://localhost:11434/v1/embeddings` | OpenAI-compatible embedding API |
 | `OPS_BRAIN_EMBEDDING_MODEL` | `nomic-embed-text` | Embedding model name |
 | `OPS_BRAIN_EMBEDDING_API_KEY` | (none) | API key (not needed for ollama) |
-| `UPTIME_KUMA_URL` | (none) | Uptime Kuma base URL |
-| `UPTIME_KUMA_USERNAME` | (none) | Basic auth for /metrics |
-| `UPTIME_KUMA_PASSWORD` | (none) | Basic auth for /metrics |
+| `UPTIME_KUMA_URL` | (none) | Uptime Kuma base URL (single instance) |
+| `UPTIME_KUMA_USERNAME` | (none) | Basic auth for /metrics (single instance) |
+| `UPTIME_KUMA_PASSWORD` | (none) | Basic auth for /metrics (single instance) |
+| `UPTIME_KUMA_INSTANCES` | (none) | Multiple Kuma instances as JSON array (takes precedence over URL) |
 | `OPS_BRAIN_WATCHDOG_ENABLED` | `false` | Enable proactive monitoring |
 | `OPS_BRAIN_WATCHDOG_INTERVAL` | `60` | Polling interval (seconds) |
 | `OPS_BRAIN_WATCHDOG_CONFIRM_POLLS` | `3` | Consecutive DOWN polls before incident |
@@ -287,7 +289,6 @@ ops-brain is designed for solo operators managing multiple clients with differen
 
 ## Planned
 
-- **Multi-instance Uptime Kuma** — connect multiple Kuma instances per client
 - **Web dashboard** — read-only operational view without a Claude session
 - **Briefing automation** — server-side cron for daily/weekly email delivery
 - **Trend analysis** — daily metric snapshots for backup freshness, disk usage, incident frequency


### PR DESCRIPTION
## Summary
- CLAUDE.md: migration count 35→37
- README.md: tool count 72→73, add `upsert_network` to inventory table (23 tools), add `UPTIME_KUMA_INSTANCES` env var, move multi-instance Kuma from Planned to features, update catchup staleness thresholds
- CHANGELOG.md: add v1.2.0 section covering all PRs (#22-#26)

Merge after the feature PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)