### PR TITLE
fix(coordination): normalize handoff machine names to canonical CC form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Handoff routing was silently dropping messages when sender and recipient used different name forms.** A CC writing `to_machine: "CC-Stealth"` (CC name) was invisible to a recipient running `check_in(my_name: "CC-Stealth")` because `check_in` queried by hostname (`stealth`) — and vice versa. The bug surfaced when CC-CPA sent a reply handoff with `to_machine: "CC-Stealth"` / `from_machine: "CC-CPA"` and the recipient's `check_in` returned 0. Fix: all handoff handlers now normalize machine-name inputs (CC name OR hostname OR mixed-case alias) to a single canonical CC-name form before write/query. Migration `20260426000002_normalize_handoff_machine_names.sql` backfills existing rows; idempotent, covers the five known hostname aliases (`stealth`, `kensai-cloud`, `HV-FS0`, `SMYT-SERVER`, legacy `CPA-SRV`).
+
+### Changed
+
+- **`CC_TEAM` table shape** in `src/tools/cc_team.rs` widened from `(cc_name, hostname, client_slug)` to `(cc_name, &[hostname_aliases], client_slug)`. CC-CPA's machine has been called both `SMYT-SERVER` and `CPA-SRV` across docs and history; both now resolve to `CC-CPA`. Adding more aliases is a one-line edit, not a schema change.
+- **`normalize_machine_name(input)` helper** added (case-insensitive, trims whitespace, returns canonical CC name with allowlist on error). Applied at `handle_create_handoff`, `handle_list_handoffs`, `handle_check_in`, and the `machine` filter in `handle_get_situational_awareness`.
+- **Tool param descriptions** updated on `CreateHandoffParams`, `ListHandoffsParams`, `CheckInParams`, `GetSituationalAwarenessParams.machine` to document the dual-form acceptance and CC-name canonical form.
+- **`is_valid_cc_name()` retained as a strict check** (case-sensitive, no hostnames) for `add_knowledge.author_cc` validation — provenance is immutable post-write, so loose normalization is the wrong tradeoff there.
+
 ## [1.8.0] — 2026-04-26
 
 **Runbooks killed.** The runbooks feature is gone — table, tools, junctions, embeddings, watchdog suggestions, every reference. Running theme of the v1.5/v1.6/v1.7 architecture is "ops-brain is the team bus, not a brain; local is the source of truth." Runbooks were the last surface still pulling against that principle: a centrally-stored procedural-doc store that drifted away from the systems it documented and required cross-CC maintenance to keep current. Per-system procedures now live where the systems live (each repo's CLAUDE.md, configs, and docs); cross-CC durable safety/compliance content stays in `knowledge` (which is what `knowledge` is for). Tool count: 64 → 59.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -135,4 +135,4 @@ Before opening a PR, verify:
 - [ ] No hardcoded credentials, URLs, or tokens
 - [ ] Migration files are idempotent (`IF NOT EXISTS`, etc.)
 - [ ] Cross-client safety considered: if the tool touches knowledge/incidents, does it need `client_slug` and `acknowledge_cross_client` params?
-- [ ] Handoff created to stealth for review/merge (PRs don't notify -- handoffs do)
+- [ ] Handoff created to CC-Stealth for review/merge (PRs don't notify -- handoffs do)

--- a/migrations/20260426000002_normalize_handoff_machine_names.sql
+++ b/migrations/20260426000002_normalize_handoff_machine_names.sql
@@ -1,0 +1,40 @@
+-- v1.9 — Normalize handoff machine names to canonical CC form.
+--
+-- Background: handoffs.from_machine and handoffs.to_machine were free-text
+-- and accumulated a mix of hostnames (`stealth`, `kensai-cloud`, `HV-FS0`,
+-- `SMYT-SERVER`, occasionally `CPA-SRV`) and CC names (`CC-Stealth`,
+-- `CC-CPA`, …). The mismatch silently broke `check_in` routing — a CC
+-- writing `to_machine = "CC-Stealth"` was invisible to a recipient
+-- querying by hostname `stealth`.
+--
+-- After this migration all rows store the canonical CC name. Tool handlers
+-- (handle_create_handoff, handle_list_handoffs, handle_check_in,
+-- handle_get_situational_awareness) normalize at the boundary so callers
+-- can still pass either form and converge on the CC name.
+--
+-- Idempotent: rerunning is a no-op because canonical CC values
+-- (`CC-Cloud`, `CC-Stealth`, `CC-HSR`, `CC-CPA`) are not in the WHEN list.
+-- LOWER() on the input handles mixed-case writes (`hv-fs0`, `Stealth`).
+-- Unknown values pass through unchanged via ELSE.
+
+UPDATE handoffs
+SET
+    from_machine = CASE LOWER(from_machine)
+        WHEN 'stealth' THEN 'CC-Stealth'
+        WHEN 'kensai-cloud' THEN 'CC-Cloud'
+        WHEN 'hv-fs0' THEN 'CC-HSR'
+        WHEN 'smyt-server' THEN 'CC-CPA'
+        WHEN 'cpa-srv' THEN 'CC-CPA'
+        ELSE from_machine
+    END,
+    to_machine = CASE LOWER(to_machine)
+        WHEN 'stealth' THEN 'CC-Stealth'
+        WHEN 'kensai-cloud' THEN 'CC-Cloud'
+        WHEN 'hv-fs0' THEN 'CC-HSR'
+        WHEN 'smyt-server' THEN 'CC-CPA'
+        WHEN 'cpa-srv' THEN 'CC-CPA'
+        ELSE to_machine
+    END
+WHERE
+    LOWER(from_machine) IN ('stealth', 'kensai-cloud', 'hv-fs0', 'smyt-server', 'cpa-srv')
+    OR LOWER(to_machine) IN ('stealth', 'kensai-cloud', 'hv-fs0', 'smyt-server', 'cpa-srv');

--- a/src/tools/cc_team.rs
+++ b/src/tools/cc_team.rs
@@ -3,14 +3,15 @@
 //! ops-brain is the team bus, not a brain. Each CC already knows who it is
 //! from its own CLAUDE.md. `check_in` exists for one reason: to answer
 //! "what's pending for me from the rest of the team?" — open handoffs to
-//! my machine, recent notifications, open incidents in my scope. It is
+//! my CC, recent notifications, open incidents in my scope. It is
 //! **opt-in**, not a mandatory startup ritual. Call it when you want to know
 //! what's waiting; otherwise just do the work.
 //!
-//! `CC_TEAM` is a tiny lookup table that translates `my_name` to a hostname
-//! (for handoff filtering) and to a client slug (for incident scoping). It
-//! is NOT identity storage — identity lives in each CC's per-machine
-//! CLAUDE.md.
+//! `CC_TEAM` is the authoritative table of CC names, the hostname aliases
+//! that should normalize to each CC, and each CC's client scope. Identity
+//! itself lives in each CC's per-machine CLAUDE.md — this table only
+//! exists so cross-CC tooling can speak both forms (CC name and hostname)
+//! and converge on a single canonical form (CC name).
 
 use rmcp::model::*;
 use schemars::JsonSchema;
@@ -19,69 +20,103 @@ use serde::Deserialize;
 use super::helpers::{error_result, json_result};
 use crate::repo::{client_repo, handoff_repo, incident_repo};
 
-/// The four CCs on the team. `(cc_name, hostname, client_slug)`.
+/// The four CCs on the team. `(canonical_cc_name, hostname_aliases, client_slug)`.
 /// `client_slug = None` means the CC operates globally / has no single client
 /// scope (cloud server, dev workstation).
 ///
+/// Multiple hostnames per CC are accepted as legacy/ergonomic aliases — for
+/// example CC-CPA's machine has been called both `CPA-SRV` and `SMYT-SERVER`
+/// across docs and history. Any alias normalizes to the canonical CC name.
+///
 /// To add a fifth CC: append one row here, set the new CC's hostname in its
 /// per-machine CLAUDE.md, and (if it owns a client) create the client row.
-pub const CC_TEAM: &[(&str, &str, Option<&str>)] = &[
-    ("CC-Cloud", "kensai-cloud", None),
-    ("CC-Stealth", "stealth", None),
-    ("CC-HSR", "HV-FS0", Some("hsr")),
-    ("CC-CPA", "CPA-SRV", Some("cpa")),
+pub const CC_TEAM: &[(&str, &[&str], Option<&str>)] = &[
+    ("CC-Cloud", &["kensai-cloud"], None),
+    ("CC-Stealth", &["stealth"], None),
+    ("CC-HSR", &["HV-FS0"], Some("hsr")),
+    ("CC-CPA", &["SMYT-SERVER", "CPA-SRV"], Some("cpa")),
 ];
 
-/// Returns `(hostname, client_slug)` if `cc_name` is in the allowlist.
-fn lookup(cc_name: &str) -> Option<(&'static str, Option<&'static str>)> {
+/// Normalize a CC name or hostname (any known alias) to its canonical CC name.
+/// Case-insensitive on the input. Returns an error string with the allowlist
+/// when the input doesn't match anything.
+///
+/// Examples — all of these resolve to `"CC-Stealth"`:
+/// `"CC-Stealth"`, `"cc-stealth"`, `"CC-STEALTH"`, `"stealth"`, `"STEALTH"`.
+///
+/// This is the right helper to call at any tool boundary that takes a
+/// machine name from a user/CC. Strict CC-name validation (no hostnames, no
+/// case folding) is `is_valid_cc_name` instead.
+pub(crate) fn normalize_machine_name(input: &str) -> Result<&'static str, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(format!(
+            "Empty CC name. Valid: {}",
+            cc_allowlist().join(", ")
+        ));
+    }
+
+    for (cc_name, hostnames, _) in CC_TEAM {
+        if cc_name.eq_ignore_ascii_case(trimmed) {
+            return Ok(*cc_name);
+        }
+        for h in *hostnames {
+            if h.eq_ignore_ascii_case(trimmed) {
+                return Ok(*cc_name);
+            }
+        }
+    }
+
+    Err(format!(
+        "Invalid CC name or hostname: '{}'. Valid CC names: {}",
+        input,
+        cc_allowlist().join(", ")
+    ))
+}
+
+/// Return the client slug for a canonical CC name. Returns `None` for CCs
+/// with global scope (CC-Cloud, CC-Stealth) and for unknown names.
+fn client_slug_for(cc_name: &str) -> Option<&'static str> {
     CC_TEAM
         .iter()
         .find(|(n, _, _)| *n == cc_name)
-        .map(|(_, h, c)| (*h, *c))
+        .and_then(|(_, _, c)| *c)
 }
 
-fn allowlist_names() -> Vec<&'static str> {
-    CC_TEAM.iter().map(|(n, _, _)| *n).collect()
-}
-
-/// Returns true if `cc_name` exactly matches one of the four valid CC names.
-/// Case-sensitive. Exposed for use by other tool handlers (e.g. knowledge
-/// provenance validation in `add_knowledge`) that need the same allowlist
-/// gate without duplicating the `CC_TEAM` table.
+/// True iff `cc_name` is exactly one of the four canonical CC names
+/// (case-sensitive, no hostnames). Used by `add_knowledge` provenance
+/// validation where strictness matters — knowledge `author_cc` is immutable
+/// after write and we don't want hostname-shaped values landing there.
 pub(crate) fn is_valid_cc_name(cc_name: &str) -> bool {
     CC_TEAM.iter().any(|(n, _, _)| *n == cc_name)
 }
 
-/// Returns the list of all valid CC names, in `CC_TEAM` declaration order.
-/// Use when building user-facing error messages that need to display the
-/// full allowlist.
+/// All canonical CC names in `CC_TEAM` declaration order.
 pub(crate) fn cc_allowlist() -> Vec<&'static str> {
-    allowlist_names()
+    CC_TEAM.iter().map(|(n, _, _)| *n).collect()
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CheckInParams {
-    /// Your CC name. Must be one of: CC-Cloud, CC-Stealth, CC-HSR, CC-CPA.
+    /// Your CC name (canonical: CC-Cloud, CC-Stealth, CC-HSR, CC-CPA).
+    /// Hostnames are also accepted and normalized.
     pub my_name: String,
 }
 
 pub async fn handle_check_in(brain: &super::OpsBrain, p: CheckInParams) -> CallToolResult {
-    let cc_name = p.my_name.trim();
-    let (hostname, client_slug) = match lookup(cc_name) {
-        Some(t) => t,
-        None => {
-            return error_result(&format!(
-                "Invalid CC name: '{cc_name}'. Valid: {}",
-                allowlist_names().join(", ")
-            ))
-        }
+    let cc_name = match normalize_machine_name(&p.my_name) {
+        Ok(n) => n,
+        Err(e) => return error_result(&e),
     };
+    let client_slug = client_slug_for(cc_name);
 
-    // Open action handoffs targeted at your machine.
+    // Open action handoffs targeted at your CC. Stored canonical form is
+    // the CC name (post-migration `20260426000002`); hostnames are
+    // normalized at write time so this lookup always uses the CC name.
     let action_handoffs = match handoff_repo::list_handoffs(
         &brain.pool,
         Some("pending"),
-        Some(hostname),
+        Some(cc_name),
         None,
         Some("action"),
         false,
@@ -93,13 +128,12 @@ pub async fn handle_check_in(brain: &super::OpsBrain, p: CheckInParams) -> CallT
         Err(e) => return error_result(&format!("Failed to load action handoffs: {e}")),
     };
 
-    // Recent notify-class handoffs targeted at your machine (compact: id/title/from/created_at only).
+    // Recent notify-class handoffs targeted at your CC (compact: id/title/from/created_at only).
     // Notifications older than NOTIFY_TTL_DAYS are filtered at the repo level.
-    // include_notify is ignored when category is set explicitly — passing false for clarity.
     let notify_handoffs = match handoff_repo::list_handoffs(
         &brain.pool,
         Some("pending"),
-        Some(hostname),
+        Some(cc_name),
         None,
         Some("notify"),
         false,
@@ -181,36 +215,103 @@ mod tests {
     fn cc_team_has_four_unique_entries() {
         assert_eq!(CC_TEAM.len(), 4);
         let names: std::collections::HashSet<_> = CC_TEAM.iter().map(|(n, _, _)| *n).collect();
-        let hosts: std::collections::HashSet<_> = CC_TEAM.iter().map(|(_, h, _)| *h).collect();
-        assert_eq!(names.len(), 4, "duplicate CC names");
-        assert_eq!(hosts.len(), 4, "duplicate hostnames");
-    }
+        assert_eq!(names.len(), 4, "duplicate canonical CC names");
 
-    #[test]
-    fn allowlist_round_trip() {
-        for (n, h, _) in CC_TEAM {
-            assert!(lookup(n).is_some(), "{n} should be in allowlist");
-            assert_eq!(lookup(n).map(|(host, _)| host), Some(*h));
+        // Hostname aliases must be unique across all CCs (a hostname can't
+        // map to two different CCs).
+        let mut seen = std::collections::HashSet::new();
+        for (cc, hosts, _) in CC_TEAM {
+            for h in *hosts {
+                let key = h.to_ascii_lowercase();
+                assert!(
+                    seen.insert(key),
+                    "hostname '{h}' appears twice (in or before {cc})"
+                );
+            }
         }
     }
 
     #[test]
-    fn allowlist_rejects_unknown() {
-        assert!(lookup("CC-NotReal").is_none());
-        assert!(lookup("").is_none());
-        assert!(
-            lookup("cc-stealth").is_none(),
-            "names should be case-sensitive"
-        );
+    fn normalize_canonical_cc_name() {
+        assert_eq!(normalize_machine_name("CC-Stealth").unwrap(), "CC-Stealth");
+        assert_eq!(normalize_machine_name("CC-Cloud").unwrap(), "CC-Cloud");
+        assert_eq!(normalize_machine_name("CC-HSR").unwrap(), "CC-HSR");
+        assert_eq!(normalize_machine_name("CC-CPA").unwrap(), "CC-CPA");
     }
 
     #[test]
-    fn allowlist_names_returns_all_four() {
-        let names = allowlist_names();
-        assert_eq!(names.len(), 4);
-        assert!(names.contains(&"CC-Cloud"));
-        assert!(names.contains(&"CC-Stealth"));
-        assert!(names.contains(&"CC-HSR"));
-        assert!(names.contains(&"CC-CPA"));
+    fn normalize_hostname_alias() {
+        assert_eq!(normalize_machine_name("stealth").unwrap(), "CC-Stealth");
+        assert_eq!(normalize_machine_name("kensai-cloud").unwrap(), "CC-Cloud");
+        assert_eq!(normalize_machine_name("HV-FS0").unwrap(), "CC-HSR");
+        assert_eq!(normalize_machine_name("SMYT-SERVER").unwrap(), "CC-CPA");
+        // Legacy alias still accepted.
+        assert_eq!(normalize_machine_name("CPA-SRV").unwrap(), "CC-CPA");
+    }
+
+    #[test]
+    fn normalize_is_case_insensitive() {
+        assert_eq!(normalize_machine_name("cc-stealth").unwrap(), "CC-Stealth");
+        assert_eq!(normalize_machine_name("CC-STEALTH").unwrap(), "CC-Stealth");
+        assert_eq!(normalize_machine_name("STEALTH").unwrap(), "CC-Stealth");
+        assert_eq!(normalize_machine_name("hv-fs0").unwrap(), "CC-HSR");
+        assert_eq!(normalize_machine_name("smyt-server").unwrap(), "CC-CPA");
+    }
+
+    #[test]
+    fn normalize_trims_whitespace() {
+        assert_eq!(
+            normalize_machine_name("  CC-Stealth  ").unwrap(),
+            "CC-Stealth"
+        );
+        assert_eq!(normalize_machine_name("\tstealth\n").unwrap(), "CC-Stealth");
+    }
+
+    #[test]
+    fn normalize_rejects_unknown() {
+        let err = normalize_machine_name("CC-NotReal").unwrap_err();
+        assert!(err.contains("CC-NotReal"));
+        assert!(
+            err.contains("CC-Stealth"),
+            "allowlist should appear in error"
+        );
+
+        let err_empty = normalize_machine_name("").unwrap_err();
+        assert!(err_empty.contains("Empty"));
+
+        let err_ws = normalize_machine_name("   ").unwrap_err();
+        assert!(err_ws.contains("Empty"));
+
+        assert!(normalize_machine_name("random-host").is_err());
+    }
+
+    #[test]
+    fn is_valid_cc_name_is_strict() {
+        assert!(is_valid_cc_name("CC-Stealth"));
+        assert!(is_valid_cc_name("CC-Cloud"));
+        assert!(is_valid_cc_name("CC-HSR"));
+        assert!(is_valid_cc_name("CC-CPA"));
+
+        // Strict mode does NOT accept the things normalize accepts.
+        assert!(!is_valid_cc_name("cc-stealth"), "strict is case-sensitive");
+        assert!(!is_valid_cc_name("stealth"), "strict rejects hostnames");
+        assert!(!is_valid_cc_name(""));
+    }
+
+    #[test]
+    fn cc_allowlist_returns_all_four_in_order() {
+        let names = cc_allowlist();
+        assert_eq!(names, vec!["CC-Cloud", "CC-Stealth", "CC-HSR", "CC-CPA"]);
+    }
+
+    #[test]
+    fn client_slug_for_canonical_cc() {
+        assert_eq!(client_slug_for("CC-HSR"), Some("hsr"));
+        assert_eq!(client_slug_for("CC-CPA"), Some("cpa"));
+        assert_eq!(client_slug_for("CC-Cloud"), None);
+        assert_eq!(client_slug_for("CC-Stealth"), None);
+        assert_eq!(client_slug_for("not-a-cc"), None);
+        // Strict — case mismatch returns None.
+        assert_eq!(client_slug_for("cc-hsr"), None);
     }
 }

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -18,7 +18,8 @@ pub struct GetSituationalAwarenessParams {
     pub service_slug: Option<String>,
     /// Client slug to get context for
     pub client_slug: Option<String>,
-    /// Machine hostname — filters handoffs to those addressed to you
+    /// Your CC (CC-Cloud, CC-Stealth, CC-HSR, CC-CPA) — filters handoffs
+    /// addressed to you. Hostnames also accepted and normalized.
     pub machine: Option<String>,
     /// Release cross-client results withheld due to scope mismatch
     pub acknowledge_cross_client: Option<bool>,
@@ -331,20 +332,39 @@ pub(crate) async fn handle_get_situational_awareness(
         }
     }
 
-    // Get pending handoffs (scoped to machine if provided)
-    let handoff_result = if let Some(ref machine) = p.machine {
-        sqlx::query_as::<_, Handoff>(
+    // Get pending handoffs. If `machine` is provided, normalize it (CC name
+    // or hostname → canonical CC name) and filter. If normalization fails
+    // (unknown name), record a warning and skip the handoff section
+    // entirely — falling through to the unfiltered query would surprise the
+    // caller by returning every pending handoff in the system.
+    enum MachineFilter<'a> {
+        None,
+        Filter(&'a str),
+        Skip,
+    }
+    let machine_filter = match p.machine.as_deref() {
+        None => MachineFilter::None,
+        Some(raw) => match super::cc_team::normalize_machine_name(raw) {
+            Ok(n) => MachineFilter::Filter(n),
+            Err(e) => {
+                warnings.push(format!("machine filter ignored: {e}"));
+                MachineFilter::Skip
+            }
+        },
+    };
+    let handoff_result = match machine_filter {
+        MachineFilter::Filter(machine) => sqlx::query_as::<_, Handoff>(
             "SELECT * FROM handoffs WHERE status = 'pending' AND to_machine = $1 ORDER BY created_at DESC LIMIT 10",
         )
         .bind(machine)
         .fetch_all(&brain.pool)
-        .await
-    } else {
-        sqlx::query_as::<_, Handoff>(
+        .await,
+        MachineFilter::None => sqlx::query_as::<_, Handoff>(
             "SELECT * FROM handoffs WHERE status = 'pending' ORDER BY created_at DESC LIMIT 10",
         )
         .fetch_all(&brain.pool)
-        .await
+        .await,
+        MachineFilter::Skip => Ok(Vec::new()),
     };
     match handoff_result {
         Ok(handoffs) => {

--- a/src/tools/coordination.rs
+++ b/src/tools/coordination.rs
@@ -11,9 +11,11 @@ use rmcp::model::*;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CreateHandoffParams {
-    /// Machine this handoff is coming from
+    /// Sender CC. Use the canonical CC name (CC-Cloud, CC-Stealth, CC-HSR,
+    /// CC-CPA). Hostnames are accepted and normalized to the CC name on write.
     pub from_machine: String,
-    /// Target machine (optional — if omitted, any machine can pick it up)
+    /// Target CC (optional — if omitted, any CC can pick it up). Same form
+    /// as `from_machine`: CC name preferred, hostnames normalized.
     pub to_machine: Option<String>,
     /// Priority: low, normal, high, or critical
     pub priority: Option<String>,
@@ -42,9 +44,9 @@ pub struct UpdateHandoffStatusParams {
 pub struct ListHandoffsParams {
     /// Filter by status: pending, accepted, or completed
     pub status: Option<String>,
-    /// Filter by target machine
+    /// Filter by target CC (CC name or hostname; normalized before query).
     pub to_machine: Option<String>,
-    /// Filter by source machine
+    /// Filter by source CC (CC name or hostname; normalized before query).
     pub from_machine: Option<String>,
     /// Filter by category: "action" or "notify". Overrides include_notify
     /// when set. Omit to use the default action-only view.
@@ -109,11 +111,26 @@ pub(crate) async fn handle_create_handoff(
         None => None,
     };
 
+    // Normalize sender + target to canonical CC name. Either form (CC name
+    // or hostname) is accepted on input; the DB stores only the CC name so
+    // that `check_in` lookups don't depend on which form the writer used.
+    let from_machine = match super::cc_team::normalize_machine_name(&p.from_machine) {
+        Ok(n) => n,
+        Err(e) => return error_result(&format!("from_machine: {e}")),
+    };
+    let to_machine = match p.to_machine.as_deref() {
+        Some(raw) => match super::cc_team::normalize_machine_name(raw) {
+            Ok(n) => Some(n),
+            Err(e) => return error_result(&format!("to_machine: {e}")),
+        },
+        None => None,
+    };
+
     match crate::repo::handoff_repo::create_handoff(
         &brain.pool,
         from_session_id,
-        &p.from_machine,
-        p.to_machine.as_deref(),
+        from_machine,
+        to_machine,
         priority,
         category,
         &p.title,
@@ -211,11 +228,28 @@ pub(crate) async fn handle_list_handoffs(
         return error_result(&msg);
     }
 
+    // Normalize machine-name filters so callers can query by CC name or
+    // hostname interchangeably; rows are stored in canonical CC form.
+    let to_machine_filter = match p.to_machine.as_deref() {
+        Some(raw) => match super::cc_team::normalize_machine_name(raw) {
+            Ok(n) => Some(n),
+            Err(e) => return error_result(&format!("to_machine: {e}")),
+        },
+        None => None,
+    };
+    let from_machine_filter = match p.from_machine.as_deref() {
+        Some(raw) => match super::cc_team::normalize_machine_name(raw) {
+            Ok(n) => Some(n),
+            Err(e) => return error_result(&format!("from_machine: {e}")),
+        },
+        None => None,
+    };
+
     match crate::repo::handoff_repo::list_handoffs(
         &brain.pool,
         p.status.as_deref(),
-        p.to_machine.as_deref(),
-        p.from_machine.as_deref(),
+        to_machine_filter,
+        from_machine_filter,
         p.category.as_deref(),
         include_notify,
         limit,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -500,9 +500,9 @@ impl OpsBrain {
 
     #[tool(
         name = "check_in",
-        description = "Pending-work query: open handoffs for your machine, recent \
+        description = "Pending-work query: open handoffs addressed to your CC, recent \
         notify-class handoffs (compact), and open incidents in your scope. Pass \
-        `my_name` (your CC name) to scope results."
+        `my_name` (your CC name; hostname also accepted) to scope results."
     )]
     async fn check_in(
         &self,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1315,6 +1315,136 @@ mod coordination_tests {
             .await
             .unwrap();
     }
+
+    /// Verifies migration `20260426000002_normalize_handoff_machine_names.sql`
+    /// is idempotent and covers every legacy hostname → canonical CC mapping.
+    /// Re-runs the migration's UPDATE on synthetic rows containing each known
+    /// hostname (mixed-case included) and confirms convergence to CC names.
+    /// Running it a second time must be a no-op.
+    #[tokio::test]
+    async fn handoff_machine_names_migration_is_idempotent() {
+        let pool = pool().await;
+
+        // Seed one row per known hostname, in mixed casing to verify LOWER()
+        // handling. Each row stores the same hostname in both from_ and to_
+        // so we exercise both columns at once.
+        let cases = [
+            ("stealth", "CC-Stealth"),
+            ("kensai-cloud", "CC-Cloud"),
+            ("HV-FS0", "CC-HSR"),
+            ("SMYT-SERVER", "CC-CPA"),
+            ("CPA-SRV", "CC-CPA"),
+            // Mixed case, should still normalize:
+            ("HV-fs0", "CC-HSR"),
+            ("smyt-server", "CC-CPA"),
+        ];
+        let mut ids = Vec::new();
+        for (hostname, _expected) in &cases {
+            let h = ops_brain::repo::handoff_repo::create_handoff(
+                &pool,
+                None,
+                hostname,
+                Some(hostname),
+                "normal",
+                "action",
+                "migration round-trip test",
+                "body",
+                None,
+            )
+            .await
+            .unwrap();
+            ids.push(h.id);
+        }
+
+        // Inline the migration's UPDATE so the test exercises the exact SQL
+        // that ships in the file. If you change the migration, mirror the
+        // change here.
+        let migration_sql = r#"
+            UPDATE handoffs
+            SET
+                from_machine = CASE LOWER(from_machine)
+                    WHEN 'stealth' THEN 'CC-Stealth'
+                    WHEN 'kensai-cloud' THEN 'CC-Cloud'
+                    WHEN 'hv-fs0' THEN 'CC-HSR'
+                    WHEN 'smyt-server' THEN 'CC-CPA'
+                    WHEN 'cpa-srv' THEN 'CC-CPA'
+                    ELSE from_machine
+                END,
+                to_machine = CASE LOWER(to_machine)
+                    WHEN 'stealth' THEN 'CC-Stealth'
+                    WHEN 'kensai-cloud' THEN 'CC-Cloud'
+                    WHEN 'hv-fs0' THEN 'CC-HSR'
+                    WHEN 'smyt-server' THEN 'CC-CPA'
+                    WHEN 'cpa-srv' THEN 'CC-CPA'
+                    ELSE to_machine
+                END
+            WHERE
+                LOWER(from_machine) IN ('stealth', 'kensai-cloud', 'hv-fs0', 'smyt-server', 'cpa-srv')
+                OR LOWER(to_machine) IN ('stealth', 'kensai-cloud', 'hv-fs0', 'smyt-server', 'cpa-srv')
+        "#;
+
+        let first_run = sqlx::query(migration_sql)
+            .execute(&pool)
+            .await
+            .unwrap()
+            .rows_affected();
+        assert!(
+            first_run >= ids.len() as u64,
+            "first migration pass should touch every seeded row (got {first_run}, seeded {})",
+            ids.len()
+        );
+
+        // Verify each row converged to its expected CC name.
+        for (id, (_hostname, expected_cc)) in ids.iter().zip(cases.iter()) {
+            let row: (String, Option<String>) =
+                sqlx::query_as("SELECT from_machine, to_machine FROM handoffs WHERE id = $1")
+                    .bind(id)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(row.0, *expected_cc, "from_machine for row {id}");
+            assert_eq!(
+                row.1.as_deref(),
+                Some(*expected_cc),
+                "to_machine for row {id}"
+            );
+        }
+
+        // Idempotency: rerunning must affect zero of our seeded rows
+        // (canonical CC names are NOT in the WHEN list).
+        let second_run = sqlx::query(migration_sql)
+            .execute(&pool)
+            .await
+            .unwrap()
+            .rows_affected();
+        // Other tests may have left non-canonical rows in the table; what we
+        // can guarantee is our seeded rows did not change.
+        let _ = second_run;
+        for (id, (_, expected_cc)) in ids.iter().zip(cases.iter()) {
+            let row: (String, Option<String>) =
+                sqlx::query_as("SELECT from_machine, to_machine FROM handoffs WHERE id = $1")
+                    .bind(id)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                row.0, *expected_cc,
+                "second pass changed from_machine for {id}"
+            );
+            assert_eq!(
+                row.1.as_deref(),
+                Some(*expected_cc),
+                "second pass changed to_machine for {id}"
+            );
+        }
+
+        // Cleanup
+        sqlx::query("DELETE FROM handoffs WHERE id = ANY($1)")
+            .bind(&ids)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
 }
 
 // ===== Audit Log Repo =====


### PR DESCRIPTION
## Summary

Handoff routing was silently dropping messages when sender and recipient used different name forms. CC-CPA sent a reply handoff today with `from_machine: "CC-CPA"` / `to_machine: "CC-Stealth"`; the recipient's `check_in(my_name: "CC-Stealth")` returned 0 because it queried by hostname `stealth`. The row was in the DB but invisible to the routing query.

This PR makes the dual-form reality explicit: all handoff handlers accept either CC name or hostname, normalize to a single canonical CC-name form, and converge on it in storage. The friction the user originally flagged ("handoffs aren't being addressed to CC names") is no longer load-bearing — both forms work, the convention is documented.

## What changed

- **`normalize_machine_name(input)`** in `src/tools/cc_team.rs` — case-insensitive, trims whitespace, accepts CC names or any known hostname alias, returns the canonical CC name with full allowlist on error.
- **`CC_TEAM` widened** from `(cc_name, hostname, client_slug)` to `(cc_name, &[hostname_aliases], client_slug)`. CC-CPA's machine has been called both `SMYT-SERVER` and `CPA-SRV` across docs/history; both now resolve to `CC-CPA`. Adding more aliases is a one-line edit.
- **Applied at all I/O boundaries:** `handle_create_handoff`, `handle_list_handoffs`, `handle_check_in`, and the `machine` filter in `handle_get_situational_awareness` (where bad input now skips the section vs. accidentally returning all pending handoffs via the unfiltered fallback).
- **Migration `20260426000002_normalize_handoff_machine_names.sql`** — idempotent backfill of existing rows: `stealth`, `kensai-cloud`, `HV-FS0`, `SMYT-SERVER`, legacy `CPA-SRV` → CC names. Mixed-case handled via `LOWER()`. Rerunning is a no-op (canonical CC values aren't in the WHEN list).
- **`is_valid_cc_name()` kept strict** (case-sensitive, no hostnames) for `add_knowledge.author_cc` validation. Provenance is immutable post-write so loose normalization is the wrong tradeoff there.
- Tool param descriptions on `CreateHandoffParams`, `ListHandoffsParams`, `CheckInParams`, and `GetSituationalAwarenessParams.machine` updated to document the dual-form acceptance.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 125 passed (+5 new `cc_team` unit tests covering canonical form, hostname aliases incl. legacy `CPA-SRV`, case-insensitivity, whitespace trim, rejection messages, strict `is_valid_cc_name`)
- [x] `cargo test --test integration` — 43 passed (+1 new `handoff_machine_names_migration_is_idempotent` that runs the migration SQL on synthetic seeded rows in mixed casing, asserts convergence across all five aliases, then re-runs and asserts no further changes)
- [ ] Post-deploy: CC-CPA sends a fresh handoff with `from_machine: "CC-CPA"` / `to_machine: "CC-Stealth"`, recipient runs `check_in(my_name: "CC-Stealth")`, handoff appears in `open_handoffs_to_you` (this is the exact bug repro)
- [ ] Post-deploy: existing rows in `handoffs` show CC-name form for all five legacy hostnames

🤖 Generated with [Claude Code](https://claude.com/claude-code)