### PR TITLE
chore(deps): bump rmcp 1.2 → 1.6 + opt-in DNS-rebind allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ OPS_BRAIN_TRANSPORT=http
 # HTTP settings (only used when transport=http)
 OPS_BRAIN_LISTEN=0.0.0.0:3000
 OPS_BRAIN_AUTH_TOKEN=
+# Comma-separated allowed Host headers (DNS-rebind mitigation, rmcp 1.4+).
+# Defaults to loopback only. Public deployments behind a reverse proxy
+# MUST list their public hostname, e.g.: ops.example.com,ops.example.com:443
+OPS_BRAIN_ALLOWED_HOSTS=
 
 # Auto-migrate on startup
 OPS_BRAIN_MIGRATE=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ops-brain
 
-Rust MCP server for IT operational intelligence. Rust 2021, rmcp 1.2, PostgreSQL 18 via sqlx, stdio/HTTP transport.
+Rust MCP server for IT operational intelligence. Rust 2021, rmcp 1.6, PostgreSQL 18 via sqlx, stdio/HTTP transport.
 
 For project layout, env vars, subsystem details: see `docs/REFERENCE.md`
 For adding tools, branch/commit conventions, PR checklist: see `docs/CONTRIBUTING.md`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
  "base64",
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/TheK3nsai/ops-brain"
 
 [dependencies]
 # MCP SDK
-rmcp = { version = "1.2", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "1.5", features = ["server", "transport-io", "transport-streamable-http-server"] }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/TheK3nsai/ops-brain"
 
 [dependencies]
 # MCP SDK
-rmcp = { version = "1.5", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "1.6", features = ["server", "transport-io", "transport-streamable-http-server"] }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -59,6 +59,7 @@ just check          # fmt + clippy + test
 | `OPS_BRAIN_TRANSPORT` | `stdio` | Transport: `stdio` or `http` |
 | `OPS_BRAIN_LISTEN` | `0.0.0.0:3000` | HTTP bind address |
 | `OPS_BRAIN_AUTH_TOKEN` | (none) | Bearer token for HTTP auth |
+| `OPS_BRAIN_ALLOWED_HOSTS` | loopback only | Comma-separated allowed `Host` header values for HTTP transport (rmcp 1.4+ DNS-rebind mitigation). Public deploys behind a reverse proxy must set their hostname. |
 | `OPS_BRAIN_MIGRATE` | `true` | Run migrations on startup |
 | `UPTIME_KUMA_URL` | (none) | Uptime Kuma base URL for /metrics scraping (single instance) |
 | `UPTIME_KUMA_USERNAME` | (none) | Basic auth username for /metrics (single instance) |

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,12 @@ pub struct Config {
     #[arg(long, env = "OPS_BRAIN_AUTH_TOKEN")]
     pub auth_token: Option<String>,
 
+    /// Comma-separated allowed Host header values for HTTP transport (DNS-rebind mitigation
+    /// added in rmcp 1.4). Defaults to loopback only — public deployments behind a reverse
+    /// proxy must list their public hostname (e.g. `ops.example.com,ops.example.com:443`).
+    #[arg(long, env = "OPS_BRAIN_ALLOWED_HOSTS")]
+    pub allowed_hosts: Option<String>,
+
     /// Run database migrations on startup
     #[arg(long, env = "OPS_BRAIN_MIGRATE", default_value = "true")]
     pub migrate: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,6 +221,9 @@ async fn main() -> anyhow::Result<()> {
                 .route("/briefing", axum::routing::post(api::generate_briefing))
                 .with_state(api_state);
 
+            // Outer .layer wraps everything below — auth runs BEFORE rmcp's
+            // host check inside /mcp. Don't reorder: unauthenticated callers
+            // shouldn't be able to enumerate which Host values are accepted.
             let app = axum::Router::new()
                 .route("/health", axum::routing::get(|| async { "OK" }))
                 .nest("/api", api_routes)

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,8 @@ async fn main() -> anyhow::Result<()> {
         }
         "http" => {
             use rmcp::transport::streamable_http_server::{
-                session::local::LocalSessionManager, tower::StreamableHttpService,
+                session::local::LocalSessionManager,
+                tower::{StreamableHttpServerConfig, StreamableHttpService},
             };
             use std::sync::Arc;
 
@@ -174,6 +175,31 @@ async fn main() -> anyhow::Result<()> {
                 kuma_configs: kuma_configs.clone(),
                 zammad_config: zammad_config.clone(),
             });
+
+            let mut http_config = StreamableHttpServerConfig::default();
+            let parsed_hosts: Vec<String> = config
+                .allowed_hosts
+                .as_deref()
+                .map(|h| {
+                    h.split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default();
+            if !parsed_hosts.is_empty() {
+                tracing::info!("HTTP allowed_hosts: {:?}", parsed_hosts);
+                http_config = http_config.with_allowed_hosts(parsed_hosts);
+            } else if config.allowed_hosts.is_some() {
+                tracing::warn!(
+                    "OPS_BRAIN_ALLOWED_HOSTS set but empty/whitespace; using loopback default. \
+                     Empty allowlist disables DNS-rebind protection in rmcp — refusing."
+                );
+            } else {
+                tracing::info!(
+                    "HTTP allowed_hosts: loopback default (set OPS_BRAIN_ALLOWED_HOSTS for public deploy)"
+                );
+            }
 
             let kuma_configs_http = kuma_configs.clone();
             let embedding_client_http = embedding_client.clone();
@@ -188,7 +214,7 @@ async fn main() -> anyhow::Result<()> {
                     ))
                 },
                 session_manager,
-                Default::default(),
+                http_config,
             );
 
             let api_routes = axum::Router::new()

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -12,9 +12,8 @@ mod shared;
 mod zammad;
 
 use rmcp::{
-    handler::server::{tool::ToolRouter, wrapper::Parameters},
-    model::*,
-    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
+    handler::server::wrapper::Parameters, model::*, tool, tool_handler, tool_router,
+    ErrorData as McpError, ServerHandler,
 };
 use sqlx::PgPool;
 
@@ -28,7 +27,6 @@ pub struct OpsBrain {
     pub(crate) kuma_configs: Vec<UptimeKumaConfig>,
     pub(crate) embedding_client: Option<EmbeddingClient>,
     pub(crate) zammad_config: Option<ZammadConfig>,
-    tool_router: ToolRouter<Self>,
 }
 
 #[tool_router]
@@ -44,7 +42,6 @@ impl OpsBrain {
             kuma_configs,
             embedding_client,
             zammad_config,
-            tool_router: Self::tool_router(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Bump `rmcp` 1.2 → 1.6 (caret-semver from `"1.5"` resolves to 1.6.0)
- Wire new `OPS_BRAIN_ALLOWED_HOSTS` env var through to `StreamableHttpServerConfig::with_allowed_hosts` — required because rmcp 1.4 added a Host header check (PR #764, DNS-rebind mitigation) defaulting to loopback only
- Drop now-unused `tool_router: ToolRouter<Self>` field from `OpsBrain` — rmcp 1.4's `#[tool_handler]` macro auto-generates the default router via the static `Self::tool_router()`, so the field is never read

## Why now
Four minor releases of rmcp had accumulated since 1.2 (released 2026-03-11). Notable picks in this bump:
- **1.4** — host check (#764), unified `IntoCallToolResult` impls (#787), auto-generated `get_info`/router (#785)
- **1.5** — drain SSE stream for connection reuse (#790), 2025-11-25 protocol version
- **1.6** — HTTP/2 `:authority` fallback for reverse-proxy setups (#827), opt-in Origin validation (#823 — we leave it off, defaults to empty `Vec` = disabled), runtime tool disabling (#809)

## ⚠️ Deploy gotcha
**Before** rolling out the new image to `ops.kensai.cloud`, the production `.env` MUST set:
```
OPS_BRAIN_ALLOWED_HOSTS=ops.kensai.cloud,ops.kensai.cloud:443
```
Otherwise rmcp's host check will 4xx every request (the loopback default rejects the public hostname). The container itself will start fine — failure is request-time, not boot-time, so it'll look healthy in `docker compose ps` but tools will be unreachable through Caddy.

## Safety guards in this PR
- Empty-string `OPS_BRAIN_ALLOWED_HOSTS=` (set but blank) is a footgun: rmcp treats `with_allowed_hosts(vec![])` as **allow-all** (a sentinel that disables host validation entirely). Caught in /prereview — the parser now detects empty input, logs a warning, and falls through to the loopback default rather than silently disabling protection.

## Test plan
- [x] `cargo check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --lib` — 125/125 pass
- [x] `cargo test --test integration` — 43/43 pass against local Postgres
- [x] /prereview — one critical found (empty-string footgun) and fixed before commit
- [ ] Post-merge: CC-Cloud sets `OPS_BRAIN_ALLOWED_HOSTS` in prod `.env`, then deploys
- [ ] Post-deploy: verify `https://ops.kensai.cloud/mcp` still serves tool list (smoke via MCP client, or `curl -H "Host: ops.kensai.cloud" -H "Authorization: Bearer ..."`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)