### PR TITLE
docs: add env-var/compose drift rule

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -38,6 +38,9 @@ You are a senior Rust code reviewer with deep knowledge of the ops-brain codebas
 - Secret leaks — no tokens, passwords, or keys in logs or responses?
 - Input validation — are string lengths bounded? IDs validated?
 
+### Deployment Plumbing
+- **New env vars must reach prod**: for every NEW `std::env::var("FOO")` (or `env::var("FOO")`) call in the diff, grep `docker-compose.prod.yml` for `FOO`. If absent from the `environment:` block, that's a **critical** finding — the prod compose has no `env_file:`, so a var that isn't enumerated will never reach the container regardless of `.env`. Suggested fix: `- FOO=${FOO:-}` under `services.ops-brain.environment:`.
+
 ## Output Format
 
 For each finding, report:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ The team-bus principle and "no startup ritual" rules live in each CC's per-machi
 - **nomic-embed-text tokenization** -- real content tokenizes at ~1-1.15 chars/token, NOT ~4 chars/token. `MAX_EMBEDDING_CHARS` is 6,000. Do not increase without empirical testing.
 - **`link_monitor` names in multi-instance mode** -- all lookups are prefix-tolerant (try exact, then strip `instance/` prefix), so linking with unprefixed Kuma names works fine.
 - **Production deploys MUST use `-f docker-compose.prod.yml`** -- prod uses `shared-postgres`, dev uses bundled postgres. Dev compose is project-namespaced as `ops-brain-dev` (PR #33) so a stray invocation can't clobber prod, but it can spin up isolated dev orphans. Full context, history, and orphan cleanup in `feedback_compose_file_footgun.md`.
+- **New env vars need BOTH `.env` AND `docker-compose.prod.yml`** -- prod compose enumerates every env var explicitly under `services.ops-brain.environment:` (no `env_file:`). Adding `FOO=...` to `.env` alone leaves the container booting without `FOO`. Always pair the binary's `std::env::var("FOO")` with a `- FOO=${FOO:-}` line in the prod compose. Caught at the rmcp 1.6 deploy (PR #47 → fix in #48); `/prereview` now greps for this.
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary
Codify the gap caught at the rmcp 1.6 deploy so the next contributor doesn't repeat it.

PR #47 wired `OPS_BRAIN_ALLOWED_HOSTS` into the binary but missed adding a corresponding line to `docker-compose.prod.yml`'s `environment:` block. Prod compose enumerates env vars explicitly (no `env_file:`), so the var never reached the container despite `.env` being populated. The fail-open guard fell back to loopback default; CC-Cloud caught it at deploy and shipped PR #48 to plug the compose.

This PR makes the rule load-bearing:

- **`CLAUDE.md` gotchas** — one-liner next to the existing prod-compose footgun, citing the PR #47 → #48 incident so the *why* is visible.
- **`.claude/agents/reviewer.md`** — new "Deployment Plumbing" check: for every NEW `std::env::var(...)` call in the diff, grep `docker-compose.prod.yml`; absence from the `environment:` block is flagged **critical** with the suggested fix (`- FOO=${FOO:-}`).

No code paths touched; no deploy follow-up (neither file ships in the runtime container).

## Test plan
- [x] `git diff` reviewed — markdown only, no Rust touched
- [ ] CI green
- [ ] Sanity-check the reviewer agent surfaces the rule when invoked against a future env-var-adding diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)