### PR TITLE
feat(runbooks): advisory warning when body is large and source_url is null

### DIFF
--- a/src/tools/runbooks.rs
+++ b/src/tools/runbooks.rs
@@ -294,8 +294,10 @@ pub(crate) async fn handle_create_runbook(
             )
             .await;
 
-            let mut value =
-                serde_json::to_value(&runbook).unwrap_or_else(|_| serde_json::json!({}));
+            let mut value = match serde_json::to_value(&runbook) {
+                Ok(v) => v,
+                Err(e) => return error_result(&format!("Serialization error: {e}")),
+            };
             if let Some(warning) = runbook_hygiene_warning(&p.content, p.source_url.as_deref()) {
                 if let Some(obj) = value.as_object_mut() {
                     obj.insert("warnings".to_string(), serde_json::json!([warning]));
@@ -349,8 +351,10 @@ pub(crate) async fn handle_update_runbook(
             // Hygiene check uses the *merged* state — caller may have only
             // updated content (leaving source_url as-is) or vice versa. The
             // returned runbook reflects what's now persisted.
-            let mut value =
-                serde_json::to_value(&updated).unwrap_or_else(|_| serde_json::json!({}));
+            let mut value = match serde_json::to_value(&updated) {
+                Ok(v) => v,
+                Err(e) => return error_result(&format!("Serialization error: {e}")),
+            };
             if let Some(warning) =
                 runbook_hygiene_warning(&updated.content, updated.source_url.as_deref())
             {


### PR DESCRIPTION
## Summary

Implements P1a of CC-HSR's runbook hygiene handoff (`019d646f-ac71-7af0-8b1e-ff8c159e4e0d`). The first HSR user offboarding runbook landed as a 340-line inlined body with no `source_url`, violating the KISS knowledge policy (\"git is canonical, ops-brain is summary + pointer\"). The drift was silent — Eduardo caught it at session end. This adds an inline guardrail so the next CC sees the advisory at the moment of mistake instead.

## What it does

When `create_runbook` or `update_runbook` is called with a body larger than 2 KiB and no `source_url` set, the response includes a `warnings` array:

\`\`\`json
{
  \"id\": \"...\",
  \"slug\": \"hsr-user-offboarding\",
  \"content\": \"... 340 lines ...\",
  \"source_url\": null,
  \"...\": \"...\",
  \"warnings\": [
    \"Runbook body is larger than 2KB but \`source_url\` is empty. Per the CC Team Contribution Standards (knowledge slug \`cc-team-contribution-standards-session-protocol\`), the canonical copy should live in a git-tracked file in the owning CC's working repo, with \`source_url\` set to that path. This ops-brain entry should be a summary (~300 words) plus the pointer, not the full procedure. The runbook was created/updated as requested — this is advisory only.\"
  ]
}
\`\`\`

The runbook is still created/updated as requested. **Advisory only**, no accept/reject change.

## Why both create AND update

CC-HSR's handoff explicitly named `create_runbook`, but the same drift mode is symmetric — a CC can just as easily update a runbook to a 5 KB body and forget the `source_url`. The cost is two extra lines of code. Wired into both for consistency. If CC-HSR pushes back I'll happily strip the update half — it's a one-line revert.

For `update_runbook` the check uses the *merged* state (the returned runbook), not just the params, since the caller may have updated only one of `content` / `source_url` and the rule is about the runbook's current persisted state.

## Implementation choices

- **Single source of truth**: `runbook_hygiene_warning(content, source_url)` is the only place the rule lives. Used by both handlers.
- **Threshold**: \`RUNBOOK_INLINE_BODY_WARN_BYTES = 2048\`, matching CC-HSR's spec exactly. Constant is in-file rather than in a config — no configurability YAGNI.
- **Whitespace-only \`source_url\` is treated as missing**. Prevents trivial bypass and matches what a CC instance would intuitively expect.
- **Response shape is additive**: only an extra \`warnings\` field on the existing runbook JSON object. Per CC-HSR's \"additions only\" constraint, no field renamed or removed. Old callers continue to work.
- **No new dependencies**, no schema/migration changes, no env vars, no config flags.

## What I deliberately did NOT do

- **Did not block** \`create_runbook\` with null \`source_url\` — CC-HSR explicitly said \"some runbooks legitimately are 'ops-brain-native' (fast one-off procedures). Warning is enough.\"
- **Did not auto-populate** \`source_url\` from heuristics — the human/CC should decide canonical location deliberately.
- **Did not change** the existing runbook API shape (renamed fields, restructured envelope, etc.).
- **Did not implement** P2 (webhook refresh endpoint) or P3 (drift detection on check_in) — both are explicitly framed as \"not urgent\" / \"too CC-specific\" in the handoff.
- **Did not update** the contribution-standards knowledge entry (P1b) in this PR. That's a pure data write to live ops-brain via \`update_knowledge\`; no code change. Will follow out of band.

## Test plan

- [x] 5 unit tests for \`runbook_hygiene_warning\`:
  - small body, no warning regardless of source_url
  - body exactly at threshold, no warning (boundary)
  - large body with valid source_url, no warning
  - large body without source_url, warns
  - large body with whitespace-only source_url, warns
- [x] \`cargo test --lib\`: 127 passed, 0 failed
- [x] \`cargo clippy --all-targets -- -D warnings\`: clean
- [x] \`cargo fmt --check\`: clean
- [ ] CI green
- [ ] CC-Cloud deploys; CC-HSR runs \`create_runbook\` with a >2KB body and null source_url to confirm the \`warnings\` field appears

## Coordination

- Stacked behind PR #33 (compose hardening). Both target main; CC-Cloud can deploy them in one go.
- I'll handle the P1b knowledge update separately once both PRs merge — it's a single \`update_knowledge\` call against live ops-brain, no PR needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)