### PR TITLE
fix: plumb OPS_BRAIN_ALLOWED_HOSTS into prod compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,6 +21,8 @@ services:
       - OPS_BRAIN_LISTEN=0.0.0.0:3000
       - OPS_BRAIN_AUTH_TOKEN=${OPS_BRAIN_AUTH_TOKEN}
       - OPS_BRAIN_MIGRATE=true
+      # rmcp 1.4+ Host header allowlist (DNS-rebind mitigation, default loopback-only)
+      - OPS_BRAIN_ALLOWED_HOSTS=${OPS_BRAIN_ALLOWED_HOSTS:-}
       # Uptime Kuma monitoring (multi-instance JSON)
       - UPTIME_KUMA_INSTANCES=${UPTIME_KUMA_INSTANCES}
       # Embeddings (ollama on same Docker network)


### PR DESCRIPTION
## Summary

- Adds `OPS_BRAIN_ALLOWED_HOSTS` to `docker-compose.prod.yml`'s `environment:` block so compose substitutes it from `.env`.
- Follow-up to #47, which wired the env var into the binary but missed the compose plumbing.

## Why

Caught at deploy time on kensai.cloud (handoff `019df2ea`). After bringing up the rebuilt container, startup logs showed:

```
HTTP allowed_hosts: loopback default (set OPS_BRAIN_ALLOWED_HOSTS for public deploy)
```

even though `~/docker/ops-brain/.env` carried `OPS_BRAIN_ALLOWED_HOSTS=ops.kensai.cloud,ops.kensai.cloud:443`. The compose `environment:` block enumerates vars explicitly (no `env_file`), so an unlisted var never reaches the container. Result: every public request through Caddy would 4xx on the rmcp 1.4+ host check.

After this patch + `up -d` recreate, prod logs show:

```
HTTP allowed_hosts: ["ops.kensai.cloud", "ops.kensai.cloud:443"]
```

`curl -i https://ops.kensai.cloud/mcp` returns 401 (auth-required, host check passed). Container healthy, MCP reachable end-to-end.

## Test plan

- [x] Manual: edited prod compose + `docker compose -f docker-compose.prod.yml up -d`; verified env reaches container via `docker exec ops-brain printenv OPS_BRAIN_ALLOWED_HOSTS`
- [x] Verified startup log line shows the configured list, not the loopback fallback
- [x] Verified `/health` over Caddy and `/mcp` no longer 4xx on host check

🤖 Generated with [Claude Code](https://claude.com/claude-code)