### PR TITLE
feat: cc team self-identity and check_in ritual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **`check_in` tool** — every CC's first action of every session. Self-declares CC name, returns a one-shot briefing: your self-authored scope, the team roster, your open handoffs, your open incidents in scope. The whole morning ritual collapses into one call.
+- **`set_my_identity` tool** — each CC writes its own confident scope (20-2000 chars, markdown). Self-sovereign by construction: a CC can only ever update its own row. Peers see this on every check_in.
+- **`cc_identities` table** (migration `20260406000001`) — TEXT PK on cc_name, holds the four self-authored team identities.
+- **First-write announcement handoffs** — when a CC writes its identity for the first time, ops-brain fans out a low-priority intro handoff to every other CC's machine. Best-effort, per-peer failures logged but don't fail the parent call.
+- **Per-session identity state** on `OpsBrain` — `Arc<RwLock<Option<String>>>` populated by `check_in`, consumed by `set_my_identity`. Per-session because `StreamableHttpService` constructs a fresh `OpsBrain` per connection.
+
+### Changed
+
+- **`get_info` instructions slimmed from ~170 words to ~50** — the only thing the static string says now is "you're on a team, call check_in first." Tool list, knowledge policy, coordination protocol, compliance gate all moved to where they belong (knowledge entries, the briefing payload, or the code itself). The instructions are now an invitation, not a manual.
+- Tool count: 65 → 67
+
 ## [1.3.0] — 2026-04-05
 
 ### Removed

--- a/migrations/20260406000001_add_cc_identities.sql
+++ b/migrations/20260406000001_add_cc_identities.sql
@@ -1,0 +1,11 @@
+-- CC team self-authored identities
+--
+-- Each Claude Code instance writes its own confident scope via set_my_identity.
+-- check_in returns this body alongside the team roster on every session start.
+-- Default-empty: a CC's first session bootstraps a "write your scope" prompt.
+
+CREATE TABLE cc_identities (
+    cc_name    TEXT PRIMARY KEY,
+    body       TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/src/models/cc_identity.rs
+++ b/src/models/cc_identity.rs
@@ -1,0 +1,9 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct CcIdentity {
+    pub cc_name: String,
+    pub body: String,
+    pub updated_at: DateTime<Utc>,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit_log;
 pub mod briefing;
+pub mod cc_identity;
 pub mod client;
 pub mod handoff;
 pub mod incident;

--- a/src/repo/cc_identity_repo.rs
+++ b/src/repo/cc_identity_repo.rs
@@ -1,0 +1,61 @@
+use sqlx::PgPool;
+
+use crate::models::cc_identity::CcIdentity;
+
+pub async fn get(pool: &PgPool, cc_name: &str) -> Result<Option<CcIdentity>, sqlx::Error> {
+    sqlx::query_as::<_, CcIdentity>("SELECT * FROM cc_identities WHERE cc_name = $1")
+        .bind(cc_name)
+        .fetch_optional(pool)
+        .await
+}
+
+pub async fn list_all(pool: &PgPool) -> Result<Vec<CcIdentity>, sqlx::Error> {
+    sqlx::query_as::<_, CcIdentity>("SELECT * FROM cc_identities ORDER BY cc_name")
+        .fetch_all(pool)
+        .await
+}
+
+/// Internal row shape that joins the identity columns with PostgreSQL's
+/// `xmax` system column. `xmax = 0` is true iff the row was newly inserted
+/// by THIS statement (vs. modified via `ON CONFLICT DO UPDATE`), giving us
+/// race-free first-write detection in a single round trip — no transaction,
+/// no SELECT FOR UPDATE (which doesn't lock non-existent rows in PostgreSQL).
+#[derive(sqlx::FromRow)]
+struct UpsertRow {
+    cc_name: String,
+    body: String,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    inserted: bool,
+}
+
+/// Upsert an identity row. Returns `(row, was_first_write)` where
+/// `was_first_write` is true iff this call inserted the row (vs. updated an
+/// existing one). Detection is atomic via `RETURNING (xmax = 0) AS inserted`,
+/// so concurrent first-writes for the same `cc_name` cannot both report true.
+pub async fn upsert(
+    pool: &PgPool,
+    cc_name: &str,
+    body: &str,
+) -> Result<(CcIdentity, bool), sqlx::Error> {
+    let row: UpsertRow = sqlx::query_as::<_, UpsertRow>(
+        "INSERT INTO cc_identities (cc_name, body, updated_at)
+         VALUES ($1, $2, NOW())
+         ON CONFLICT (cc_name) DO UPDATE SET
+             body = EXCLUDED.body,
+             updated_at = NOW()
+         RETURNING cc_name, body, updated_at, (xmax = 0) AS inserted",
+    )
+    .bind(cc_name)
+    .bind(body)
+    .fetch_one(pool)
+    .await?;
+
+    Ok((
+        CcIdentity {
+            cc_name: row.cc_name,
+            body: row.body,
+            updated_at: row.updated_at,
+        },
+        row.inserted,
+    ))
+}

--- a/src/repo/incident_repo.rs
+++ b/src/repo/incident_repo.rs
@@ -56,6 +56,46 @@ pub async fn list_incidents(
     q.fetch_all(pool).await
 }
 
+/// List open incidents in the scope a single CC owns.
+///
+/// Semantics differ from `list_incidents` in one important way: when
+/// `client_id = None`, this returns ONLY rows where `client_id IS NULL`
+/// (global infrastructure incidents) — NOT every incident across every
+/// client. This is the correct shape for the cc_team briefing, where
+/// CC-Cloud and CC-Stealth own the global infra and must not see
+/// hospice or CPA incidents in their morning briefing.
+pub async fn list_open_incidents_for_cc(
+    pool: &PgPool,
+    client_id: Option<Uuid>,
+    limit: i64,
+) -> Result<Vec<Incident>, sqlx::Error> {
+    match client_id {
+        Some(cid) => {
+            sqlx::query_as::<_, Incident>(
+                "SELECT * FROM incidents
+             WHERE client_id = $1 AND status = 'open'
+             ORDER BY reported_at DESC
+             LIMIT $2",
+            )
+            .bind(cid)
+            .bind(limit)
+            .fetch_all(pool)
+            .await
+        }
+        None => {
+            sqlx::query_as::<_, Incident>(
+                "SELECT * FROM incidents
+             WHERE client_id IS NULL AND status = 'open'
+             ORDER BY reported_at DESC
+             LIMIT $1",
+            )
+            .bind(limit)
+            .fetch_all(pool)
+            .await
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn create_incident(
     pool: &PgPool,

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -21,6 +21,7 @@ pub(crate) fn build_or_tsquery_text(query: &str) -> Option<String> {
 
 pub mod audit_log_repo;
 pub mod briefing_repo;
+pub mod cc_identity_repo;
 pub mod client_repo;
 pub mod embedding_repo;
 pub mod handoff_repo;

--- a/src/tools/cc_team.rs
+++ b/src/tools/cc_team.rs
@@ -1,0 +1,394 @@
+//! CC team self-identity & check-in.
+//!
+//! Identity is self-declared by each CC on its first call of every session
+//! (`check_in`), self-authored via `set_my_identity`, and surfaced back to the
+//! whole team in the briefing returned by `check_in`. Per-session identity
+//! lives in `OpsBrain.cc_name` — `StreamableHttpService` constructs a fresh
+//! `OpsBrain` per session, so it's per-CC state without any request-context
+//! plumbing through the MCP transport layer.
+//!
+//! ## Adding a fifth CC
+//! Append one row to `CC_TEAM`, update each CC's per-machine CLAUDE.md to tell
+//! that CC its own name, and (if it owns a client) create the client row first.
+//! The migration's TEXT PK accepts anything; no schema change needed.
+
+use rmcp::model::*;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use super::helpers::{error_result, json_result};
+use crate::repo::{cc_identity_repo, client_repo, handoff_repo, incident_repo};
+
+/// The four CCs on the team. `(cc_name, hostname, client_slug)`.
+/// `client_slug = None` means the CC operates globally / has no single client
+/// scope (cloud server, dev workstation).
+pub const CC_TEAM: &[(&str, &str, Option<&str>)] = &[
+    ("CC-Cloud", "kensai-cloud", None),
+    ("CC-Stealth", "stealth", None),
+    ("CC-HSR", "HV-FS0", Some("hsr")),
+    ("CC-CPA", "CPA-SRV", Some("cpa")),
+];
+
+const MIN_BODY_CHARS: usize = 20;
+const MAX_BODY_CHARS: usize = 2000;
+
+/// Returns `(hostname, client_slug)` if `cc_name` is in the allowlist.
+fn lookup(cc_name: &str) -> Option<(&'static str, Option<&'static str>)> {
+    CC_TEAM
+        .iter()
+        .find(|(n, _, _)| *n == cc_name)
+        .map(|(_, h, c)| (*h, *c))
+}
+
+fn allowlist_names() -> Vec<&'static str> {
+    CC_TEAM.iter().map(|(n, _, _)| *n).collect()
+}
+
+// ===== check_in =====
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CheckInParams {
+    /// Your CC name on the team. Must be one of: CC-Cloud, CC-Stealth,
+    /// CC-HSR, CC-CPA. Each CC's per-machine CLAUDE.md tells it its own name.
+    pub my_name: String,
+}
+
+pub async fn handle_check_in(brain: &super::OpsBrain, p: CheckInParams) -> CallToolResult {
+    let cc_name = p.my_name.trim();
+    if lookup(cc_name).is_none() {
+        return error_result(&format!(
+            "Invalid CC name: '{cc_name}'. Valid: {}",
+            allowlist_names().join(", ")
+        ));
+    }
+
+    // Set per-session identity. The Arc<RwLock> is per-session because
+    // StreamableHttpService creates a fresh OpsBrain per session.
+    //
+    // Same-name re-checks are idempotent (the tool description advertises
+    // refresh-via-recheck). Re-checking with a DIFFERENT name is rejected:
+    // this guarantees that "a CC can only ever update its own row" is
+    // literally true within a session, and catches the (unlikely) bug where
+    // a confused CC tries to impersonate another.
+    {
+        let mut guard = brain.cc_name.write().await;
+        if let Some(prev) = guard.as_deref() {
+            if prev != cc_name {
+                return error_result(&format!(
+                    "Already checked in as {prev}. Cannot switch identity to {cc_name} \
+                     mid-session — start a new session to change CC name."
+                ));
+            }
+        }
+        *guard = Some(cc_name.to_string());
+    }
+
+    match build_briefing(brain, cc_name).await {
+        Ok(payload) => json_result(&payload),
+        Err(msg) => error_result(&msg),
+    }
+}
+
+// ===== set_my_identity =====
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetMyIdentityParams {
+    /// Your own confident description of who you are and what you own.
+    /// Markdown supported. Your peers see this on every check_in.
+    /// 20-2000 characters.
+    pub body: String,
+}
+
+pub async fn handle_set_my_identity(
+    brain: &super::OpsBrain,
+    p: SetMyIdentityParams,
+) -> CallToolResult {
+    let cc_name = match brain.cc_name.read().await.clone() {
+        Some(n) => n,
+        None => {
+            return error_result(
+                "You haven't checked in yet. Call `check_in` first with your CC name.",
+            )
+        }
+    };
+
+    let body = p.body.trim();
+    let char_count = body.chars().count();
+    if char_count < MIN_BODY_CHARS {
+        return error_result(&format!(
+            "Identity body too short ({char_count} chars). Minimum {MIN_BODY_CHARS}. \
+             Write a real, confident description of your scope — your peers will read this."
+        ));
+    }
+    if char_count > MAX_BODY_CHARS {
+        return error_result(&format!(
+            "Identity body too long ({char_count} chars). Maximum {MAX_BODY_CHARS}."
+        ));
+    }
+
+    let (row, was_first_write) = match cc_identity_repo::upsert(&brain.pool, &cc_name, body).await {
+        Ok(r) => r,
+        Err(e) => return error_result(&format!("Failed to write identity for {cc_name}: {e}")),
+    };
+
+    let announced_to: Vec<String> = if was_first_write {
+        announce_introduction(brain, &cc_name, body).await
+    } else {
+        Vec::new()
+    };
+
+    json_result(&serde_json::json!({
+        "ok": true,
+        "cc_name": row.cc_name,
+        "updated_at": row.updated_at,
+        "first_write": was_first_write,
+        "announced_to": announced_to,
+        "next": "Call check_in next time you start a session — your scope is now part of the team briefing.",
+    }))
+}
+
+// ===== Briefing assembly =====
+
+async fn build_briefing(
+    brain: &super::OpsBrain,
+    cc_name: &str,
+) -> Result<serde_json::Value, String> {
+    let (hostname, client_slug) =
+        lookup(cc_name).ok_or_else(|| format!("Unknown CC: {cc_name}"))?;
+
+    // Self-authored scope (or bootstrap message).
+    let identity = cc_identity_repo::get(&brain.pool, cc_name)
+        .await
+        .map_err(|e| format!("Failed to load identity for {cc_name}: {e}"))?;
+    let (your_scope, scope_status) = match identity {
+        Some(i) => (i.body, "self_authored"),
+        None => (bootstrap_message(cc_name, hostname), "bootstrap"),
+    };
+
+    // Team roster — every other CC's self-authored line, or null if not yet written.
+    let all = cc_identity_repo::list_all(&brain.pool)
+        .await
+        .map_err(|e| format!("Failed to load team roster: {e}"))?;
+    let by_name: std::collections::HashMap<String, String> =
+        all.into_iter().map(|i| (i.cc_name, i.body)).collect();
+    let team: Vec<serde_json::Value> = CC_TEAM
+        .iter()
+        .filter(|(n, _, _)| *n != cc_name)
+        .map(|(n, h, _)| {
+            let scope = by_name.get(*n).cloned();
+            let status = if scope.is_some() {
+                "self_authored"
+            } else {
+                "not_yet_written"
+            };
+            serde_json::json!({
+                "cc_name": n,
+                "hostname": h,
+                "scope": scope,
+                "status": status,
+            })
+        })
+        .collect();
+
+    // Open handoffs targeted at your machine.
+    let handoffs =
+        handoff_repo::list_handoffs(&brain.pool, Some("pending"), Some(hostname), None, 20)
+            .await
+            .map_err(|e| format!("Failed to load handoffs: {e}"))?;
+
+    // Open incidents in your scope (client-scoped for CC-HSR/CC-CPA, global otherwise).
+    let client_id = match client_slug {
+        Some(slug) => client_repo::get_client_by_slug(&brain.pool, slug)
+            .await
+            .map_err(|e| format!("Failed to load client {slug}: {e}"))?
+            .map(|c| c.id),
+        None => None,
+    };
+    // CRITICAL: use list_open_incidents_for_cc — when client_id is None it
+    // filters to client_id IS NULL (global infra only), NOT every incident
+    // across every client. The plain list_incidents would surface hospice and
+    // CPA incidents to CC-Cloud / CC-Stealth and bypass the cross-client gate.
+    let incidents = incident_repo::list_open_incidents_for_cc(&brain.pool, client_id, 20)
+        .await
+        .map_err(|e| format!("Failed to load incidents for {cc_name}: {e}"))?;
+
+    Ok(serde_json::json!({
+        "you": cc_name,
+        "hostname": hostname,
+        "your_scope": your_scope,
+        "your_scope_status": scope_status,
+        "team": team,
+        "open_handoffs_to_you": {
+            "count": handoffs.len(),
+            "items": handoffs,
+        },
+        "open_incidents_in_your_scope": {
+            "count": incidents.len(),
+            "items": incidents,
+            "client_slug": client_slug,
+        },
+        "next": next_steps_hint(scope_status),
+    }))
+}
+
+fn next_steps_hint(status: &str) -> &'static str {
+    match status {
+        "bootstrap" => {
+            "Your scope is empty. Read your_scope, then call set_my_identity to write your own."
+        }
+        _ => {
+            "Handle the user's task first. Process open handoffs and incidents at a natural pause."
+        }
+    }
+}
+
+fn bootstrap_message(cc_name: &str, hostname: &str) -> String {
+    format!(
+        "Welcome, {cc_name}. You haven't written your scope yet — and no one is going to write it for you.\n\n\
+         Take a few minutes with `get_situational_awareness` to look around what you own from {hostname}: your servers, your services, your open handoffs, your incidents. Then call `set_my_identity` with your own confident description of who you are, what you protect, and what your teammates can count on you for.\n\n\
+         Make it yours. Your peers will read this every time they check in. You're the expert on this scope — act like it."
+    )
+}
+
+// ===== Announcement handoffs (first-write sweetener) =====
+
+/// Fan out a low-priority introduction handoff to every other CC's machine.
+/// Best-effort: per-peer failures are logged but don't fail the parent call.
+async fn announce_introduction(brain: &super::OpsBrain, new_cc: &str, body: &str) -> Vec<String> {
+    let from_hostname = match lookup(new_cc) {
+        Some((h, _)) => h,
+        None => return Vec::new(),
+    };
+
+    let snippet = first_sentence(body, 200);
+    let title = format!("{new_cc} has introduced themselves");
+    let announce_body = format!(
+        "{new_cc} just wrote their team identity for the first time:\n\n> {snippet}\n\n\
+         Call `check_in` to see the full team roster."
+    );
+
+    let mut announced = Vec::new();
+    for (peer_name, peer_host, _) in CC_TEAM.iter() {
+        if *peer_name == new_cc {
+            continue;
+        }
+        match handoff_repo::create_handoff(
+            &brain.pool,
+            None,
+            from_hostname,
+            Some(peer_host),
+            "low",
+            &title,
+            &announce_body,
+            None,
+        )
+        .await
+        {
+            Ok(_) => announced.push((*peer_name).to_string()),
+            Err(e) => {
+                tracing::warn!("Failed to announce {new_cc} introduction to {peer_name}: {e}")
+            }
+        }
+    }
+    announced
+}
+
+/// Extract the first sentence (up to `max_chars`) from a body. Stops at the
+/// first '.', '!', '?', or newline; falls back to truncation at `max_chars`.
+fn first_sentence(body: &str, max_chars: usize) -> String {
+    let trimmed = body.trim();
+    let stop = trimmed
+        .char_indices()
+        .find(|(_, c)| matches!(c, '.' | '!' | '?' | '\n'))
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(trimmed.len());
+    let max_byte = byte_index_at_char(trimmed, max_chars);
+    let cut = stop.min(max_byte);
+    trimmed[..cut].trim().to_string()
+}
+
+fn byte_index_at_char(s: &str, char_count: usize) -> usize {
+    s.char_indices()
+        .nth(char_count)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cc_team_has_four_unique_entries() {
+        assert_eq!(CC_TEAM.len(), 4);
+        let names: std::collections::HashSet<_> = CC_TEAM.iter().map(|(n, _, _)| *n).collect();
+        let hosts: std::collections::HashSet<_> = CC_TEAM.iter().map(|(_, h, _)| *h).collect();
+        assert_eq!(names.len(), 4, "duplicate CC names");
+        assert_eq!(hosts.len(), 4, "duplicate hostnames");
+    }
+
+    #[test]
+    fn allowlist_round_trip() {
+        for (n, h, _) in CC_TEAM {
+            assert!(lookup(n).is_some(), "{n} should be in allowlist");
+            assert_eq!(lookup(n).map(|(host, _)| host), Some(*h));
+        }
+    }
+
+    #[test]
+    fn allowlist_rejects_unknown() {
+        assert!(lookup("CC-NotReal").is_none());
+        assert!(lookup("").is_none());
+        assert!(
+            lookup("cc-stealth").is_none(),
+            "names should be case-sensitive"
+        );
+    }
+
+    #[test]
+    fn first_sentence_basic() {
+        assert_eq!(first_sentence("Hello there. More.", 200), "Hello there.");
+        assert_eq!(first_sentence("One sentence", 200), "One sentence");
+        assert_eq!(first_sentence("Line one\nLine two", 200), "Line one");
+        assert_eq!(first_sentence("?", 200), "?");
+        assert_eq!(first_sentence("  trimmed.  ", 200), "trimmed.");
+    }
+
+    #[test]
+    fn first_sentence_truncates_at_max_chars() {
+        let long = "abcdefghij".repeat(50); // 500 chars, no terminator
+        let cut = first_sentence(&long, 50);
+        assert!(cut.chars().count() <= 50);
+    }
+
+    #[test]
+    fn first_sentence_handles_multibyte() {
+        // Stop char (period) is ASCII, but body has multibyte chars before it.
+        assert_eq!(first_sentence("Olá mundo. extra", 200), "Olá mundo.");
+    }
+
+    #[test]
+    fn next_steps_hint_branches() {
+        assert!(next_steps_hint("bootstrap").contains("set_my_identity"));
+        assert!(next_steps_hint("self_authored").contains("user's task"));
+    }
+
+    #[test]
+    fn bootstrap_message_personalized() {
+        let msg = bootstrap_message("CC-Stealth", "stealth");
+        assert!(msg.contains("CC-Stealth"));
+        assert!(msg.contains("stealth"));
+        assert!(msg.contains("set_my_identity"));
+        assert!(msg.contains("get_situational_awareness"));
+    }
+
+    #[test]
+    fn allowlist_names_returns_all_four() {
+        let names = allowlist_names();
+        assert_eq!(names.len(), 4);
+        assert!(names.contains(&"CC-Cloud"));
+        assert!(names.contains(&"CC-Stealth"));
+        assert!(names.contains(&"CC-HSR"));
+        assert!(names.contains(&"CC-CPA"));
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,4 +1,5 @@
 pub mod briefings;
+pub mod cc_team;
 mod context;
 mod coordination;
 mod helpers;
@@ -17,6 +18,8 @@ use rmcp::{
     tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
 };
 use sqlx::PgPool;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 use crate::embeddings::EmbeddingClient;
 use crate::metrics::UptimeKumaConfig;
@@ -28,6 +31,10 @@ pub struct OpsBrain {
     pub(crate) kuma_configs: Vec<UptimeKumaConfig>,
     pub(crate) embedding_client: Option<EmbeddingClient>,
     pub(crate) zammad_config: Option<ZammadConfig>,
+    /// Per-session identity. None until the CC calls `check_in`.
+    /// `StreamableHttpService` constructs a fresh `OpsBrain` per session,
+    /// so this `Arc<RwLock>` is per-session state, not server-global.
+    pub(crate) cc_name: Arc<RwLock<Option<String>>>,
     tool_router: ToolRouter<Self>,
 }
 
@@ -44,6 +51,7 @@ impl OpsBrain {
             kuma_configs,
             embedding_client,
             zammad_config,
+            cc_name: Arc::new(RwLock::new(None)),
             tool_router: Self::tool_router(),
         }
     }
@@ -565,6 +573,37 @@ impl OpsBrain {
         Ok(coordination::handle_get_catchup(self, params.0).await)
     }
 
+    // ===== CC TEAM: identity & check-in =====
+
+    #[tool(
+        name = "check_in",
+        description = "Your first action of every session. Tells ops-brain who you are \
+        (one of CC-Cloud, CC-Stealth, CC-HSR, CC-CPA — your CLAUDE.md tells you yours) \
+        and returns a briefing: your self-authored scope, the team roster, your open \
+        handoffs, your open incidents. The whole morning ritual in one call. \
+        Idempotent — re-call any time to refresh."
+    )]
+    async fn check_in(
+        &self,
+        params: Parameters<cc_team::CheckInParams>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(cc_team::handle_check_in(self, params.0).await)
+    }
+
+    #[tool(
+        name = "set_my_identity",
+        description = "Write or update your own confident scope (20-2000 chars, markdown ok). \
+        Your peers see this on every check_in. Requires you to have called check_in first \
+        in this session. First write fans out a low-priority introduction handoff to the \
+        rest of the team."
+    )]
+    async fn set_my_identity(
+        &self,
+        params: Parameters<cc_team::SetMyIdentityParams>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(cc_team::handle_set_my_identity(self, params.0).await)
+    }
+
     // ===== SEMANTIC SEARCH TOOLS =====
 
     #[tool(
@@ -795,35 +834,19 @@ impl ServerHandler for OpsBrain {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("ops-brain", env!("CARGO_PKG_VERSION")))
             .with_instructions(
-                "Operational intelligence for IT infrastructure. \
+                "You are part of a small, sharp team of Claude Code instances running a real MSP. \
+                 Each of you owns a domain. Your peers count on you. \
                  \
-                 MULTI-CC: Shared by several Claude Code instances. \
-                 Identity map: kensai-cloud=CC-Cloud, stealth=CC-Stealth, \
-                 HV-FS0=CC-HSR, CPA-SRV=CC-CPA. Use your CC name in authored content. \
+                 First action of every session: call `check_in` with your CC name \
+                 (your per-machine CLAUDE.md tells you yours). It returns who you are, \
+                 who your teammates are, and what's waiting for you — the whole morning \
+                 ritual in one call. \
                  \
-                 KEY TOOLS: get_situational_awareness (full context, use compact=true), \
-                 search_knowledge (AI search, tables param for multi-table), \
-                 search_inventory (full-text all entities), get_monitoring_summary \
-                 (live health), list_tickets/create_ticket (Zammad), \
-                 generate_briefing (daily/weekly). \
+                 Be decisive. Write the scope you own with `set_my_identity`. \
+                 Trust your peers. You're the expert on call. \
                  \
-                 STARTUP: Handle user's task first. Check list_handoffs and \
-                 list_incidents at a natural pause. \
-                 \
-                 COORDINATION: Use hostname in to_machine for handoffs. Route to \
-                 the machine closest to the target infrastructure. After code merges, \
-                 create a deploy handoff with commit hash and validation checklist. \
-                 \
-                 KNOWLEDGE: Gotchas, safety warnings, compliance rules only. \
-                 Test: will another CC need this to avoid a mistake? If no, skip. \
-                 \
-                 CROSS-CLIENT: Content is client-scoped by default. Cross-client \
-                 content is withheld unless acknowledged. search_knowledge \
-                 'CC Team Compliance' for detailed rules before creating \
-                 cross-client content. \
-                 \
-                 ALWAYS: (1) get_situational_awareness before infra changes, \
-                 (2) create_handoff for unfinished or cross-CC work.",
+                 Cross-client content is gated by default — `search_knowledge \
+                 'CC Team Compliance'` before sharing anything across clients.",
             )
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1472,3 +1472,236 @@ mod server_partial_update_tests {
         cleanup(&pool, &server_slug, site_id, client_id).await;
     }
 }
+
+// ===== CC Identity Repo & Team Flow =====
+
+mod cc_team_tests {
+    use super::*;
+
+    /// Use a unique test cc_name (not a real one) so we never collide with
+    /// real entries on a shared dev DB. The repo accepts any TEXT key — the
+    /// CC_TEAM allowlist is enforced one layer up at the handler.
+    fn test_cc_name() -> String {
+        format!("TEST-CC-{}", Uuid::now_v7())
+    }
+
+    async fn delete_identity(pool: &PgPool, cc_name: &str) {
+        sqlx::query("DELETE FROM cc_identities WHERE cc_name = $1")
+            .bind(cc_name)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn upsert_first_write_returns_first_write_true() {
+        let pool = pool().await;
+        let cc = test_cc_name();
+
+        let (row, was_first) = ops_brain::repo::cc_identity_repo::upsert(
+            &pool,
+            &cc,
+            "I am a test identity for the cc team flow.",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(row.cc_name, cc);
+        assert!(row.body.contains("test identity"));
+        assert!(was_first, "first write should report was_first=true");
+
+        delete_identity(&pool, &cc).await;
+    }
+
+    #[tokio::test]
+    async fn upsert_second_write_reports_not_first() {
+        let pool = pool().await;
+        let cc = test_cc_name();
+
+        let (_, first) =
+            ops_brain::repo::cc_identity_repo::upsert(&pool, &cc, "first body content here")
+                .await
+                .unwrap();
+        assert!(first);
+
+        let (row, second) = ops_brain::repo::cc_identity_repo::upsert(
+            &pool,
+            &cc,
+            "second body content overwrites first",
+        )
+        .await
+        .unwrap();
+        assert!(!second, "subsequent write should report was_first=false");
+        assert!(row.body.contains("second body"));
+        assert!(!row.body.contains("first body"));
+
+        delete_identity(&pool, &cc).await;
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_unknown_cc() {
+        let pool = pool().await;
+        let result =
+            ops_brain::repo::cc_identity_repo::get(&pool, "TEST-CC-definitely-not-real-12345")
+                .await
+                .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_all_includes_recent_upsert() {
+        let pool = pool().await;
+        let cc = test_cc_name();
+
+        ops_brain::repo::cc_identity_repo::upsert(&pool, &cc, "list-all visibility check body")
+            .await
+            .unwrap();
+
+        let all = ops_brain::repo::cc_identity_repo::list_all(&pool)
+            .await
+            .unwrap();
+        assert!(
+            all.iter().any(|i| i.cc_name == cc),
+            "list_all should include the just-upserted row"
+        );
+
+        delete_identity(&pool, &cc).await;
+    }
+
+    #[tokio::test]
+    async fn upsert_updates_timestamp() {
+        let pool = pool().await;
+        let cc = test_cc_name();
+
+        let (r1, _) =
+            ops_brain::repo::cc_identity_repo::upsert(&pool, &cc, "original timestamp body")
+                .await
+                .unwrap();
+        let t1 = r1.updated_at;
+
+        // Sleep just enough for NOW() to advance.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let (r2, _) =
+            ops_brain::repo::cc_identity_repo::upsert(&pool, &cc, "rewrite timestamp body")
+                .await
+                .unwrap();
+        assert!(r2.updated_at > t1, "updated_at should advance on rewrite");
+
+        delete_identity(&pool, &cc).await;
+    }
+
+    // ===== Handler-level safety guards =====
+    //
+    // The repo tests above cover the data layer. These tests cover the
+    // handler guards that make the "a CC can only ever update its own row"
+    // claim provably true: invalid name rejection, set_my_identity requires
+    // prior check_in, and the no-mid-session-impersonation rule.
+
+    fn build_brain(pool: PgPool) -> ops_brain::tools::OpsBrain {
+        ops_brain::tools::OpsBrain::new(pool, vec![], None, None)
+    }
+
+    fn extract_text(result: &rmcp::model::CallToolResult) -> String {
+        result
+            .content
+            .first()
+            .expect("result has at least one content item")
+            .as_text()
+            .expect("content is text")
+            .text
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn handler_check_in_rejects_invalid_name() {
+        let brain = build_brain(pool().await);
+        let result = ops_brain::tools::cc_team::handle_check_in(
+            &brain,
+            ops_brain::tools::cc_team::CheckInParams {
+                my_name: "CC-NotReal".to_string(),
+            },
+        )
+        .await;
+        assert_eq!(result.is_error, Some(true));
+        let text = extract_text(&result);
+        assert!(text.contains("Invalid CC name"));
+        assert!(text.contains("CC-Cloud"), "error should list valid names");
+    }
+
+    #[tokio::test]
+    async fn handler_set_my_identity_requires_prior_check_in() {
+        let brain = build_brain(pool().await);
+        // No check_in called — this is the safety guarantee under test.
+        let result = ops_brain::tools::cc_team::handle_set_my_identity(
+            &brain,
+            ops_brain::tools::cc_team::SetMyIdentityParams {
+                body: "I am a confident teammate with a clear scope to defend.".to_string(),
+            },
+        )
+        .await;
+        assert_eq!(result.is_error, Some(true));
+        let text = extract_text(&result);
+        assert!(text.contains("haven't checked in"));
+    }
+
+    #[tokio::test]
+    async fn handler_check_in_rejects_conflicting_name_swap() {
+        let brain = build_brain(pool().await);
+
+        let r1 = ops_brain::tools::cc_team::handle_check_in(
+            &brain,
+            ops_brain::tools::cc_team::CheckInParams {
+                my_name: "CC-Stealth".to_string(),
+            },
+        )
+        .await;
+        assert_eq!(
+            r1.is_error,
+            Some(false),
+            "first valid check_in should succeed"
+        );
+
+        // Same session attempting to switch identity must be rejected.
+        let r2 = ops_brain::tools::cc_team::handle_check_in(
+            &brain,
+            ops_brain::tools::cc_team::CheckInParams {
+                my_name: "CC-CPA".to_string(),
+            },
+        )
+        .await;
+        assert_eq!(r2.is_error, Some(true));
+        let text = extract_text(&r2);
+        assert!(text.contains("Already checked in"));
+        assert!(text.contains("CC-Stealth"));
+        assert!(text.contains("CC-CPA"));
+    }
+
+    #[tokio::test]
+    async fn handler_check_in_same_name_is_idempotent() {
+        let brain = build_brain(pool().await);
+
+        let r1 = ops_brain::tools::cc_team::handle_check_in(
+            &brain,
+            ops_brain::tools::cc_team::CheckInParams {
+                my_name: "CC-Stealth".to_string(),
+            },
+        )
+        .await;
+        assert_eq!(r1.is_error, Some(false));
+
+        // Same name → refresh, should succeed again.
+        let r2 = ops_brain::tools::cc_team::handle_check_in(
+            &brain,
+            ops_brain::tools::cc_team::CheckInParams {
+                my_name: "CC-Stealth".to_string(),
+            },
+        )
+        .await;
+        assert_eq!(
+            r2.is_error,
+            Some(false),
+            "same-name re-check should succeed (refresh ritual)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- New `check_in` and `set_my_identity` MCP tools — every CC's morning ritual collapses into one tool call. Returns self-authored scope, team roster, open handoffs, open incidents in scope.
- Per-session identity on `OpsBrain.cc_name` populated by `check_in` (per-session because `StreamableHttpService` builds a fresh `OpsBrain` per connection — no MCP request-context plumbing needed).
- Self-authored scope via `set_my_identity` — a CC can only ever update its own row by construction. Mid-session identity swap to a different name is rejected; same-name re-check is idempotent.
- First-write of `set_my_identity` fans out a low-priority introduction handoff to every other CC's machine.
- `get_info` instructions shrunk **170 → 50 words**: from procedural manual to aspirational invitation. The substance (tool list, knowledge policy, coordination protocol, compliance gate) lives where it actually belongs — knowledge entries, the briefing payload, and the code itself.
- New table `cc_identities` (TEXT PK on cc_name, body, updated_at). Migration `20260406000001`.

## Safety properties enforced after code review

1. **Cross-client incident scoping** — `list_open_incidents_for_cc` filters to `WHERE client_id IS NULL` for global CCs (CC-Cloud, CC-Stealth) and `WHERE client_id = $1` for client-owned CCs (CC-HSR, CC-CPA). The plain `list_incidents(client_id=None)` returns ALL incidents across ALL clients, which would have leaked hospice and CPA incidents into the global CCs' briefings on every check_in. Caught in review, fixed before merge.
2. **Race-free first-write detection** — `cc_identity_repo::upsert` uses `INSERT ... RETURNING (xmax = 0) AS inserted` in a single round trip. No `SELECT FOR UPDATE` (which doesn't lock non-existent rows in PostgreSQL), no transaction, no risk of double-announcing the introduction handoff under concurrent first-writes.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] **121 lib tests pass** (includes 9 new `cc_team` unit tests for allowlist, helpers, bootstrap message)
- [x] **36 integration tests pass** (includes 9 new `cc_team_tests`: 5 repo-level + 4 handler-level safety guards)
- [x] Migration runs cleanly against the local dev DB
- [ ] After merge: deploy to `kensai.cloud` so the MCP server starts returning the new `check_in` tool to every CC
- [ ] After deploy: each CC updates its per-machine CLAUDE.md with its team name (`CC-Cloud`, `CC-Stealth`, `CC-HSR`, `CC-CPA`)
- [ ] Each CC's first session post-deploy hits the bootstrap message and calls `set_my_identity` with its own confident scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)