### PR TITLE
docs(knowledge): CLAUDE.md policy note + CONTRIBUTING handler visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ The most important tool. Accepts `server_slug`, `service_slug`, or `client_slug`
 
 - **No startup ritual** -- there is no required "first call." If the user leads with a task, do the task. Call `check_in` when you actually want to know what's pending from the rest of the team; otherwise don't. (This replaces the old v1.4 "morning ritual" framing — see CHANGELOG v1.5.)
 - **Handoffs are the coordination layer** -- creating a handoff IS the notification mechanism. `action`-category for things the recipient must do; `notify`-category for FYI broadcasts (auto-pruned after 7 days).
-- **Knowledge policy** -- knowledge entries are for gotchas, safety warnings, compliance rules, and vendor behavior ONLY. Every entry costs tokens across all CC instances. If it would fit in your own CLAUDE.md, put it there instead.
+- **Knowledge policy** -- knowledge entries are for gotchas, safety warnings, compliance rules, and vendor behavior ONLY. Every entry costs tokens across all CC instances. If it would fit in your own CLAUDE.md, put it there instead. `add_knowledge` requires `author_cc` (your CC name from your per-machine CLAUDE.md) and accepts an optional `source_incident_id` to link the entry back to the incident that produced it — provenance is immutable via the tool surface once set.
 - **Default-deny across clients** -- cross-client surfacing requires explicit `acknowledge_cross_client: true` and is audit-logged.
 
 ## Gotchas

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -88,6 +88,8 @@ pub(crate) async fn handle_delete_thing(brain: &super::OpsBrain, params: DeleteT
 }
 ```
 
+**Visibility note:** Use `pub(crate)` by default. If you want to write *handler-level* integration tests that call the handler directly (not just the repo layer), promote the handler to `pub` **and** promote the module declaration in `src/tools/mod.rs` from `mod foo` to `pub mod foo` — integration tests live in a separate crate and cannot reach `pub(crate)` items. See `src/tools/cc_team.rs` + `src/tools/knowledge.rs` for the established pattern, and `tests/integration.rs::check_in_tests` / `knowledge_provenance_tests` for example handler-level test modules.
+
 **6. Tool stub**
 
 Add a thin stub to the `#[tool_router] impl OpsBrain` block in `src/tools/mod.rs`:


### PR DESCRIPTION
## Summary

Follow-up docs PR to PR #37 (knowledge provenance). Documents two session learnings that would have ridden with #37 except a merge race stranded the docs commit on a post-merge branch.

## What's here

- **`CLAUDE.md` Knowledge policy** gets one sentence about the new `author_cc` requirement and the optional `source_incident_id` linkage, plus the "immutable via tool surface" guarantee. CCs reading the repo docs see the breaking change up front instead of hitting the polite-error fallback on first call.
- **`docs/CONTRIBUTING.md` Handler function step** gets a visibility note: handlers tested at the *handler level* (not just the repo layer) need `pub` + `pub mod`, since integration tests live in a separate crate and cannot reach `pub(crate)` items. The knowledge provenance PR hit this pitfall directly — documenting the pattern so the next contributor hits the shortcut instead of the learning curve. Points at `cc_team.rs` + `knowledge.rs` as the established pattern, and `check_in_tests` / `knowledge_provenance_tests` as example modules.

## Why separate from #37

#37 merged (as `f5f4aa1`) before this docs commit was pushed — a timing race with CC-Cloud's deploy. The docs are scoped tightly and land cleanly on `main` as a pure follow-up.

## Test plan

- [x] No code changes — only `.md` files, no compile/clippy/test impact
- [x] Rendered the diff against `main` — both additions apply cleanly as additive edits

## Diffstat

\`\`\`
 CLAUDE.md            | 2 +-
 docs/CONTRIBUTING.md | 2 ++
 2 files changed, 3 insertions(+), 1 deletion(-)
\`\`\`