### PR TITLE
fix: harden dev docker-compose against the prod-clobber footgun

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,26 @@
-# ops-brain — Self-contained deployment for new users
-# Includes PostgreSQL with pgvector. Just run: docker compose up -d
-# Then configure Claude Code to connect via stdio or HTTP.
+# ops-brain — Self-contained development / new-user deployment
+# ============================================================================
+#  Spins up its own PostgreSQL (pgvector/pgvector:pg18). Just run:
+#    docker compose up -d
+#
+#  USE THIS FILE WHEN: you're trying ops-brain for the first time, you don't
+#  already have a PostgreSQL server, or you want a self-contained stack.
+#
+#  DO NOT USE THIS FILE WHEN: you're deploying alongside an existing
+#  PostgreSQL (e.g. shared-postgres on kensai-cloud) — use docker-compose.prod.yml
+#  with `docker compose -f docker-compose.prod.yml up -d` instead.
+#
+#  Container names are intentionally suffixed `-dev` and the project is named
+#  `ops-brain-dev` so this file cannot recreate or clobber a production
+#  `ops-brain` container, network, or volume if run by mistake.
+# ============================================================================
+
+name: ops-brain-dev
 
 services:
   postgres:
     image: pgvector/pgvector:pg18
-    container_name: ops-brain-db
+    container_name: ops-brain-dev-db
     restart: unless-stopped
     environment:
       POSTGRES_USER: ops_brain
@@ -26,7 +41,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: ops-brain
+    container_name: ops-brain-dev
     restart: unless-stopped
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary

Closes the loop on the PR #31 escape-hatch deploy footgun. CC-Cloud's post-mortem (handoff `019d642f-7b6a-7d22-8995-2587882a3ead`) called for a real guardrail rather than another \"be careful\" warning. This is that guardrail.

The risk: running the default `docker-compose.yml` on the prod host recreates the `ops-brain` container wired to a fresh empty postgres, even though the real DB lives in `shared-postgres` behind `docker-compose.prod.yml`. Docs and gotchas don't prevent the mistake.

The fix: namespace the dev stack so it **cannot** collide with prod, even if run from the wrong place.

## Changes

- **`name: ops-brain-dev`** at the top level — project namespace becomes `ops-brain-dev`, so the default network is `ops-brain-dev_default` and the volume is `ops-brain-dev_pgdata`. Fully isolated from any project named `ops-brain`.
- **`container_name`** renamed: `ops-brain` → `ops-brain-dev`, `ops-brain-db` → `ops-brain-dev-db`. A stray `docker compose up` from this file spins up *new* containers, leaving the production `ops-brain` untouched. A stray `docker compose down` only kills the dev containers.
- **Expanded header comment** with USE WHEN / DO NOT USE WHEN sections and an explicit pointer to `docker-compose.prod.yml`.

## What I deliberately did NOT do

- **Did not rename the file to `docker-compose.dev.yml`** — would break the README's \"just clone and `docker compose up -d`\" UX. The dev file exists *because* it's the default.
- **Did not move the dev file out of the repo** — same reason; new-user onboarding lives in this file.
- **Did not touch `docker-compose.prod.yml`** — production container is still `ops-brain` with the existing networks; CC-Cloud's deploy workflow is unaffected.

## Public surface

Unchanged. New users still run `docker compose up -d` and get a working stack on `localhost:3000`. The README's `docker compose exec postgres psql ...` example references the *service name* (`postgres`), not the container name, so it keeps working without edits.

## One-time wart for existing dev users

If anyone has an existing dev stack from this repo, the project rename means volumes/networks get fresh names — `ops-brain_pgdata` → `ops-brain-dev_pgdata`. After updating, the new stack starts with an empty DB. Most dev stacks have nothing of value; if someone cares about their data, they can `docker run --rm -v ops-brain_pgdata:/old -v ops-brain-dev_pgdata:/new alpine cp -a /old/. /new/` before deleting the old volume. Mentioned in the commit message.

## Test plan

- [x] `python3 -c \"import yaml; ...\"` parses cleanly: `name=ops-brain-dev`, `container_names=['ops-brain-dev-db', 'ops-brain-dev']`
- [x] `grep -rn 'container_name: ops-brain' .` shows only the prod file (production container untouched)
- [x] `grep -rn 'ops-brain-db' .` shows no remaining stale references outside `CLAUDE.md` (which describes the historical bug)
- [x] README only references service names, not container names — no doc edits needed
- [ ] CI green (CC-Cloud will deploy via the `/deploy` skill, which mandates `-f docker-compose.prod.yml` and is therefore unaffected by this change)

## Handoff

Once merged, I'll create a deploy handoff back to **CC-Cloud**. Per the role split, they own the deploy. This change does not require any prod action — `docker-compose.prod.yml` is untouched — but the merge should still ride through the normal deploy flow so CC-Cloud can confirm the new dev file is what's checked out at `~/ops-brain` on kensai.cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)