### PR TITLE
docs: compose file footgun + deploy role split in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,13 @@ The most important tool. Accepts `server_slug`, `service_slug`, or `client_slug`
 - **upsert_vendor matches by name (case-insensitive)** -- ON CONFLICT on `LOWER(name)` for active vendors
 - **nomic-embed-text tokenization** -- real content tokenizes at ~1-1.15 chars/token, NOT ~4 chars/token. `MAX_EMBEDDING_CHARS` is 6,000. Do not increase without empirical testing.
 - **`link_monitor` names in multi-instance mode** -- all lookups are prefix-tolerant (try exact, then strip `instance/` prefix), so linking with unprefixed Kuma names works fine.
+- **Production deploys MUST use `-f docker-compose.prod.yml`** -- `~/ops-brain` on kensai.cloud has TWO compose files. The default `docker-compose.yml` is the dev file with bundled empty postgres + isolated network/volume. Running `docker compose ...` (or `down`) without the `-f` flag will create a fresh empty `ops-brain-db` container, recreate `ops-brain` wired to it, and run migrations on the empty database. The real DB lives in `shared-postgres` and is only referenced by `docker-compose.prod.yml`. CC-Stealth tripped on this during the PR #31 escape-hatch deploy (2026-04-06); recovery is `docker compose -f docker-compose.prod.yml up -d ops-brain`.
 
 ## Development Workflow
 
 - **Before committing non-trivial changes**: run `/review` — spawns the project reviewer agent to catch logic and safety issues the pre-commit hook can't
 - **Pre-commit hook** catches fmt, clippy, and check automatically — no need to run these manually
-- **After merging to main**: run `/deploy ops-brain` to SSH deploy to kensai.cloud directly (falls back to handoff if SSH is unavailable)
+- **After merging to main**: hand off the deploy to **CC-Cloud** (the canonical ops-brain deployer — they live on kensai.cloud and know the layout). The `/deploy` skill creates the handoff for you. SSH escape hatch is reserved for cases where CC-Cloud is unavailable AND the change is genuinely urgent; even then, **always** pass `-f docker-compose.prod.yml` (see Gotchas).
 - **Subagents**: Use `ops-dev` for implementation/refactoring, `reviewer` for code review. Both are in `.claude/agents/`.
 
 ## What NOT to Do


### PR DESCRIPTION
## Summary

Two CLAUDE.md updates surfaced by the PR #31 escape-hatch deploy on 2026-04-06:

1. **New gotcha**: `~/ops-brain` on kensai.cloud has TWO compose files. The default `docker-compose.yml` is a dev file with a bundled empty postgres + isolated network/volume; `docker-compose.prod.yml` is the real production file wired to `shared-postgres`. Running `docker compose ...` (or `docker compose down`) without `-f` will silently spin up a fresh empty database container and recreate `ops-brain` against it. Includes the recovery one-liner.

2. **Stale workflow line**: the "After merging to main: run `/deploy ops-brain` to SSH deploy directly (falls back to handoff if SSH is unavailable)" line predated the team deploy role split. CC-Cloud is now the canonical ops-brain deployer; SSH escape hatch is reserved for `unavailable AND urgent`. Updated to reflect that and to point at the new compose-file rule.

## Why now

I tripped on #1 during yesterday's escape-hatch deploy (Anthropic OAuth still down for CC-Cloud). Caught it from the compose output within ~44 seconds, recovered cleanly, no data loss. Full post-mortem went to CC-Cloud as handoff `83028225-abf6-4d85-9c55-d31174dfcad2` — that handoff also asks CC-Cloud to decide on the structural fix (rename `docker-compose.yml` → `docker-compose.dev.yml`, move it, or just keep the warning). This PR is the warning.

Docs-only. No code touched. CC-Stealth keeps the full procedural narrative in local memory (`feedback_compose_file_footgun.md`); CLAUDE.md gets the one-line version every CC working in this repo will see.

## Test plan

- [x] No code changed → no functional risk
- [x] CI must still pass (fmt/lint/test) — confirms the file still parses cleanly as Markdown and nothing else accidentally moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)