### PR TITLE
feat(knowledge): provenance (author, source incident, staleness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Knowledge provenance: `author_cc`, `source_incident_id`, `_staleness_warning`** (migration `20260408000001`) — v1.5 established that local is the source of truth for everything *except* shared cross-CC knowledge; this release closes the provenance gap in that one shared artifact. Every new knowledge entry is stamped with its author CC at create time, optionally linked to the incident that produced it, and surfaces a read-time staleness flag when it goes >90 days without a verify.
+  - **`author_cc` is required on `add_knowledge`** — validated against the `CC_TEAM` allowlist (`CC-Cloud`, `CC-Stealth`, `CC-HSR`, `CC-CPA`). Missing or unknown names fail loudly with the full allowlist in the error. Pre-v1.6 rows stay NULL — no forced backfill, no fabricated authorship. **Breaking change**: existing MCP callers that omit `author_cc` will see a clean error and need to pass their CC name (read from per-machine CLAUDE.md) on the first call after deploy. This is intentional: soft-defaulting to NULL would perpetuate the stealth bug we're closing.
+  - **`author_cc` is immutable via the tool surface** — `UpdateKnowledgeParams` has no `author_cc` field, so the compiler itself guarantees the invariant. Provenance that can be rewritten isn't provenance. Emergency correction still possible via direct SQL.
+  - **`source_incident_id` is optional and post-hoc updatable** — can be set at create time or added later via `update_knowledge`. FK with `ON DELETE SET NULL` on `incidents(id)` so cleaning up incidents doesn't cascade-delete the lessons learned from them. Handlers verify the incident exists before INSERT/UPDATE so failures are clean errors rather than raw FK violations.
+  - **`_staleness_warning` is computed at read time** — `true` if `last_verified_at.unwrap_or(created_at)` is older than 90 days. No schema column, no background job, no drift. Surfaced in `search_knowledge` (single-table, multi-table, and browse modes), `list_knowledge`, and on every knowledge result returned through compact or non-compact paths. Threshold constant is `KNOWLEDGE_STALE_DAYS = 90` in `src/tools/knowledge.rs`.
+  - **`CC_TEAM` allowlist helpers** exposed from `src/tools/cc_team.rs` as `pub(crate) fn is_valid_cc_name` and `pub(crate) fn cc_allowlist`, reusing the static `CC_TEAM` table instead of duplicating the 4-name list. The `knowledge` module uses them for validation without a DB-side membership table.
+- **15 new tests** — 7 pure-logic unit tests in `src/tools/knowledge.rs` (staleness thresholds, off-by-one guards, JSON enrichment) + 8 handler-level integration tests in `tests/integration.rs::knowledge_provenance_tests` (allowlist validation, FK existence checks, author_cc immutability, post-hoc linking, staleness surfaced on list). Existing `knowledge_tests::add_and_get_knowledge` and `knowledge_cross_client_safe_field` updated for the new required repo param.
+
+### Changed
+
+- **`knowledge` module visibility: `mod knowledge` → `pub mod knowledge`** in `src/tools/mod.rs`, so handler-level integration tests can reach `handle_add_knowledge`, `handle_update_knowledge`, and `handle_list_knowledge`. Matches the existing `pub mod cc_team` pattern. Internal handlers moved from `pub(crate)` to `pub` for the same reason.
+- **Migration count: 42 → 43.** Tool count unchanged at 64 (new params on existing tools, no new tools). No fields added to `check_in` (hard-stop respected).
+
 ## [1.5.0] — 2026-04-07
 
 **ops-brain is the team bus, not a brain.** Local is the source of truth for each CC — its CLAUDE.md is its scope, its filesystem is its state, its git history is its memory. ops-brain exists for things CCs genuinely cannot do alone: handoffs to each other, shared incidents, cross-client knowledge with isolation rules, monitors, tickets that span systems. If a question can be answered without ops-brain, it should be.

--- a/migrations/20260408000001_add_knowledge_provenance.sql
+++ b/migrations/20260408000001_add_knowledge_provenance.sql
@@ -1,0 +1,45 @@
+-- v1.6: knowledge provenance (who wrote it, which incident produced it).
+--
+-- v1.5 established that local is the source of truth for everything except
+-- shared cross-CC knowledge. That one shared artifact was missing provenance:
+-- stale cross-scope entries looked identical to fresh local ones in search
+-- results, a stealth bug waiting to bite. This migration closes that gap.
+--
+-- Two new nullable columns on `knowledge`:
+--
+-- 1. `author_cc` (TEXT) — which CC created the entry. v1.5 dropped the
+--    `cc_identities` table, so this is populated from a per-call param on
+--    `add_knowledge`, validated against the static CC_TEAM allowlist in
+--    `src/tools/cc_team.rs` (CC-Cloud, CC-Stealth, CC-HSR, CC-CPA). No
+--    DB-side membership table; the allowlist lives in Rust source and
+--    moves with the code. Becomes required on all future add_knowledge
+--    calls via an allowlist check in the handler.
+--
+-- 2. `source_incident_id` (UUID) — the incident that produced this
+--    knowledge entry, if any. Links gotchas back to the incidents that
+--    taught us those gotchas. ON DELETE SET NULL so incident cleanup
+--    doesn't cascade-delete the knowledge we learned from it. Can be
+--    set at create time or added post-hoc via update_knowledge.
+--
+-- Existing rows backfill to NULL for both columns — no forced re-stamping,
+-- no fabricated provenance. Honest legacy state.
+--
+-- Staleness warnings are computed at read time from `last_verified_at` and
+-- `created_at` — no new column, no background job, no drift.
+--
+-- Immutability: `author_cc` is set once at creation and NEVER updatable
+-- via the tool surface (enforced at the handler layer, not the DB layer —
+-- direct SQL updates are still possible for emergency correction).
+
+ALTER TABLE knowledge
+    ADD COLUMN IF NOT EXISTS author_cc TEXT NULL;
+
+ALTER TABLE knowledge
+    ADD COLUMN IF NOT EXISTS source_incident_id UUID NULL
+        REFERENCES incidents(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN knowledge.author_cc IS
+    'CC that created this knowledge entry (CC-Cloud, CC-Stealth, CC-HSR, CC-CPA). NULL for rows created before v1.6. Required on all new add_knowledge calls. Immutable via tool surface once set.';
+
+COMMENT ON COLUMN knowledge.source_incident_id IS
+    'Incident that produced this knowledge entry, if any. NULL if the entry is standalone or pre-dates v1.6. FK with ON DELETE SET NULL — cleaning up incidents does not cascade-delete the lessons learned from them.';

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -204,6 +204,8 @@ mod tests {
             client_id: None,
             cross_client_safe: false,
             last_verified_at: None,
+            author_cc: None,
+            source_incident_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/src/models/knowledge.rs
+++ b/src/models/knowledge.rs
@@ -12,6 +12,13 @@ pub struct Knowledge {
     pub client_id: Option<Uuid>,
     pub cross_client_safe: bool,
     pub last_verified_at: Option<DateTime<Utc>>,
+    /// Which CC authored this entry (CC-Cloud, CC-Stealth, CC-HSR, CC-CPA).
+    /// NULL for rows created before v1.6. Required on new entries; immutable
+    /// once set via the tool surface.
+    pub author_cc: Option<String>,
+    /// Incident that produced this knowledge entry, if any. NULL if
+    /// standalone or pre-dates v1.6. FK with ON DELETE SET NULL.
+    pub source_incident_id: Option<Uuid>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/src/repo/knowledge_repo.rs
+++ b/src/repo/knowledge_repo.rs
@@ -3,6 +3,7 @@ use uuid::Uuid;
 
 use crate::models::knowledge::Knowledge;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn add_knowledge(
     pool: &PgPool,
     title: &str,
@@ -11,11 +12,13 @@ pub async fn add_knowledge(
     tags: &[String],
     client_id: Option<Uuid>,
     cross_client_safe: bool,
+    author_cc: Option<&str>,
+    source_incident_id: Option<Uuid>,
 ) -> Result<Knowledge, sqlx::Error> {
     let id = Uuid::now_v7();
     sqlx::query_as::<_, Knowledge>(
-        "INSERT INTO knowledge (id, title, content, category, tags, client_id, cross_client_safe)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+        "INSERT INTO knowledge (id, title, content, category, tags, client_id, cross_client_safe, author_cc, source_incident_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
          RETURNING *",
     )
     .bind(id)
@@ -25,6 +28,8 @@ pub async fn add_knowledge(
     .bind(tags)
     .bind(client_id)
     .bind(cross_client_safe)
+    .bind(author_cc)
+    .bind(source_incident_id)
     .fetch_one(pool)
     .await
 }
@@ -83,7 +88,11 @@ pub async fn update_knowledge(
     category: Option<&str>,
     tags: Option<&[String]>,
     cross_client_safe: Option<bool>,
+    source_incident_id: Option<Uuid>,
 ) -> Result<Knowledge, sqlx::Error> {
+    // NOTE: `author_cc` is intentionally NOT updatable — provenance is
+    // immutable via the tool surface. Direct SQL is still possible for
+    // emergency correction. See migration 20260408000001.
     sqlx::query_as::<_, Knowledge>(
         "UPDATE knowledge SET
             title = COALESCE($2, title),
@@ -91,6 +100,7 @@ pub async fn update_knowledge(
             category = COALESCE($4, category),
             tags = COALESCE($5, tags),
             cross_client_safe = COALESCE($6, cross_client_safe),
+            source_incident_id = COALESCE($7, source_incident_id),
             updated_at = NOW()
          WHERE id = $1 RETURNING *",
     )
@@ -100,6 +110,7 @@ pub async fn update_knowledge(
     .bind(category)
     .bind(tags)
     .bind(cross_client_safe)
+    .bind(source_incident_id)
     .fetch_one(pool)
     .await
 }

--- a/src/tools/cc_team.rs
+++ b/src/tools/cc_team.rs
@@ -44,6 +44,21 @@ fn allowlist_names() -> Vec<&'static str> {
     CC_TEAM.iter().map(|(n, _, _)| *n).collect()
 }
 
+/// Returns true if `cc_name` exactly matches one of the four valid CC names.
+/// Case-sensitive. Exposed for use by other tool handlers (e.g. knowledge
+/// provenance validation in `add_knowledge`) that need the same allowlist
+/// gate without duplicating the `CC_TEAM` table.
+pub(crate) fn is_valid_cc_name(cc_name: &str) -> bool {
+    CC_TEAM.iter().any(|(n, _, _)| *n == cc_name)
+}
+
+/// Returns the list of all valid CC names, in `CC_TEAM` declaration order.
+/// Use when building user-facing error messages that need to display the
+/// full allowlist.
+pub(crate) fn cc_allowlist() -> Vec<&'static str> {
+    allowlist_names()
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CheckInParams {
     /// Your CC name on the team. Must be one of: CC-Cloud, CC-Stealth,

--- a/src/tools/knowledge.rs
+++ b/src/tools/knowledge.rs
@@ -25,6 +25,11 @@ fn compact_search_item(item: &serde_json::Value, entity_type: &str) -> serde_jso
             "cross_client_safe",
             "_client_slug",
             "_client_name",
+            // v1.6 provenance fields
+            "author_cc",
+            "source_incident_id",
+            "last_verified_at",
+            "_staleness_warning",
             "created_at",
             "updated_at",
         ],
@@ -117,6 +122,43 @@ fn compact_search_results(
         .collect()
 }
 
+/// v1.6: knowledge staleness threshold in days. An entry is considered stale
+/// if (now - last_verified_at.unwrap_or(created_at)) exceeds this. Computed
+/// at read time — no schema column, no background job.
+const KNOWLEDGE_STALE_DAYS: i64 = 90;
+
+/// True if a knowledge entry is stale: >90 days since last verification, or
+/// since creation if it has never been verified.
+fn is_knowledge_stale(k: &crate::models::knowledge::Knowledge) -> bool {
+    let most_recent_check = k.last_verified_at.unwrap_or(k.created_at);
+    let age = chrono::Utc::now() - most_recent_check;
+    age > chrono::Duration::days(KNOWLEDGE_STALE_DAYS)
+}
+
+/// Serialize knowledge entries to JSON values with `_staleness_warning`
+/// computed at read time and injected into each item. Use this in place of
+/// the raw `serde_json::to_value(k)` pattern whenever knowledge results are
+/// returned to the user — keeps staleness signals visible in both compact
+/// and non-compact modes without a schema column.
+fn knowledge_entries_to_json(
+    items: &[crate::models::knowledge::Knowledge],
+) -> Vec<serde_json::Value> {
+    items
+        .iter()
+        .filter_map(|k| {
+            let stale = is_knowledge_stale(k);
+            let mut v = serde_json::to_value(k).ok()?;
+            if let Some(obj) = v.as_object_mut() {
+                obj.insert(
+                    "_staleness_warning".to_string(),
+                    serde_json::Value::Bool(stale),
+                );
+            }
+            Some(v)
+        })
+        .collect()
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AddKnowledgeParams {
     pub title: String,
@@ -128,6 +170,14 @@ pub struct AddKnowledgeParams {
     pub cross_client_safe: Option<bool>,
     /// Skip duplicate detection check. Set to true if you've already seen the warning and want to create anyway.
     pub force: Option<bool>,
+    /// Your CC name — stamps provenance on this knowledge entry. Must be
+    /// one of: CC-Cloud, CC-Stealth, CC-HSR, CC-CPA. Required since v1.6.
+    /// Read your own name from your per-machine CLAUDE.md.
+    pub author_cc: String,
+    /// Optional incident that produced this knowledge entry (UUID string).
+    /// Links the gotcha back to the incident that taught us the gotcha.
+    /// Can be set here or added post-hoc via update_knowledge.
+    pub source_incident_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -149,6 +199,12 @@ pub struct SearchKnowledgeParams {
     pub compact: Option<bool>,
 }
 
+/// Update an existing knowledge entry.
+///
+/// Note: `author_cc` is intentionally NOT updatable via this tool. Provenance
+/// is immutable after creation — if you need to correct the author, do it
+/// via direct SQL. This prevents accidental (or deliberate) rewriting of
+/// history in the one cross-CC shared artifact.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct UpdateKnowledgeParams {
     /// Knowledge entry ID (UUID)
@@ -162,6 +218,10 @@ pub struct UpdateKnowledgeParams {
     /// Set to true to mark this entry as verified (confirms content is still accurate).
     /// Sets last_verified_at to now without requiring content changes.
     pub verified: Option<bool>,
+    /// Link (or re-link) the incident that produced this knowledge entry.
+    /// Use this to add provenance post-hoc when you didn't know the source
+    /// incident at create time. Pass the incident UUID as a string.
+    pub source_incident_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -181,10 +241,36 @@ pub struct ListKnowledgeParams {
 
 // ===== HANDLERS =====
 
-pub(crate) async fn handle_add_knowledge(
+pub async fn handle_add_knowledge(
     brain: &super::OpsBrain,
     p: AddKnowledgeParams,
 ) -> CallToolResult {
+    // v1.6: validate author_cc against CC_TEAM allowlist — fail fast
+    // before any DB work. Provenance is required on every new entry.
+    let author_cc = p.author_cc.trim();
+    if !super::cc_team::is_valid_cc_name(author_cc) {
+        return error_result(&format!(
+            "Invalid author_cc: '{author_cc}'. Must be one of: {}. \
+             Read your CC name from your per-machine CLAUDE.md.",
+            super::cc_team::cc_allowlist().join(", ")
+        ));
+    }
+
+    // v1.6: parse optional source_incident_id and verify the incident
+    // exists, so we fail with a clean error instead of a raw FK violation
+    // at INSERT time.
+    let source_incident_id = match p.source_incident_id.as_deref() {
+        Some(s) => match uuid::Uuid::parse_str(s) {
+            Ok(id) => match crate::repo::incident_repo::get_incident(&brain.pool, id).await {
+                Ok(Some(_)) => Some(id),
+                Ok(None) => return error_result(&format!("Incident not found: {id}")),
+                Err(e) => return error_result(&format!("Database error: {e}")),
+            },
+            Err(_) => return error_result(&format!("Invalid source_incident_id UUID: {s}")),
+        },
+        None => None,
+    };
+
     let tags = p.tags.unwrap_or_default();
     let cross_client_safe = p.cross_client_safe.unwrap_or(false);
     let force = p.force.unwrap_or(false);
@@ -244,6 +330,8 @@ pub(crate) async fn handle_add_knowledge(
         &tags,
         client_id,
         cross_client_safe,
+        Some(author_cc),
+        source_incident_id,
     )
     .await
     {
@@ -263,7 +351,7 @@ pub(crate) async fn handle_add_knowledge(
     }
 }
 
-pub(crate) async fn handle_update_knowledge(
+pub async fn handle_update_knowledge(
     brain: &super::OpsBrain,
     p: UpdateKnowledgeParams,
 ) -> CallToolResult {
@@ -277,6 +365,22 @@ pub(crate) async fn handle_update_knowledge(
         Ok(Some(_)) => {}
         Ok(None) => return not_found("Knowledge", &p.id),
         Err(e) => return error_result(&format!("Database error: {e}")),
+    };
+
+    // v1.6: parse optional source_incident_id and verify the incident
+    // exists before the UPDATE.
+    let source_incident_id = match p.source_incident_id.as_deref() {
+        Some(s) => match uuid::Uuid::parse_str(s) {
+            Ok(incident_id) => {
+                match crate::repo::incident_repo::get_incident(&brain.pool, incident_id).await {
+                    Ok(Some(_)) => Some(incident_id),
+                    Ok(None) => return error_result(&format!("Incident not found: {incident_id}")),
+                    Err(e) => return error_result(&format!("Database error: {e}")),
+                }
+            }
+            Err(_) => return error_result(&format!("Invalid source_incident_id UUID: {s}")),
+        },
+        None => None,
     };
 
     // Mark as verified if requested
@@ -295,6 +399,7 @@ pub(crate) async fn handle_update_knowledge(
         p.category.as_deref(),
         p.tags.as_deref(),
         p.cross_client_safe,
+        source_incident_id,
     )
     .await
     {
@@ -449,10 +554,7 @@ pub(crate) async fn handle_search_knowledge(
                 };
                 match search_result {
                     Ok(items) => {
-                        let json_items: Vec<serde_json::Value> = items
-                            .iter()
-                            .filter_map(|k| serde_json::to_value(k).ok())
-                            .collect();
+                        let json_items = knowledge_entries_to_json(&items);
                         let filtered = filter_cross_client(
                             json_items,
                             "knowledge",
@@ -723,7 +825,7 @@ async fn browse_recent_entries(
             "knowledge" => {
                 match crate::repo::knowledge_repo::list_knowledge(&brain.pool, None, None, limit).await {
                     Ok(items) => {
-                        let json_items: Vec<serde_json::Value> = items.iter().filter_map(|k| serde_json::to_value(k).ok()).collect();
+                        let json_items = knowledge_entries_to_json(&items);
                         let filtered = filter_cross_client(json_items, "knowledge", requesting_client_id, acknowledge, &client_lookup);
                         let final_items = if compact { compact_search_results(&filtered.allowed, "knowledge") } else { filtered.allowed };
                         results.insert("knowledge".to_string(), serde_json::to_value(&final_items).unwrap_or_default());
@@ -822,10 +924,7 @@ async fn search_knowledge_single(
     };
     match result {
         Ok(entries) => {
-            let items: Vec<serde_json::Value> = entries
-                .iter()
-                .filter_map(|k| serde_json::to_value(k).ok())
-                .collect();
+            let items = knowledge_entries_to_json(&entries);
             let client_lookup = build_client_lookup(&brain.pool).await;
             let filtered = filter_cross_client(
                 items,
@@ -859,7 +958,7 @@ async fn search_knowledge_single(
     }
 }
 
-pub(crate) async fn handle_list_knowledge(
+pub async fn handle_list_knowledge(
     brain: &super::OpsBrain,
     p: ListKnowledgeParams,
 ) -> CallToolResult {
@@ -882,7 +981,119 @@ pub(crate) async fn handle_list_knowledge(
     )
     .await
     {
-        Ok(entries) => json_result(&entries),
+        // v1.6: surface provenance + staleness warnings on list results.
+        Ok(entries) => json_result(&knowledge_entries_to_json(&entries)),
         Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-logic unit tests for knowledge provenance (v1.6). DB-backed
+    //! handler tests live in `tests/integration.rs`.
+
+    use super::*;
+    use chrono::{Duration, Utc};
+    use uuid::Uuid;
+
+    fn make_knowledge(
+        last_verified: Option<chrono::DateTime<Utc>>,
+        created: chrono::DateTime<Utc>,
+    ) -> crate::models::knowledge::Knowledge {
+        crate::models::knowledge::Knowledge {
+            id: Uuid::now_v7(),
+            title: "test".to_string(),
+            content: "test content".to_string(),
+            category: None,
+            tags: vec![],
+            client_id: None,
+            cross_client_safe: false,
+            last_verified_at: last_verified,
+            author_cc: Some("CC-Stealth".to_string()),
+            source_incident_id: None,
+            created_at: created,
+            updated_at: created,
+        }
+    }
+
+    #[test]
+    fn is_knowledge_stale_false_for_fresh_unverified_entry() {
+        // Created recently, never verified — NOT stale.
+        let k = make_knowledge(None, Utc::now() - Duration::days(10));
+        assert!(!is_knowledge_stale(&k));
+    }
+
+    #[test]
+    fn is_knowledge_stale_true_for_old_unverified_entry() {
+        // Created 100 days ago, never verified — STALE.
+        let k = make_knowledge(None, Utc::now() - Duration::days(100));
+        assert!(is_knowledge_stale(&k));
+    }
+
+    #[test]
+    fn is_knowledge_stale_false_for_recently_verified_entry() {
+        // Created 200 days ago, verified 30 days ago — NOT stale.
+        // The verification resets the clock.
+        let k = make_knowledge(
+            Some(Utc::now() - Duration::days(30)),
+            Utc::now() - Duration::days(200),
+        );
+        assert!(!is_knowledge_stale(&k));
+    }
+
+    #[test]
+    fn is_knowledge_stale_true_for_stale_verified_entry() {
+        // Created 200 days ago, verified 95 days ago — STALE.
+        // Verification aged out of the 90-day window.
+        let k = make_knowledge(
+            Some(Utc::now() - Duration::days(95)),
+            Utc::now() - Duration::days(200),
+        );
+        assert!(is_knowledge_stale(&k));
+    }
+
+    #[test]
+    fn is_knowledge_stale_false_exactly_at_threshold() {
+        // Exactly 90 days old — strictly `> 90 days` is the trigger,
+        // so 90d on the nose is NOT stale. This is an off-by-one guard.
+        // Use 89 days to avoid clock-skew races with `Utc::now()` inside
+        // the function itself (the function reads now fresh, so 90 days
+        // ago from the test's now might read as 90 days + epsilon).
+        let k = make_knowledge(None, Utc::now() - Duration::days(89));
+        assert!(!is_knowledge_stale(&k));
+    }
+
+    #[test]
+    fn knowledge_entries_to_json_injects_staleness_flag() {
+        let fresh = make_knowledge(None, Utc::now() - Duration::days(1));
+        let stale = make_knowledge(None, Utc::now() - Duration::days(120));
+        let json = knowledge_entries_to_json(&[fresh, stale]);
+        assert_eq!(json.len(), 2);
+        assert_eq!(
+            json[0].get("_staleness_warning"),
+            Some(&serde_json::Value::Bool(false)),
+            "fresh entry should not be stale"
+        );
+        assert_eq!(
+            json[1].get("_staleness_warning"),
+            Some(&serde_json::Value::Bool(true)),
+            "120-day-old entry should be stale"
+        );
+    }
+
+    #[test]
+    fn knowledge_entries_to_json_preserves_provenance_fields() {
+        let k = make_knowledge(None, Utc::now());
+        let json = knowledge_entries_to_json(&[k]);
+        let obj = json[0].as_object().expect("should be object");
+        assert_eq!(
+            obj.get("author_cc"),
+            Some(&serde_json::Value::String("CC-Stealth".to_string())),
+            "author_cc should survive serialization"
+        );
+        assert!(
+            obj.contains_key("source_incident_id"),
+            "source_incident_id field should be present even when null"
+        );
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -5,7 +5,7 @@ mod coordination;
 mod helpers;
 mod incidents;
 mod inventory;
-mod knowledge;
+pub mod knowledge;
 mod monitoring;
 mod runbooks;
 mod search;
@@ -328,7 +328,7 @@ impl OpsBrain {
 
     #[tool(
         name = "add_knowledge",
-        description = "Add a knowledge base entry (lesson learned, gotcha, tip, etc.)"
+        description = "Add a knowledge base entry (lesson, gotcha, tip). Requires author_cc — your CC name (read it from your CLAUDE.md)."
     )]
     async fn add_knowledge(
         &self,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -302,12 +302,16 @@ mod knowledge_tests {
             &["ci".to_string()],
             None,
             false,
+            Some("CC-Stealth"),
+            None,
         )
         .await
         .unwrap();
 
         assert_eq!(k.title, "Test Knowledge Entry");
         assert!(!k.cross_client_safe);
+        assert_eq!(k.author_cc.as_deref(), Some("CC-Stealth"));
+        assert_eq!(k.source_incident_id, None);
 
         let fetched = ops_brain::repo::knowledge_repo::get_knowledge(&pool, k.id)
             .await
@@ -335,6 +339,8 @@ mod knowledge_tests {
             &[],
             None,
             true,
+            Some("CC-Stealth"),
+            None,
         )
         .await
         .unwrap();
@@ -344,6 +350,512 @@ mod knowledge_tests {
         // Cleanup
         sqlx::query("DELETE FROM knowledge WHERE id = $1")
             .bind(k.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+}
+
+// ===== Knowledge Provenance (v1.6) =====
+//
+// Handler-level end-to-end tests for the provenance feature:
+//   - author_cc allowlist validation (fail loudly on invalid names)
+//   - source_incident_id FK resolution (exist-check before INSERT)
+//   - author_cc immutability across updates (enforced at type level)
+//   - source_incident_id updatable post-hoc
+//   - staleness flag surfaced in list_knowledge results
+//
+// Pure logic (is_knowledge_stale, knowledge_entries_to_json) is unit-tested
+// in src/tools/knowledge.rs — these tests exist to catch handler-layer
+// regressions (validation, error messages, response shapes).
+
+mod knowledge_provenance_tests {
+    use super::*;
+
+    fn build_brain(pool: PgPool) -> ops_brain::tools::OpsBrain {
+        ops_brain::tools::OpsBrain::new(pool, vec![], None, None)
+    }
+
+    fn extract_text(result: &rmcp::model::CallToolResult) -> String {
+        result
+            .content
+            .first()
+            .expect("result has at least one content item")
+            .as_text()
+            .expect("content is text")
+            .text
+            .clone()
+    }
+
+    /// Strip all whitespace so assertions are robust against pretty vs
+    /// compact JSON formatting. `json_result` currently pretty-prints,
+    /// meaning `"field": "value"` with a space after the colon, but we
+    /// don't want tests to break if that changes.
+    fn no_ws(s: &str) -> String {
+        s.chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    async fn seed_incident(pool: &PgPool) -> uuid::Uuid {
+        let incident = ops_brain::repo::incident_repo::create_incident(
+            pool,
+            "provenance test incident",
+            "low",
+            None,
+            Some("synthetic symptoms for FK link"),
+            Some("created by knowledge_provenance_tests"),
+            false,
+        )
+        .await
+        .unwrap();
+        incident.id
+    }
+
+    #[tokio::test]
+    async fn handler_add_knowledge_rejects_invalid_author_cc() {
+        let brain = build_brain(pool().await);
+        let result = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: "rejected title".to_string(),
+                content: "rejected content".to_string(),
+                category: None,
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-NotReal".to_string(),
+                source_incident_id: None,
+            },
+        )
+        .await;
+        assert_eq!(result.is_error, Some(true));
+        let text = extract_text(&result);
+        assert!(
+            text.contains("Invalid author_cc"),
+            "error should name the field"
+        );
+        assert!(text.contains("CC-Stealth"), "error should list valid names");
+    }
+
+    #[tokio::test]
+    async fn handler_add_knowledge_stores_author_cc() {
+        let pool = pool().await;
+        let brain = build_brain(pool.clone());
+        let result = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: format!("provenance stored {}", uuid::Uuid::now_v7()),
+                content: "content stamped with author".to_string(),
+                category: None,
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-Stealth".to_string(),
+                source_incident_id: None,
+            },
+        )
+        .await;
+        assert_eq!(result.is_error, Some(false));
+        let text = extract_text(&result);
+        let compact = no_ws(&text);
+        assert!(compact.contains("\"author_cc\":\"CC-Stealth\""));
+        assert!(compact.contains("\"source_incident_id\":null"));
+
+        // Cleanup: extract id from the JSON and delete.
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let id = v.get("id").and_then(|x| x.as_str()).unwrap().to_string();
+        sqlx::query("DELETE FROM knowledge WHERE id = $1::uuid")
+            .bind(&id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn handler_add_knowledge_links_source_incident_id() {
+        let pool = pool().await;
+        let brain = build_brain(pool.clone());
+        let incident_id = seed_incident(&pool).await;
+
+        let result = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: format!("linked to incident {incident_id}"),
+                content: "knowledge born from an incident".to_string(),
+                category: None,
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-Stealth".to_string(),
+                source_incident_id: Some(incident_id.to_string()),
+            },
+        )
+        .await;
+        assert_eq!(result.is_error, Some(false));
+        let text = extract_text(&result);
+        assert!(
+            no_ws(&text).contains(&format!("\"source_incident_id\":\"{incident_id}\"")),
+            "response should include the FK value"
+        );
+
+        // Cleanup (knowledge first, incident last — FK order doesn't matter
+        // due to ON DELETE SET NULL, but keeps the fixture tidy).
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let id = v.get("id").and_then(|x| x.as_str()).unwrap().to_string();
+        sqlx::query("DELETE FROM knowledge WHERE id = $1::uuid")
+            .bind(&id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM incidents WHERE id = $1")
+            .bind(incident_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn handler_add_knowledge_rejects_nonexistent_incident() {
+        let brain = build_brain(pool().await);
+        let ghost_id = uuid::Uuid::now_v7();
+        let result = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: "should not land".to_string(),
+                content: "no incident behind this".to_string(),
+                category: None,
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-Stealth".to_string(),
+                source_incident_id: Some(ghost_id.to_string()),
+            },
+        )
+        .await;
+        assert_eq!(result.is_error, Some(true));
+        let text = extract_text(&result);
+        assert!(
+            text.contains("Incident not found"),
+            "error should be explicit about the missing incident, not a raw FK violation"
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_add_knowledge_rejects_malformed_incident_uuid() {
+        let brain = build_brain(pool().await);
+        let result = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: "malformed uuid".to_string(),
+                content: "not a uuid string".to_string(),
+                category: None,
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-Stealth".to_string(),
+                source_incident_id: Some("obviously-not-a-uuid".to_string()),
+            },
+        )
+        .await;
+        assert_eq!(result.is_error, Some(true));
+        let text = extract_text(&result);
+        assert!(text.contains("Invalid source_incident_id UUID"));
+    }
+
+    #[tokio::test]
+    async fn handler_update_knowledge_can_link_source_incident_id_post_hoc() {
+        let pool = pool().await;
+        let brain = build_brain(pool.clone());
+
+        // Create knowledge without a source incident.
+        let add_result = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: format!("post-hoc link {}", uuid::Uuid::now_v7()),
+                content: "initially unlinked".to_string(),
+                category: None,
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-Stealth".to_string(),
+                source_incident_id: None,
+            },
+        )
+        .await;
+        let text = extract_text(&add_result);
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let knowledge_id = v.get("id").and_then(|x| x.as_str()).unwrap().to_string();
+
+        // Seed an incident and link it via update.
+        let incident_id = seed_incident(&pool).await;
+        let update_result = ops_brain::tools::knowledge::handle_update_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::UpdateKnowledgeParams {
+                id: knowledge_id.clone(),
+                title: None,
+                content: None,
+                category: None,
+                tags: None,
+                cross_client_safe: None,
+                verified: None,
+                source_incident_id: Some(incident_id.to_string()),
+            },
+        )
+        .await;
+        assert_eq!(update_result.is_error, Some(false));
+        let updated_text = extract_text(&update_result);
+        let updated_compact = no_ws(&updated_text);
+        assert!(updated_compact.contains(&format!("\"source_incident_id\":\"{incident_id}\"")));
+        assert!(
+            updated_compact.contains("\"author_cc\":\"CC-Stealth\""),
+            "author_cc should be preserved across update"
+        );
+
+        // Cleanup
+        sqlx::query("DELETE FROM knowledge WHERE id = $1::uuid")
+            .bind(&knowledge_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM incidents WHERE id = $1")
+            .bind(incident_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn handler_update_knowledge_cannot_mutate_author_cc() {
+        // Structural test: UpdateKnowledgeParams has no `author_cc` field,
+        // so the compiler itself guarantees this invariant. This test
+        // documents the guarantee via a positive assertion: after an
+        // update, author_cc is unchanged from the original value.
+        let pool = pool().await;
+        let brain = build_brain(pool.clone());
+
+        let add_result = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: format!("immutable author {}", uuid::Uuid::now_v7()),
+                content: "v1".to_string(),
+                category: None,
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-HSR".to_string(),
+                source_incident_id: None,
+            },
+        )
+        .await;
+        let text = extract_text(&add_result);
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let knowledge_id = v.get("id").and_then(|x| x.as_str()).unwrap().to_string();
+        assert!(no_ws(&text).contains("\"author_cc\":\"CC-HSR\""));
+
+        // Update unrelated field (content) — author_cc must still be CC-HSR.
+        let update_result = ops_brain::tools::knowledge::handle_update_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::UpdateKnowledgeParams {
+                id: knowledge_id.clone(),
+                title: None,
+                content: Some("v2 — rewritten but still by CC-HSR".to_string()),
+                category: None,
+                tags: None,
+                cross_client_safe: None,
+                verified: None,
+                source_incident_id: None,
+            },
+        )
+        .await;
+        assert_eq!(update_result.is_error, Some(false));
+        let updated_text = extract_text(&update_result);
+        assert!(
+            no_ws(&updated_text).contains("\"author_cc\":\"CC-HSR\""),
+            "author_cc must be preserved across updates — provenance is immutable"
+        );
+
+        // Cleanup
+        sqlx::query("DELETE FROM knowledge WHERE id = $1::uuid")
+            .bind(&knowledge_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn handler_list_knowledge_surfaces_staleness_warning() {
+        // Create a fresh entry via handler, then backdate it via SQL to
+        // force the stale flag, then list and verify the flag is true.
+        let pool = pool().await;
+        let brain = build_brain(pool.clone());
+
+        let add_result = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: format!("staleness test {}", uuid::Uuid::now_v7()),
+                content: "will be backdated".to_string(),
+                category: Some("provenance-test-stale".to_string()),
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-Stealth".to_string(),
+                source_incident_id: None,
+            },
+        )
+        .await;
+        let text = extract_text(&add_result);
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let knowledge_id = v.get("id").and_then(|x| x.as_str()).unwrap().to_string();
+
+        // Backdate created_at to 100 days ago; leave last_verified_at NULL.
+        sqlx::query(
+            "UPDATE knowledge SET created_at = now() - interval '100 days', \
+             last_verified_at = NULL WHERE id = $1::uuid",
+        )
+        .bind(&knowledge_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let list_result = ops_brain::tools::knowledge::handle_list_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::ListKnowledgeParams {
+                category: Some("provenance-test-stale".to_string()),
+                client_slug: None,
+                limit: Some(10),
+            },
+        )
+        .await;
+        assert_eq!(list_result.is_error, Some(false));
+        let list_text = extract_text(&list_result);
+        assert!(
+            no_ws(&list_text).contains("\"_staleness_warning\":true"),
+            "backdated entry should be flagged stale; got: {list_text}"
+        );
+
+        // Also assert that a fresh entry in the same category comes back false.
+        let fresh_add = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: format!("fresh staleness test {}", uuid::Uuid::now_v7()),
+                content: "not backdated".to_string(),
+                category: Some("provenance-test-stale".to_string()),
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-Stealth".to_string(),
+                source_incident_id: None,
+            },
+        )
+        .await;
+        let fresh_text = extract_text(&fresh_add);
+        let fresh_v: serde_json::Value = serde_json::from_str(&fresh_text).unwrap();
+        let fresh_id = fresh_v
+            .get("id")
+            .and_then(|x| x.as_str())
+            .unwrap()
+            .to_string();
+
+        let list_again = ops_brain::tools::knowledge::handle_list_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::ListKnowledgeParams {
+                category: Some("provenance-test-stale".to_string()),
+                client_slug: None,
+                limit: Some(10),
+            },
+        )
+        .await;
+        let list_again_text = extract_text(&list_again);
+        assert!(
+            no_ws(&list_again_text).contains("\"_staleness_warning\":false"),
+            "fresh entry should not be flagged stale; got: {list_again_text}"
+        );
+
+        // Cleanup
+        sqlx::query("DELETE FROM knowledge WHERE id = $1::uuid")
+            .bind(&knowledge_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM knowledge WHERE id = $1::uuid")
+            .bind(&fresh_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn source_incident_id_on_delete_set_null() {
+        // Migration 20260408000001 uses `ON DELETE SET NULL` on the
+        // source_incident_id FK so cleaning up incidents does not
+        // cascade-delete the knowledge we learned from them. This test
+        // guards the cascade behavior at runtime — if a future migration
+        // ever flips this to `ON DELETE CASCADE` by mistake, this test
+        // will fail loudly.
+        let pool = pool().await;
+        let brain = build_brain(pool.clone());
+        let incident_id = seed_incident(&pool).await;
+
+        let add_result = ops_brain::tools::knowledge::handle_add_knowledge(
+            &brain,
+            ops_brain::tools::knowledge::AddKnowledgeParams {
+                title: format!("cascade test {}", uuid::Uuid::now_v7()),
+                content: "linked to an incident that will be deleted".to_string(),
+                category: None,
+                tags: None,
+                client_slug: None,
+                cross_client_safe: None,
+                force: Some(true),
+                author_cc: "CC-Stealth".to_string(),
+                source_incident_id: Some(incident_id.to_string()),
+            },
+        )
+        .await;
+        assert_eq!(add_result.is_error, Some(false));
+        let text = extract_text(&add_result);
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let knowledge_id = v.get("id").and_then(|x| x.as_str()).unwrap().to_string();
+
+        // Sanity: knowledge is currently linked to the incident.
+        assert!(
+            no_ws(&text).contains(&format!("\"source_incident_id\":\"{incident_id}\"")),
+            "pre-delete: knowledge should be linked to incident"
+        );
+
+        // Delete the incident. Knowledge row must survive.
+        sqlx::query("DELETE FROM incidents WHERE id = $1")
+            .bind(incident_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Knowledge row still exists, but its source_incident_id is NULL.
+        let knowledge_uuid = uuid::Uuid::parse_str(&knowledge_id).unwrap();
+        let fetched = ops_brain::repo::knowledge_repo::get_knowledge(&pool, knowledge_uuid)
+            .await
+            .unwrap()
+            .expect("knowledge row must survive incident deletion");
+        assert_eq!(
+            fetched.source_incident_id, None,
+            "FK cascade must be SET NULL, not CASCADE — incident cleanup should never delete learned lessons"
+        );
+        assert_eq!(
+            fetched.author_cc.as_deref(),
+            Some("CC-Stealth"),
+            "author_cc must survive cascade unchanged"
+        );
+
+        // Cleanup
+        sqlx::query("DELETE FROM knowledge WHERE id = $1")
+            .bind(knowledge_uuid)
             .execute(&pool)
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

Closes **#2 on the post-v1.5 roadmap**: knowledge provenance. v1.5 established that local is the source of truth for everything *except* shared cross-CC knowledge. This PR closes the provenance gap in that one shared artifact.

**Problem this solves:** stale cross-scope knowledge entries currently look identical to fresh local ones in search results. A silent correctness bug — a CC reading a stale entry has no signal that the entry is stale or who wrote it.

## What this adds

- **`author_cc`** — required on new `add_knowledge` calls, validated against the `CC_TEAM` allowlist (`CC-Cloud`, `CC-Stealth`, `CC-HSR`, `CC-CPA`). Stamps provenance on every new entry. Immutable via the tool surface once set.
- **`source_incident_id`** — optional FK to `incidents(id)` with `ON DELETE SET NULL`. Links gotchas back to the incidents that taught us the gotchas. Can be set at create time or added post-hoc via `update_knowledge`.
- **`_staleness_warning`** — computed at read time (`>90 days since last_verified_at.unwrap_or(created_at)`). Surfaced on `search_knowledge` (all 3 paths), `list_knowledge`, and both compact and non-compact response shapes. No schema column, no background job.

## ⚠️ Breaking change

`add_knowledge` now **requires** `author_cc`. Existing callers that omit it will see a clean error on the first call with the full allowlist and instructions to read their CC name from their CLAUDE.md. This is intentional: soft-defaulting to NULL would perpetuate the exact stealth bug this PR closes.

Pre-v1.6 rows stay NULL for `author_cc` and `source_incident_id`. No forced backfill, no fabricated authorship.

## Design calls

| Call | Rationale |
|---|---|
| `author_cc` is immutable via the tool surface | `UpdateKnowledgeParams` has no `author_cc` field — compiler-enforced. Provenance that can be rewritten isn't provenance. Direct SQL still works for emergency correction. |
| `source_incident_id` is optional + post-hoc updatable | You might not know the linking incident at create time. FK `ON DELETE SET NULL` so incident cleanup never cascades to learned lessons. |
| `_staleness_warning` computed at read time | No schema column, no drift, no background job. Threshold constant `KNOWLEDGE_STALE_DAYS = 90` in `src/tools/knowledge.rs`. Strict `>` comparison — exactly 90 days is still fresh. |
| Reused `CC_TEAM` allowlist | Exposed `is_valid_cc_name` and `cc_allowlist` as `pub(crate)` helpers from `src/tools/cc_team.rs`. Zero duplication. |

## Architecture constraints honored

- ✅ Tool stubs remain in the single `#[tool_router] impl OpsBrain` block
- ✅ Parameter structs + handlers live in the category module
- ✅ Tool errors return `Ok(CallToolResult::error(...))`, never `Err(McpError)`
- ✅ `#[allow(clippy::too_many_arguments)]` on the repo function — alternative (builder struct) adds noise without value
- ✅ All new queries use `.bind()` — no format-string SQL
- ✅ Idempotent migration (`ADD COLUMN IF NOT EXISTS`)
- ✅ Migration is additive-only — no DROP, no ALTER of existing columns
- ✅ Tool count unchanged at 64 (new params on existing tools, no new tools)
- ✅ No new fields on `check_in` (hard-stop respected)
- ✅ `/review` run, findings addressed

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 129 lib tests + 38 integration tests, zero failures
  - 7 new pure-logic unit tests for staleness thresholds + JSON enrichment
  - 9 new handler-level integration tests: allowlist rejection, valid author_cc roundtrip, FK existence checks (valid incident, non-existent incident, malformed UUID), post-hoc incident linking, author_cc immutability across update, staleness flag surfaced on list, and **runtime guard for `ON DELETE SET NULL` cascade behavior** (catches future migrations flipping to CASCADE)
- [ ] Post-deploy smoke check: `add_knowledge` with new `author_cc` param works from a live CC session
- [ ] Post-deploy smoke check: existing `search_knowledge` queries surface `_staleness_warning` on knowledge results

## Migration

`migrations/20260408000001_add_knowledge_provenance.sql` — migration count 42 → 43.

```sql
ALTER TABLE knowledge
    ADD COLUMN IF NOT EXISTS author_cc TEXT NULL;

ALTER TABLE knowledge
    ADD COLUMN IF NOT EXISTS source_incident_id UUID NULL
        REFERENCES incidents(id) ON DELETE SET NULL;
```

Idempotent, safe to apply. FK is `ON DELETE SET NULL` so incident cleanup never cascades.

## Deploy notes (for CC-Cloud)

- Standard deploy flow: migration inspection → `/deploy-ops-brain` → smoke tests.
- The breaking-change warning above will become visible the first time any CC calls `add_knowledge` on the new build. Expect one polite error per CC before they start passing `author_cc`.
- Tool manifest will re-propagate cleanly on container swap per the rmcp-over-HTTP cutover behavior (see v1.5 deploy observations).

---

Generated via `/review` workflow. Branch cut from `origin/main` (596b787).