### PR TITLE
feat(incidents): surface similar open work on create_incident

### DIFF
--- a/src/repo/embedding_repo.rs
+++ b/src/repo/embedding_repo.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use pgvector::Vector;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -422,6 +423,63 @@ pub async fn vector_search_incidents(
         "SELECT * FROM incidents WHERE embedding IS NOT NULL ORDER BY embedding <=> $1 LIMIT $2",
     )
     .bind(vec)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+}
+
+/// Compact view of an open incident matched by semantic similarity. Returned
+/// by `find_similar_open_incidents` so `create_incident` can surface "this
+/// looks like work already in flight" without sending the full Incident row
+/// for every match.
+///
+/// `cross_client_safe` and `client_id` are included so the cross-client gate
+/// in the handler can decide which matches to release vs withhold.
+#[derive(Debug, sqlx::FromRow, serde::Serialize)]
+pub struct SimilarIncident {
+    pub id: Uuid,
+    pub title: String,
+    pub status: String,
+    pub severity: String,
+    pub client_id: Option<Uuid>,
+    pub cross_client_safe: bool,
+    pub created_at: DateTime<Utc>,
+    pub distance: f64,
+}
+
+/// Find OPEN incidents semantically similar to the given embedding within a
+/// cosine distance threshold. Excludes `exclude_id` (the incident that just
+/// produced the query embedding, so a freshly-created row never matches itself).
+///
+/// Returns matches across ALL clients; the cross-client gate is applied at the
+/// handler layer (`tools::helpers::filter_cross_client`) so this function stays
+/// composable with the standard scoping pattern used elsewhere.
+///
+/// Used by `create_incident` to surface related work to the caller. Threshold
+/// 0.30 (≈70% similarity) is empirical — looser than knowledge's 0.15
+/// (duplicate detection) because the goal here is "related work" not "same thing".
+pub async fn find_similar_open_incidents(
+    pool: &PgPool,
+    query_embedding: &[f32],
+    exclude_id: Uuid,
+    max_distance: f64,
+    limit: i64,
+) -> Result<Vec<SimilarIncident>, sqlx::Error> {
+    let vec = Vector::from(query_embedding.to_vec());
+    sqlx::query_as::<_, SimilarIncident>(
+        "SELECT id, title, status, severity, client_id, cross_client_safe, created_at,
+                (embedding <=> $1)::float8 AS distance
+         FROM incidents
+         WHERE embedding IS NOT NULL
+           AND status = 'open'
+           AND id != $2
+           AND (embedding <=> $1) < $3
+         ORDER BY distance
+         LIMIT $4",
+    )
+    .bind(vec)
+    .bind(exclude_id)
+    .bind(max_distance)
     .bind(limit)
     .fetch_all(pool)
     .await

--- a/src/tools/incidents.rs
+++ b/src/tools/incidents.rs
@@ -4,10 +4,10 @@ use serde::Deserialize;
 use crate::validation::deserialize_flexible_i64;
 
 use super::helpers::{
-    error_result, json_result, not_found, not_found_vendor_with_suggestions,
+    error_result, filter_cross_client, json_result, not_found, not_found_vendor_with_suggestions,
     not_found_with_suggestions,
 };
-use super::shared::{embed_and_store, get_query_embedding};
+use super::shared::{build_client_lookup, embed_and_store, get_query_embedding, log_audit_entries};
 use rmcp::model::*;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -28,6 +28,11 @@ pub struct CreateIncidentParams {
     pub service_slugs: Option<Vec<String>>,
     /// Mark as safe to surface in cross-client contexts (default: false)
     pub cross_client_safe: Option<bool>,
+    /// Release similar-incident matches from other clients in the response.
+    /// Default false. When false, cross-client matches are withheld and the
+    /// response includes a `_cross_client_withheld` notice. Re-call with
+    /// `acknowledge_cross_client: true` to release them (audit-logged).
+    pub acknowledge_cross_client: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -108,7 +113,7 @@ pub struct RunbookLink {
 
 // ===== HANDLERS =====
 
-pub(crate) async fn handle_create_incident(
+pub async fn handle_create_incident(
     brain: &super::OpsBrain,
     p: CreateIncidentParams,
 ) -> CallToolResult {
@@ -133,6 +138,8 @@ pub(crate) async fn handle_create_incident(
     };
 
     let cross_client_safe = p.cross_client_safe.unwrap_or(false);
+    let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
+
     let incident = match crate::repo::incident_repo::create_incident(
         &brain.pool,
         &p.title,
@@ -180,17 +187,123 @@ pub(crate) async fn handle_create_incident(
         }
     }
 
-    let text = crate::embeddings::prepare_incident_text(&incident);
-    embed_and_store(
-        &brain.pool,
-        &brain.embedding_client,
-        "incidents",
-        incident.id,
-        &text,
-    )
-    .await;
+    // Compute the embedding ONCE and use it for both:
+    //   1. similarity search against existing OPEN incidents
+    //   2. storage on this new incident (replaces the embed_and_store path,
+    //      which would re-call the embedding API a second time)
+    //
+    // Best-effort: if the embedding service is down, the incident still
+    // creates successfully — `_similar_incidents` is just empty and
+    // `embedding` stays NULL on the row (re-runs of the watchdog backfill
+    // will pick it up later).
+    let mut similar_incidents_json: Vec<serde_json::Value> = Vec::new();
+    let mut withheld_notices: Vec<serde_json::Value> = Vec::new();
 
-    json_result(&incident)
+    if let Some(ref embedding_client) = brain.embedding_client {
+        let text = crate::embeddings::prepare_incident_text(&incident);
+        match embedding_client.embed_text(&text).await {
+            Ok(embedding) => {
+                // Search for related open work — top 3, distance < 0.30 ≈ similarity > 70%.
+                // Threshold tuned looser than knowledge's 0.15 because the goal is
+                // "is this related to something already in flight?", not duplicate detection.
+                match crate::repo::embedding_repo::find_similar_open_incidents(
+                    &brain.pool,
+                    &embedding,
+                    incident.id,
+                    0.30,
+                    3,
+                )
+                .await
+                {
+                    Ok(similars) if !similars.is_empty() => {
+                        // Telemetry for retuning the 0.30 threshold from real data.
+                        // similars is ORDER BY distance ASC so [0] is the closest match.
+                        tracing::info!(
+                            new_incident = %incident.id,
+                            similar_count = similars.len(),
+                            min_distance = similars[0].distance,
+                            "create_incident: surfaced similar open incidents"
+                        );
+
+                        let candidates: Vec<serde_json::Value> = similars
+                            .iter()
+                            .map(|s| {
+                                serde_json::json!({
+                                    "id": s.id.to_string(),
+                                    "title": s.title,
+                                    "status": s.status,
+                                    "severity": s.severity,
+                                    "client_id": s.client_id.map(|c| c.to_string()),
+                                    "cross_client_safe": s.cross_client_safe,
+                                    "created_at": s.created_at,
+                                    "similarity": format!("{:.1}%", (1.0 - s.distance) * 100.0),
+                                })
+                            })
+                            .collect();
+
+                        let client_lookup = build_client_lookup(&brain.pool).await;
+                        let filtered = filter_cross_client(
+                            candidates,
+                            "incident",
+                            client_id,
+                            acknowledge,
+                            &client_lookup,
+                        );
+
+                        log_audit_entries(
+                            &brain.pool,
+                            "create_incident",
+                            client_id,
+                            "incident",
+                            &filtered.audit_entries,
+                        )
+                        .await;
+
+                        similar_incidents_json = filtered.allowed;
+                        withheld_notices = filtered.withheld_notices;
+                    }
+                    Ok(_) => {} // empty match list — leave similar_incidents_json as []
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed similarity search for new incident {}: {e}",
+                            incident.id
+                        );
+                    }
+                }
+
+                // Store the embedding directly (we already computed it above).
+                if let Err(e) = crate::repo::embedding_repo::store_incident_embedding(
+                    &brain.pool,
+                    incident.id,
+                    &embedding,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        "Failed to store embedding for new incident {}: {e}",
+                        incident.id
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to generate embedding for new incident {}: {e}",
+                    incident.id
+                );
+            }
+        }
+    }
+
+    let mut response = serde_json::json!({
+        "incident": incident,
+        "_similar_incidents": similar_incidents_json,
+    });
+
+    if !withheld_notices.is_empty() {
+        response["_cross_client_withheld"] = serde_json::json!(withheld_notices);
+    }
+
+    json_result(&response)
 }
 
 pub(crate) async fn handle_update_incident(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,7 +3,7 @@ pub mod cc_team;
 mod context;
 mod coordination;
 mod helpers;
-mod incidents;
+pub mod incidents;
 mod inventory;
 pub mod knowledge;
 mod monitoring;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1008,6 +1008,268 @@ mod incident_tests {
     }
 }
 
+// ===== Incident Similarity (raid #3) =====
+
+mod incident_similarity_tests {
+    use super::*;
+    use ops_brain::repo::embedding_repo;
+    use ops_brain::repo::incident_repo;
+
+    fn build_brain(pool: PgPool) -> ops_brain::tools::OpsBrain {
+        ops_brain::tools::OpsBrain::new(pool, vec![], None, None)
+    }
+
+    fn extract_text(result: &rmcp::model::CallToolResult) -> String {
+        result
+            .content
+            .first()
+            .expect("result has at least one content item")
+            .as_text()
+            .expect("content is text")
+            .text
+            .clone()
+    }
+
+    /// Build a 768-dim test embedding with the given leading components,
+    /// rest zero. Cosine distance between two such vectors is determined
+    /// entirely by their non-zero components, so we can construct
+    /// deterministic "near" and "far" pairs without a real embedding service.
+    fn test_embedding(values: &[f32]) -> Vec<f32> {
+        let mut v = vec![0.0_f32; 768];
+        for (i, x) in values.iter().enumerate() {
+            v[i] = *x;
+        }
+        v
+    }
+
+    async fn cleanup_incidents(pool: &PgPool, ids: &[uuid::Uuid]) {
+        sqlx::query("DELETE FROM incidents WHERE id = ANY($1)")
+            .bind(ids.to_vec())
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn find_similar_open_incidents_returns_close_matches() {
+        let pool = pool().await;
+
+        // Two near-identical embeddings on the same dominant axis
+        let emb_existing = test_embedding(&[1.0, 0.0]);
+        let emb_query = test_embedding(&[0.99, 0.01]);
+
+        let existing = incident_repo::create_incident(
+            &pool,
+            "Database connection pool exhausted (similarity test)",
+            "high",
+            None,
+            None,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+        embedding_repo::store_incident_embedding(&pool, existing.id, &emb_existing)
+            .await
+            .unwrap();
+
+        // Probe with a different (synthetic) id — simulates the new incident
+        // querying against existing ones, excluding itself.
+        let probe_id = uuid::Uuid::now_v7();
+        let results =
+            embedding_repo::find_similar_open_incidents(&pool, &emb_query, probe_id, 0.30, 5)
+                .await
+                .unwrap();
+
+        assert!(
+            results.iter().any(|r| r.id == existing.id),
+            "expected existing incident to surface as similar; got {} results",
+            results.len()
+        );
+
+        cleanup_incidents(&pool, &[existing.id]).await;
+    }
+
+    #[tokio::test]
+    async fn find_similar_open_incidents_self_excludes() {
+        let pool = pool().await;
+        let emb = test_embedding(&[1.0, 0.0]);
+
+        let me = incident_repo::create_incident(
+            &pool,
+            "Self-exclusion test incident",
+            "low",
+            None,
+            None,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+        embedding_repo::store_incident_embedding(&pool, me.id, &emb)
+            .await
+            .unwrap();
+
+        // Query with my own embedding, exclude my own id
+        let results = embedding_repo::find_similar_open_incidents(&pool, &emb, me.id, 0.30, 10)
+            .await
+            .unwrap();
+
+        assert!(
+            !results.iter().any(|r| r.id == me.id),
+            "self-exclusion failed: an incident must not appear in its own similarity results"
+        );
+
+        cleanup_incidents(&pool, &[me.id]).await;
+    }
+
+    #[tokio::test]
+    async fn find_similar_open_incidents_excludes_resolved() {
+        let pool = pool().await;
+        let emb = test_embedding(&[1.0, 0.0]);
+
+        let to_be_resolved = incident_repo::create_incident(
+            &pool,
+            "Old fixed disk-full alert",
+            "low",
+            None,
+            None,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+        embedding_repo::store_incident_embedding(&pool, to_be_resolved.id, &emb)
+            .await
+            .unwrap();
+
+        // Mark it resolved
+        incident_repo::update_incident(
+            &pool,
+            to_be_resolved.id,
+            None,
+            Some("resolved"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let probe_id = uuid::Uuid::now_v7();
+        let results = embedding_repo::find_similar_open_incidents(&pool, &emb, probe_id, 0.30, 10)
+            .await
+            .unwrap();
+
+        assert!(
+            !results.iter().any(|r| r.id == to_be_resolved.id),
+            "resolved incidents must not surface in open-incidents similarity search"
+        );
+
+        cleanup_incidents(&pool, &[to_be_resolved.id]).await;
+    }
+
+    #[tokio::test]
+    async fn find_similar_open_incidents_respects_distance_threshold() {
+        let pool = pool().await;
+
+        // Orthogonal vectors → cosine distance ≈ 1.0, far above 0.30
+        let emb_x = test_embedding(&[1.0, 0.0]);
+        let emb_y = test_embedding(&[0.0, 1.0]);
+
+        let far_one = incident_repo::create_incident(
+            &pool,
+            "Unrelated billing question",
+            "low",
+            None,
+            None,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+        embedding_repo::store_incident_embedding(&pool, far_one.id, &emb_y)
+            .await
+            .unwrap();
+
+        let probe_id = uuid::Uuid::now_v7();
+        let results =
+            embedding_repo::find_similar_open_incidents(&pool, &emb_x, probe_id, 0.30, 10)
+                .await
+                .unwrap();
+
+        assert!(
+            !results.iter().any(|r| r.id == far_one.id),
+            "orthogonal embedding (distance ≈ 1.0) must not pass threshold 0.30"
+        );
+
+        cleanup_incidents(&pool, &[far_one.id]).await;
+    }
+
+    #[tokio::test]
+    async fn handler_create_incident_response_includes_similar_field() {
+        // build_brain passes None for embedding_client, so the similarity
+        // logic is skipped — but the response shape MUST still include
+        // `_similar_incidents` (as an empty array) so callers can rely on
+        // the field always being present. Guards against future regressions
+        // of the response contract.
+        let pool = pool().await;
+        let brain = build_brain(pool.clone());
+
+        let result = ops_brain::tools::incidents::handle_create_incident(
+            &brain,
+            ops_brain::tools::incidents::CreateIncidentParams {
+                title: format!("Shape contract {}", uuid::Uuid::now_v7()),
+                severity: Some("low".to_string()),
+                client_slug: None,
+                symptoms: None,
+                notes: None,
+                server_slugs: None,
+                service_slugs: None,
+                cross_client_safe: None,
+                acknowledge_cross_client: None,
+            },
+        )
+        .await;
+
+        assert_eq!(result.is_error, Some(false));
+        let text = extract_text(&result);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&text).expect("response is valid JSON");
+
+        assert!(
+            parsed.get("incident").is_some(),
+            "response must wrap the new incident under `incident`"
+        );
+        assert!(
+            parsed.get("_similar_incidents").is_some(),
+            "response must always include `_similar_incidents` (empty when no embedding client)"
+        );
+        assert!(
+            parsed["_similar_incidents"].is_array(),
+            "_similar_incidents must be an array"
+        );
+        assert_eq!(
+            parsed["_similar_incidents"].as_array().unwrap().len(),
+            0,
+            "no embedding client + clean DB = empty similar list"
+        );
+        assert!(
+            parsed.get("_cross_client_withheld").is_none(),
+            "_cross_client_withheld should be absent when nothing was withheld"
+        );
+
+        // Cleanup
+        let id_str = parsed["incident"]["id"].as_str().unwrap();
+        let id = uuid::Uuid::parse_str(id_str).unwrap();
+        cleanup_incidents(&pool, &[id]).await;
+    }
+}
+
 // ===== Session & Handoff Repo =====
 
 mod coordination_tests {


### PR DESCRIPTION
## Summary

Raid #3 of the post-PR#29 ops-brain roadmap. When `create_incident` is called, search for semantically similar OPEN incidents and surface them in the response so the calling CC sees *"this looks like work already in flight"* and can choose to link/dedupe via `link_incident` instead of duplicating effort.

- New repo function `find_similar_open_incidents` (modeled on `find_similar_knowledge`, threshold 0.30 ≈ 70% similarity, looser than knowledge's 0.15 because the goal is "related work" not duplicate detection)
- Refactored `handle_create_incident` to compute the embedding **once** and use it for both the similarity query AND the existing `store_incident_embedding` call (replaces `embed_and_store`, same number of API calls, plus one HNSW lookup)
- New param `acknowledge_cross_client: Option<bool>` releases withheld cross-client matches
- Best-effort: embedding outage logs a warning, never blocks the create

## Design notes

- **No schema change.** The `incidents.embedding` column and embed-on-create flow already existed (`embed_and_store` was being called from the handler). This PR just rewires that pipeline.
- **Cross-client gate reuse.** The SQL returns matches across all clients; the gate is applied at the handler layer using the existing `helpers::filter_cross_client` utility, with the new incident's `client_id` as `requesting_client_id`. Same pattern as `search_knowledge`. Withheld notices go to `_cross_client_withheld`. Audit-logged via `shared::log_audit_entries`.
- **Response shape change.** Handler now returns ` { incident, _similar_incidents, _cross_client_withheld? } ` instead of bare incident JSON. `_similar_incidents` is **always** present (empty array when no matches or no embedding client) — guarded by an explicit shape-contract test.
- **Threshold telemetry.** A `tracing::info!` logs new_incident id, similar_count, and min_distance whenever matches surface, so 0.30 can be retuned from real production data.
- **Visibility.** `tools::incidents` is now `pub` and `handle_create_incident` is now `pub` (was `pub(crate)`) so integration tests can call them. `tools::knowledge` already has the same shape; consistency wins.
- **Watchdog impact: none.** The watchdog calls `incident_repo::create_incident_with_source` directly, not the handler, so this refactor leaves the watchdog incident creation path untouched.

## Tests

5 new integration tests in `mod incident_similarity_tests`:

- `find_similar_open_incidents_returns_close_matches` — happy path
- `find_similar_open_incidents_self_excludes` — `id != \$exclude` correctness
- `find_similar_open_incidents_excludes_resolved` — `status='open'` filter
- `find_similar_open_incidents_respects_distance_threshold` — orthogonal vectors stay out
- `handler_create_incident_response_includes_similar_field` — shape-contract guard for the no-embedding-client path

Tests use synthetic 768-dim embeddings with leading non-zero components for deterministic distance calculations — no real embedding service required.

**Suite: 44 passed (was 39). Strict clippy (-D warnings) clean.** Reviewed via /review with the project reviewer checklist — zero criticals, zero blockers.

## Test plan

- [ ] Both CI checks green (Format + Lint + Test, Security Audit)
- [ ] CC-Cloud deploys to production via `docker-compose.prod.yml`
- [ ] Post-deploy smoke test: create a new incident in a scope where similar open incidents exist, verify `_similar_incidents` populated in the response with > 0 entries
- [ ] Post-deploy smoke test: create an incident in a clean scope, verify `_similar_incidents` is `[]`
- [ ] Tail logs for `create_incident: surfaced similar open incidents` info events to start gathering retune data for the 0.30 threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)