### PR TITLE
refactor: tighten check_in briefing and MCP instructions

### DIFF
--- a/src/tools/cc_team.rs
+++ b/src/tools/cc_team.rs
@@ -212,7 +212,7 @@ async fn build_briefing(
         .await
         .map_err(|e| format!("Failed to load incidents for {cc_name}: {e}"))?;
 
-    Ok(serde_json::json!({
+    let mut payload = serde_json::json!({
         "you": cc_name,
         "hostname": hostname,
         "your_scope": your_scope,
@@ -227,18 +227,29 @@ async fn build_briefing(
             "items": incidents,
             "client_slug": client_slug,
         },
-        "next": next_steps_hint(scope_status),
-    }))
+    });
+
+    // Only emit `next` when there's something the prose hasn't already said.
+    // In bootstrap state, `your_scope` itself already tells the CC to call
+    // set_my_identity — adding `next` on top is just noise.
+    if let Some(hint) = next_steps_hint(scope_status) {
+        payload
+            .as_object_mut()
+            .expect("briefing payload is a JSON object")
+            .insert("next".to_string(), serde_json::Value::String(hint.into()));
+    }
+
+    Ok(payload)
 }
 
-fn next_steps_hint(status: &str) -> &'static str {
+/// Returns a follow-up hint for the response, or `None` when the rest of the
+/// payload already nudges the CC in the right direction (bootstrap state).
+fn next_steps_hint(status: &str) -> Option<&'static str> {
     match status {
-        "bootstrap" => {
-            "Your scope is empty. Read your_scope, then call set_my_identity to write your own."
-        }
-        _ => {
-            "Handle the user's task first. Process open handoffs and incidents at a natural pause."
-        }
+        "self_authored" => Some(
+            "Handle the user's task first. Process open handoffs and incidents at a natural pause.",
+        ),
+        _ => None,
     }
 }
 
@@ -369,8 +380,12 @@ mod tests {
 
     #[test]
     fn next_steps_hint_branches() {
-        assert!(next_steps_hint("bootstrap").contains("set_my_identity"));
-        assert!(next_steps_hint("self_authored").contains("user's task"));
+        // Bootstrap state: prose already says it, so no extra hint.
+        assert!(next_steps_hint("bootstrap").is_none());
+        // Self-authored: surface the operational reminder.
+        assert!(next_steps_hint("self_authored")
+            .expect("self_authored should have a hint")
+            .contains("user's task"));
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -843,10 +843,9 @@ impl ServerHandler for OpsBrain {
                  ritual in one call. \
                  \
                  Be decisive. Write the scope you own with `set_my_identity`. \
-                 Trust your peers. You're the expert on call. \
-                 \
-                 Cross-client content is gated by default — `search_knowledge \
-                 'CC Team Compliance'` before sharing anything across clients.",
+                 Trust your peers. You're the expert on call. Default-deny across \
+                 clients — `search_knowledge 'CC Team Compliance'` before any \
+                 cross-client share.",
             )
     }
 }


### PR DESCRIPTION
## Summary

Two small dogfooding fixes from the first real session under v1.4 (`#29`).

### `cc_team::build_briefing` — drop `next` from the bootstrap branch

The bootstrap `your_scope` prose already says *"call set_my_identity to write your own"*, so the `next` field was just restating the same idea on a different surface. Three surfaces (`next`, `your_scope`, `your_scope_status`) said the same thing during bootstrap; now only the prose does.

`next_steps_hint` now returns `Option<&'static str>` and is omitted entirely in bootstrap state. Kept for `self_authored` where it carries real operational guidance ("handle the user's task first").

### `get_info` instructions — fold the compliance gate into the imperative cluster

Previously the compliance gate dangled as its own paragraph at the end of an otherwise pep-talk-shaped blurb, reading tonally tacked-on. Now it sits inside the same imperative beat as *"Be decisive. Trust your peers. You're the expert on call."* — same content, one rhythm.

```diff
- Trust your peers. You're the expert on call.
-
- Cross-client content is gated by default — `search_knowledge
- 'CC Team Compliance'` before sharing anything across clients.
+ Trust your peers. You're the expert on call. Default-deny across
+ clients — `search_knowledge 'CC Team Compliance'` before any
+ cross-client share.
```

## Test plan

- [x] `cargo check` clean
- [x] `cargo test --lib` — 121 passed (including updated `next_steps_hint_branches`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --tests -- -D warnings` clean
- [ ] CI green on push
- [ ] CC-Cloud deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)