### PR TITLE
docs(contributing): add env-var compose-plumbing check to PR checklist

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -134,5 +134,6 @@ Before opening a PR, verify:
 - [ ] README.md updated if tool count changed
 - [ ] No hardcoded credentials, URLs, or tokens
 - [ ] Migration files are idempotent (`IF NOT EXISTS`, etc.)
+- [ ] If you added an env var the binary reads: also added it to `docker-compose.prod.yml` under `environment:` (prod compose enumerates explicitly — no `env_file:`) and to `.env.example`
 - [ ] Cross-client safety considered: if the tool touches knowledge/incidents, does it need `client_slug` and `acknowledge_cross_client` params?
 - [ ] Handoff created to CC-Stealth for review/merge (PRs don't notify -- handoffs do)


### PR DESCRIPTION
## Summary

One-line guardrail in the PR Checklist: if a PR adds an env var the binary reads, the author must also plumb it into `docker-compose.prod.yml` and `.env.example`.

## Why

Caught at deploy time in the rmcp 1.6 rollout (#47 → #48). The binary side was correct; what got missed was that prod compose enumerates env vars explicitly under `environment:` with no `env_file:` directive, so the value sat in `.env` and never reached the container. The binary fell back to its default (loopback-only allowlist) and Caddy → container traffic would have 4xx'd silently.

#48 fixed this specific instance. This PR makes the guardrail durable for the next env-var addition.

## Test plan

- [x] One-line addition, docs only
- [x] No code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)