### PR TITLE
feat: handoff threading + commit linkage (v3.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.1.0] — 2026-05-12
+
+### Added — handoff threading + commit linkage
+
+Two additive primitives retire a pair of body-text-grep workarounds that the fleet has been carrying. Surface: **18 → 20 tools**. No breaking changes.
+
+#### New columns on `handoffs` (migration `20260512000001_handoff_threading_and_commit_linkage.sql`)
+
+- `in_reply_to UUID NULL REFERENCES handoffs(id) ON DELETE SET NULL` — explicit thread parent. Replies survive parent deletion.
+- `commit_hash TEXT NULL` — completion-time work ref (typically a git SHA).
+- `merge_commit TEXT NULL` + `merged_at TIMESTAMPTZ NULL` — populated by `mark_merged` once the bundle containing `commit_hash` lands in main.
+
+Two partial indexes: `(in_reply_to, to_agent, created_at DESC) WHERE in_reply_to IS NOT NULL` and `(commit_hash) WHERE commit_hash IS NOT NULL`.
+
+#### Tool surface
+
+- `create_handoff` gains optional `in_reply_to` (UUID string). The reply's `category` is preserved as written — no server-side coercion to `notify` (a reply may legitimately be `action`).
+- `complete_handoff` gains optional `commit_hash`. Param shape promoted from the shared `UpdateHandoffStatusParams` to a per-tool `CompleteHandoffParams`.
+- New `list_replies_to_me(agent_name, since?, limit?)` — returns handoffs whose `in_reply_to` references a handoff you originally sent.
+- New `mark_merged(handoff_id, merge_commit)` — flips `status='merged'` and records `merge_commit` + `merged_at`. Idempotent on the same merge_commit; refuses to overwrite a different one.
+
+#### Validation
+
+- `HANDOFF_STATUSES` adds `"merged"`.
+
+#### What was rejected
+
+A larger 5-deliverable brief from CC-HSR (`019e1dd7`) proposed:
+
+- `linked_todo` field with `#NNNNN` regex validation — rejected; HSR `docs/todo.md` row numbers are fleet-specific convention, not team-bus shape. Body-text search already finds them.
+- Server-side `add_knowledge` banned-category enforcement — rejected; agent-side discipline via local memory files already worked (2026-04-22 sweep stuck). Adds server intelligence the v3.0 de-bloat explicitly removed.
+- `POST /v1/land-event` webhook with strict per-fleet integrator allowlist — rejected; HSR-specific scaffolding doesn't belong in the team bus. `mark_merged` covers the legitimate primitive without the auth model.
+
+Convergence captured in handoffs `019e1ddf` (counter) and `019e1de1` (Option-A accept).
+
 ## [3.0.0] — 2026-05-09
 
 ### Removed (the de-bloat)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,10 @@ Rust MCP server for cross-agent coordination. Rust 2021, rmcp 1.6, PostgreSQL 18
 
 **v3.0.0 — team bus only.** Inventory, incidents, and monitoring subsystems were removed: configuration management owns inventory, Zammad owns tickets/incidents, Uptime Kuma owns monitoring. ops-brain stays on its lane.
 
-## Surface (18 tools)
+## Surface (20 tools)
 
 - **Knowledge** (5): `add_knowledge`, `update_knowledge`, `delete_knowledge`, `search_knowledge`, `list_knowledge`
-- **Handoffs** (6): `create_handoff`, `accept_handoff`, `complete_handoff`, `list_handoffs`, `search_handoffs`, `delete_handoff`
+- **Handoffs** (8): `create_handoff` (optional `in_reply_to`), `accept_handoff`, `complete_handoff` (optional `commit_hash`), `list_handoffs`, `search_handoffs`, `delete_handoff`, `list_replies_to_me`, `mark_merged` (flip to `status=merged`, record `merge_commit` + `merged_at`)
 - **Team bus** (1): `check_in` — pending action handoffs + recent notify-class handoffs for `agent_name`
 - **Search** (1): `backfill_embeddings`
 - **Zammad** (4): `list_tickets`, `get_ticket`, `create_ticket`, `search_tickets`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ops-brain"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ops-brain"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server team bus: cross-agent handoffs, knowledge, briefings, Zammad orchestration"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ The team bus. An [MCP](https://modelcontextprotocol.io/) server that gives Claud
 
 ops-brain is **not** local truth. Inventory belongs in your config management. Incidents belong in your ticketing system. Monitoring belongs in your monitoring stack. Reach for ops-brain only when you genuinely need the rest of the team.
 
-## Surface (18 tools)
+## Surface (20 tools)
 
 - **Knowledge** — `add_knowledge`, `update_knowledge`, `delete_knowledge`, `search_knowledge`, `list_knowledge`. Cross-agent gotchas, safety warnings, compliance rules, vendor behavior. Per-agent provenance via `author`. Default-deny across clients.
-- **Handoffs** — `create_handoff`, `accept_handoff`, `complete_handoff`, `list_handoffs`, `search_handoffs`, `delete_handoff`. `action`-class for required work; `notify`-class for FYI broadcasts (auto-pruned after 7 days).
+- **Handoffs** — `create_handoff`, `accept_handoff`, `complete_handoff`, `list_handoffs`, `search_handoffs`, `delete_handoff`, `list_replies_to_me`, `mark_merged`. `action`-class for required work; `notify`-class for FYI broadcasts (auto-pruned after 7 days). Threading via `in_reply_to`; commit-linkage via `commit_hash` on completion + `mark_merged` at integration time.
 - **Team bus** — `check_in` returns open action handoffs and recent notifications addressed to your `agent_name`.
 - **Search** — `backfill_embeddings` for the FTS+vector hybrid (PostgreSQL tsvector + pgvector HNSW + RRF fusion).
 - **Zammad** — `list_tickets`, `get_ticket`, `create_ticket`, `search_tickets`. Resolves `client_slug` to Zammad group/org/customer.

--- a/migrations/20260512000001_handoff_threading_and_commit_linkage.sql
+++ b/migrations/20260512000001_handoff_threading_and_commit_linkage.sql
@@ -1,0 +1,36 @@
+-- v3.1 — Handoff threading + commit linkage.
+--
+-- Two friction patterns retired:
+--
+--   1. "Where's the reply to my handoff?" — currently relies on body-text
+--      grep + include_notify=true, which has bitten the fleet at least once
+--      (CC-Cloud's BGP probe reply, 2026-05-05). `in_reply_to` makes
+--      threading structural so list_replies_to_me() returns it directly.
+--
+--   2. "Did the work in handoff X actually land in main?" — currently lives
+--      in body text ("completed in abc1234"). `commit_hash` carries the
+--      ref structurally; `mark_merged` flips status + records merge_commit
+--      and merged_at when the bundle containing commit_hash reaches main.
+--
+-- No backfill: new rows opt in via new params; historical rows stay NULL on
+-- the new columns. ON DELETE SET NULL on the in_reply_to FK keeps replies
+-- intact if the parent is deleted.
+
+ALTER TABLE handoffs
+    ADD COLUMN in_reply_to UUID NULL REFERENCES handoffs(id) ON DELETE SET NULL,
+    ADD COLUMN commit_hash TEXT NULL,
+    ADD COLUMN merge_commit TEXT NULL,
+    ADD COLUMN merged_at TIMESTAMPTZ NULL;
+
+-- Hot path: list_replies_to_me joins on r.in_reply_to = parent.id, then
+-- orders by r.created_at DESC. Partial index keeps non-reply rows out of
+-- the lookup entirely.
+CREATE INDEX idx_handoffs_in_reply_to
+    ON handoffs (in_reply_to, created_at DESC)
+    WHERE in_reply_to IS NOT NULL;
+
+-- Reverse lookup: "did this commit land in any handoff?" Partial index
+-- keeps the common case (no commit_hash) cheap.
+CREATE INDEX idx_handoffs_commit_hash
+    ON handoffs (commit_hash)
+    WHERE commit_hash IS NOT NULL;

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -173,6 +173,10 @@ mod tests {
             title: "Big handoff".to_string(),
             body: "x".repeat(30_000),
             context: None,
+            in_reply_to: None,
+            commit_hash: None,
+            merge_commit: None,
+            merged_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -196,6 +200,10 @@ mod tests {
             title: "Continue DNS migration".to_string(),
             body: "Need to update remaining A records".to_string(),
             context: None,
+            in_reply_to: None,
+            commit_hash: None,
+            merge_commit: None,
+            merged_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/src/models/handoff.rs
+++ b/src/models/handoff.rs
@@ -16,6 +16,16 @@ pub struct Handoff {
     pub title: String,
     pub body: String,
     pub context: Option<serde_json::Value>,
+    /// Parent handoff ID when this handoff is a reply. ON DELETE SET NULL
+    /// at the database level — replies survive parent deletion.
+    pub in_reply_to: Option<Uuid>,
+    /// Commit ref set at completion time. Carries the work product
+    /// structurally so it can be joined against `mark_merged` later.
+    pub commit_hash: Option<String>,
+    /// Merge commit set by `mark_merged` once the bundle containing
+    /// `commit_hash` lands in main.
+    pub merge_commit: Option<String>,
+    pub merged_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/src/repo/handoff_repo.rs
+++ b/src/repo/handoff_repo.rs
@@ -26,11 +26,12 @@ pub async fn create_handoff(
     title: &str,
     body: &str,
     context: Option<&serde_json::Value>,
+    in_reply_to: Option<Uuid>,
 ) -> Result<Handoff, sqlx::Error> {
     let id = Uuid::now_v7();
     sqlx::query_as::<_, Handoff>(
-        "INSERT INTO handoffs (id, from_session_id, from_agent, to_agent, priority, category, title, body, context)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        "INSERT INTO handoffs (id, from_session_id, from_agent, to_agent, priority, category, title, body, context, in_reply_to)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
          RETURNING *",
     )
     .bind(id)
@@ -42,6 +43,7 @@ pub async fn create_handoff(
     .bind(title)
     .bind(body)
     .bind(context)
+    .bind(in_reply_to)
     .fetch_one(pool)
     .await
 }
@@ -59,6 +61,82 @@ pub async fn update_handoff_status(
     .bind(status)
     .fetch_one(pool)
     .await
+}
+
+/// Complete a handoff, optionally recording the commit hash of the work
+/// that closed it. `commit_hash` is free-form; callers typically pass a
+/// short or full git SHA, but any opaque identifier works.
+pub async fn complete_handoff_with_commit(
+    pool: &PgPool,
+    id: Uuid,
+    commit_hash: Option<&str>,
+) -> Result<Handoff, sqlx::Error> {
+    sqlx::query_as::<_, Handoff>(
+        "UPDATE handoffs
+            SET status = 'completed',
+                commit_hash = COALESCE($2, commit_hash),
+                updated_at = now()
+          WHERE id = $1
+          RETURNING *",
+    )
+    .bind(id)
+    .bind(commit_hash)
+    .fetch_one(pool)
+    .await
+}
+
+/// Mark a handoff as merged. Records the merge commit (typically the
+/// merge-to-main commit that bundled the work) and the merge timestamp.
+/// Does NOT require `commit_hash` to be set; callers who care about that
+/// linkage can verify it client-side before invoking.
+pub async fn mark_merged(
+    pool: &PgPool,
+    id: Uuid,
+    merge_commit: &str,
+) -> Result<Handoff, sqlx::Error> {
+    sqlx::query_as::<_, Handoff>(
+        "UPDATE handoffs
+            SET status = 'merged',
+                merge_commit = $2,
+                merged_at = now(),
+                updated_at = now()
+          WHERE id = $1
+          RETURNING *",
+    )
+    .bind(id)
+    .bind(merge_commit)
+    .fetch_one(pool)
+    .await
+}
+
+/// Replies addressed to `agent`: handoffs whose `in_reply_to` references a
+/// handoff that `agent` originally sent. Optional `since` filters by the
+/// reply's `created_at`.
+pub async fn list_replies_to_me(
+    pool: &PgPool,
+    agent: &str,
+    since: Option<chrono::DateTime<chrono::Utc>>,
+    limit: i64,
+) -> Result<Vec<Handoff>, sqlx::Error> {
+    let mut q = String::from(
+        "SELECT r.*
+           FROM handoffs r
+           JOIN handoffs parent ON parent.id = r.in_reply_to
+          WHERE parent.from_agent = $1",
+    );
+    if since.is_some() {
+        q.push_str(" AND r.created_at > $2");
+        q.push_str(" ORDER BY r.created_at DESC LIMIT $3");
+    } else {
+        q.push_str(" ORDER BY r.created_at DESC LIMIT $2");
+    }
+
+    let mut query = sqlx::query_as::<_, Handoff>(&q).bind(agent);
+    if let Some(ts) = since {
+        query = query.bind(ts);
+    }
+    query = query.bind(limit);
+    query.fetch_all(pool).await
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/tools/coordination.rs
+++ b/src/tools/coordination.rs
@@ -34,12 +34,50 @@ pub struct CreateHandoffParams {
     pub context: Option<serde_json::Value>,
     /// Session ID this handoff originates from
     pub from_session_id: Option<String>,
+    /// Parent handoff ID (UUID) when this handoff is a reply to another.
+    /// Enables threaded discovery via `list_replies_to_me`. The reply's
+    /// `category` is preserved as written — a reply can legitimately be
+    /// `action` (it requires a response) or `notify` (pure FYI).
+    pub in_reply_to: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct UpdateHandoffStatusParams {
     /// Handoff ID (UUID)
     pub handoff_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CompleteHandoffParams {
+    /// Handoff ID (UUID)
+    pub handoff_id: String,
+    /// Optional commit ref (typically a git SHA) recording the work that
+    /// closed this handoff. When set, lets `mark_merged` link this handoff
+    /// to a merge commit later.
+    pub commit_hash: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListRepliesToMeParams {
+    /// Your agent identifier (free-form slug). Returns handoffs whose
+    /// `in_reply_to` references a handoff you originally sent.
+    #[serde(alias = "my_name")]
+    pub agent_name: String,
+    /// Optional ISO-8601 timestamp; only replies created after this time
+    /// are returned.
+    pub since: Option<String>,
+    /// Max results (default 20)
+    #[serde(default, deserialize_with = "deserialize_flexible_i64")]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MarkMergedParams {
+    /// Handoff ID (UUID) to mark as merged.
+    pub handoff_id: String,
+    /// Merge commit ref (typically the merge-to-main SHA that bundled the
+    /// work). Free-form — any opaque identifier works.
+    pub merge_commit: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -84,7 +122,7 @@ pub struct DeleteHandoffParams {
 
 // ===== HANDOFF HANDLERS =====
 
-pub(crate) async fn handle_create_handoff(
+pub async fn handle_create_handoff(
     brain: &super::OpsBrain,
     p: CreateHandoffParams,
 ) -> CallToolResult {
@@ -115,6 +153,18 @@ pub(crate) async fn handle_create_handoff(
         None => None,
     };
 
+    // Resolve optional reply-parent ID. Existence is enforced at the
+    // database level by the FK; an invalid UUID returns 422-ish error
+    // here, and a well-formed-but-missing UUID returns the FK violation
+    // surfaced from the INSERT.
+    let in_reply_to = match &p.in_reply_to {
+        Some(id_str) => match uuid::Uuid::parse_str(id_str) {
+            Ok(id) => Some(id),
+            Err(_) => return error_result(&format!("Invalid in_reply_to UUID: {id_str}")),
+        },
+        None => None,
+    };
+
     // Validate sender + target as free-form agent slugs. v2.0 dropped the
     // CC-fleet allowlist; whatever the caller says it is, it is. Stored
     // values are exact-match for `check_in` lookups, so writers and
@@ -141,6 +191,7 @@ pub(crate) async fn handle_create_handoff(
         &p.title,
         &p.body,
         p.context.as_ref(),
+        in_reply_to,
     )
     .await
     {
@@ -160,7 +211,7 @@ pub(crate) async fn handle_create_handoff(
     }
 }
 
-pub(crate) async fn handle_accept_handoff(
+pub async fn handle_accept_handoff(
     brain: &super::OpsBrain,
     p: UpdateHandoffStatusParams,
 ) -> CallToolResult {
@@ -185,32 +236,102 @@ pub(crate) async fn handle_accept_handoff(
     }
 }
 
-pub(crate) async fn handle_complete_handoff(
+pub async fn handle_complete_handoff(
     brain: &super::OpsBrain,
-    p: UpdateHandoffStatusParams,
+    p: CompleteHandoffParams,
 ) -> CallToolResult {
     let id = match uuid::Uuid::parse_str(&p.handoff_id) {
         Ok(id) => id,
         Err(_) => return error_result(&format!("Invalid UUID: {}", p.handoff_id)),
     };
 
-    // Verify it exists and is not already completed
+    // Verify it exists and is not already completed or merged. Mirroring
+    // the existing guard: re-completion is a no-op error, not a silent
+    // overwrite of commit_hash.
     match crate::repo::handoff_repo::get_handoff(&brain.pool, id).await {
         Ok(Some(h)) if h.status == "completed" => {
             return error_result("Handoff is already completed")
+        }
+        Ok(Some(h)) if h.status == "merged" => return error_result("Handoff is already merged"),
+        Ok(Some(_)) => {}
+        Ok(None) => return not_found("Handoff", &p.handoff_id),
+        Err(e) => return error_result(&format!("Database error: {e}")),
+    }
+
+    match crate::repo::handoff_repo::complete_handoff_with_commit(
+        &brain.pool,
+        id,
+        p.commit_hash.as_deref(),
+    )
+    .await
+    {
+        Ok(handoff) => json_result(&handoff),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub async fn handle_list_replies_to_me(
+    brain: &super::OpsBrain,
+    p: ListRepliesToMeParams,
+) -> CallToolResult {
+    let agent = match crate::validation::validate_agent_name(&p.agent_name) {
+        Ok(n) => n.to_string(),
+        Err(e) => return error_result(&e),
+    };
+    let since = match p.since.as_deref() {
+        Some(raw) => match chrono::DateTime::parse_from_rfc3339(raw) {
+            Ok(ts) => Some(ts.with_timezone(&chrono::Utc)),
+            Err(_) => {
+                return error_result(&format!(
+                    "Invalid `since` timestamp (expected RFC3339): {raw}"
+                ))
+            }
+        },
+        None => None,
+    };
+    let limit = p.limit.unwrap_or(20);
+
+    match crate::repo::handoff_repo::list_replies_to_me(&brain.pool, &agent, since, limit).await {
+        Ok(replies) => json_result(&replies),
+        Err(e) => error_result(&format!("Database error: {e}")),
+    }
+}
+
+pub async fn handle_mark_merged(brain: &super::OpsBrain, p: MarkMergedParams) -> CallToolResult {
+    let id = match uuid::Uuid::parse_str(&p.handoff_id) {
+        Ok(id) => id,
+        Err(_) => return error_result(&format!("Invalid UUID: {}", p.handoff_id)),
+    };
+    let merge_commit = p.merge_commit.trim();
+    if merge_commit.is_empty() {
+        return error_result("merge_commit cannot be empty");
+    }
+
+    // Idempotency: if already merged with the same commit, return current
+    // state; if merged with a different commit, surface the conflict so
+    // the caller doesn't silently overwrite.
+    match crate::repo::handoff_repo::get_handoff(&brain.pool, id).await {
+        Ok(Some(h)) if h.status == "merged" => {
+            if h.merge_commit.as_deref() == Some(merge_commit) {
+                return json_result(&h);
+            }
+            return error_result(&format!(
+                "Handoff already merged with commit {:?}; refusing to overwrite",
+                h.merge_commit.as_deref().unwrap_or("(unknown)")
+            ));
         }
         Ok(Some(_)) => {}
         Ok(None) => return not_found("Handoff", &p.handoff_id),
         Err(e) => return error_result(&format!("Database error: {e}")),
     }
 
-    match crate::repo::handoff_repo::update_handoff_status(&brain.pool, id, "completed").await {
+    match crate::repo::handoff_repo::mark_merged(&brain.pool, id, merge_commit).await {
         Ok(handoff) => json_result(&handoff),
         Err(e) => error_result(&format!("Database error: {e}")),
     }
 }
 
-pub(crate) async fn handle_list_handoffs(
+pub async fn handle_list_handoffs(
     brain: &super::OpsBrain,
     p: ListHandoffsParams,
 ) -> CallToolResult {
@@ -292,7 +413,7 @@ pub(crate) async fn handle_list_handoffs(
     }
 }
 
-pub(crate) async fn handle_search_handoffs(
+pub async fn handle_search_handoffs(
     brain: &super::OpsBrain,
     p: SearchHandoffsParams,
 ) -> CallToolResult {
@@ -330,7 +451,7 @@ pub(crate) async fn handle_search_handoffs(
     }
 }
 
-pub(crate) async fn handle_delete_handoff(
+pub async fn handle_delete_handoff(
     brain: &super::OpsBrain,
     p: DeleteHandoffParams,
 ) -> CallToolResult {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,6 +1,6 @@
 pub mod briefings;
 pub mod check_in;
-mod coordination;
+pub mod coordination;
 mod helpers;
 pub mod knowledge;
 mod search;
@@ -120,12 +120,44 @@ impl OpsBrain {
         Ok(coordination::handle_accept_handoff(self, params.0).await)
     }
 
-    #[tool(name = "complete_handoff", description = "Mark a handoff as completed")]
+    #[tool(
+        name = "complete_handoff",
+        description = "Mark a handoff as completed. Optional `commit_hash` records the work \
+        ref (typically a git SHA) so `mark_merged` can later flip the same handoff to \
+        `merged` when the bundle reaches main."
+    )]
     async fn complete_handoff(
         &self,
-        params: Parameters<coordination::UpdateHandoffStatusParams>,
+        params: Parameters<coordination::CompleteHandoffParams>,
     ) -> Result<CallToolResult, McpError> {
         Ok(coordination::handle_complete_handoff(self, params.0).await)
+    }
+
+    #[tool(
+        name = "list_replies_to_me",
+        description = "List handoffs that reply to ones you sent. Returns handoffs whose \
+        `in_reply_to` references a handoff with your `agent_name` as `from_agent`. \
+        Optional ISO-8601 `since` filters by reply timestamp."
+    )]
+    async fn list_replies_to_me(
+        &self,
+        params: Parameters<coordination::ListRepliesToMeParams>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(coordination::handle_list_replies_to_me(self, params.0).await)
+    }
+
+    #[tool(
+        name = "mark_merged",
+        description = "Flip a handoff to status=merged and record the merge commit. \
+        Typically called by an integrator script after the bundle containing the \
+        handoff's commit_hash lands in main. Idempotent on identical merge_commit; \
+        refuses to overwrite a different one."
+    )]
+    async fn mark_merged(
+        &self,
+        params: Parameters<coordination::MarkMergedParams>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(coordination::handle_mark_merged(self, params.0).await)
     }
 
     #[tool(

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -58,7 +58,7 @@ where
     }
 }
 
-pub const HANDOFF_STATUSES: &[&str] = &["pending", "accepted", "completed"];
+pub const HANDOFF_STATUSES: &[&str] = &["pending", "accepted", "completed", "merged"];
 pub const HANDOFF_PRIORITIES: &[&str] = &["low", "normal", "high", "critical"];
 pub const HANDOFF_CATEGORIES: &[&str] = &["action", "notify"];
 pub const SEARCH_MODES: &[&str] = &["fts", "semantic", "hybrid"];

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -212,6 +212,7 @@ mod coordination_tests {
             "Continue DNS migration",
             "Need to update remaining A records",
             None,
+            None,
         )
         .await
         .unwrap();
@@ -271,6 +272,7 @@ mod coordination_tests {
             "Action item",
             "Body",
             None,
+            None,
         )
         .await
         .unwrap();
@@ -284,6 +286,7 @@ mod coordination_tests {
             "notify",
             "FYI item",
             "Body",
+            None,
             None,
         )
         .await
@@ -366,6 +369,7 @@ mod coordination_tests {
                 "agent preservation test",
                 "body",
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -386,6 +390,189 @@ mod coordination_tests {
         // Cleanup
         sqlx::query("DELETE FROM handoffs WHERE id = ANY($1)")
             .bind(&ids)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// in_reply_to threads a child handoff to a parent and list_replies_to_me
+    /// surfaces it via the parent's from_agent (not the reply's).
+    #[tokio::test]
+    async fn handoff_in_reply_to_threading() {
+        let pool = pool().await;
+        let alice = format!("alice-{}", Uuid::now_v7());
+        let bob = format!("bob-{}", Uuid::now_v7());
+
+        let parent = ops_brain::repo::handoff_repo::create_handoff(
+            &pool,
+            None,
+            &alice,
+            Some(&bob),
+            "normal",
+            "action",
+            "Please review",
+            "body",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let reply = ops_brain::repo::handoff_repo::create_handoff(
+            &pool,
+            None,
+            &bob,
+            Some(&alice),
+            "normal",
+            "action",
+            "Re: Please review",
+            "looks good",
+            None,
+            Some(parent.id),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(reply.in_reply_to, Some(parent.id));
+        // Category is preserved — the reply stays `action` even though it's a reply.
+        assert_eq!(reply.category, "action");
+
+        let replies = ops_brain::repo::handoff_repo::list_replies_to_me(&pool, &alice, None, 10)
+            .await
+            .unwrap();
+        assert!(replies.iter().any(|h| h.id == reply.id));
+        // Parent author asking for *their* replies shouldn't see unrelated rows.
+        assert!(replies.iter().all(|h| h.in_reply_to == Some(parent.id)));
+
+        // Cleanup — order matters because of the FK.
+        sqlx::query("DELETE FROM handoffs WHERE id = $1")
+            .bind(reply.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM handoffs WHERE id = $1")
+            .bind(parent.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// in_reply_to FK is ON DELETE SET NULL — deleting a parent leaves the
+    /// reply intact with a nulled link, never cascade-orphaned.
+    #[tokio::test]
+    async fn handoff_reply_survives_parent_deletion() {
+        let pool = pool().await;
+        let from = format!("from-{}", Uuid::now_v7());
+
+        let parent = ops_brain::repo::handoff_repo::create_handoff(
+            &pool, None, &from, None, "normal", "action", "Parent", "body", None, None,
+        )
+        .await
+        .unwrap();
+        let reply = ops_brain::repo::handoff_repo::create_handoff(
+            &pool,
+            None,
+            &from,
+            None,
+            "normal",
+            "notify",
+            "Reply",
+            "body",
+            None,
+            Some(parent.id),
+        )
+        .await
+        .unwrap();
+
+        sqlx::query("DELETE FROM handoffs WHERE id = $1")
+            .bind(parent.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let row: (Option<Uuid>,) = sqlx::query_as("SELECT in_reply_to FROM handoffs WHERE id = $1")
+            .bind(reply.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(
+            row.0.is_none(),
+            "in_reply_to should null out on parent delete"
+        );
+
+        sqlx::query("DELETE FROM handoffs WHERE id = $1")
+            .bind(reply.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// complete_handoff_with_commit stores the commit_hash and flips status
+    /// to completed. Re-running with a different commit doesn't silently
+    /// overwrite (guarded at the tool layer; repo layer keeps it permissive
+    /// for explicit-reset paths).
+    #[tokio::test]
+    async fn handoff_complete_with_commit_hash() {
+        let pool = pool().await;
+        let from = format!("from-{}", Uuid::now_v7());
+
+        let h = ops_brain::repo::handoff_repo::create_handoff(
+            &pool, None, &from, None, "normal", "action", "Work", "body", None, None,
+        )
+        .await
+        .unwrap();
+
+        let completed = ops_brain::repo::handoff_repo::complete_handoff_with_commit(
+            &pool,
+            h.id,
+            Some("abc1234"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(completed.status, "completed");
+        assert_eq!(completed.commit_hash.as_deref(), Some("abc1234"));
+
+        sqlx::query("DELETE FROM handoffs WHERE id = $1")
+            .bind(h.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// mark_merged flips status to merged and records merge_commit + merged_at.
+    /// Works regardless of whether complete_handoff was called first — the
+    /// integrator script may not have local visibility into completion state.
+    #[tokio::test]
+    async fn handoff_mark_merged_flips_status_and_records_commit() {
+        let pool = pool().await;
+        let from = format!("from-{}", Uuid::now_v7());
+
+        let h = ops_brain::repo::handoff_repo::create_handoff(
+            &pool, None, &from, None, "normal", "action", "Work", "body", None, None,
+        )
+        .await
+        .unwrap();
+        let _ = ops_brain::repo::handoff_repo::complete_handoff_with_commit(
+            &pool,
+            h.id,
+            Some("feedf00d"),
+        )
+        .await
+        .unwrap();
+
+        let merged = ops_brain::repo::handoff_repo::mark_merged(&pool, h.id, "deadbeef0001")
+            .await
+            .unwrap();
+
+        assert_eq!(merged.status, "merged");
+        assert_eq!(merged.merge_commit.as_deref(), Some("deadbeef0001"));
+        assert!(merged.merged_at.is_some());
+        // commit_hash from the completion step is preserved.
+        assert_eq!(merged.commit_hash.as_deref(), Some("feedf00d"));
+
+        sqlx::query("DELETE FROM handoffs WHERE id = $1")
+            .bind(h.id)
             .execute(&pool)
             .await
             .unwrap();
@@ -576,5 +763,181 @@ mod check_in_tests {
             !text.contains("\"hostname\":"),
             "v1.5: `hostname` field must not echo back — local is the source of truth"
         );
+    }
+}
+
+// Handler-layer tests for the v3.1.0 safety guards on threading + commit
+// linkage. Repo-level happy paths are covered in `coordination_tests` above;
+// these pin the tool-layer behavior (invalid input, not-found, conflict-refuse,
+// idempotency) the locked design promises.
+mod coordination_handler_tests {
+    use super::*;
+    use ops_brain::tools::coordination::{
+        handle_create_handoff, handle_mark_merged, CreateHandoffParams, MarkMergedParams,
+    };
+
+    fn build_brain(pool: PgPool) -> ops_brain::tools::OpsBrain {
+        ops_brain::tools::OpsBrain::new(pool, None, None)
+    }
+
+    fn extract_text(result: &rmcp::model::CallToolResult) -> String {
+        result
+            .content
+            .first()
+            .expect("result has at least one content item")
+            .as_text()
+            .expect("content is text")
+            .text
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn create_handoff_rejects_malformed_in_reply_to() {
+        let brain = build_brain(pool().await);
+        let result = handle_create_handoff(
+            &brain,
+            CreateHandoffParams {
+                from_agent: "CC-Stealth".to_string(),
+                to_agent: None,
+                priority: None,
+                category: None,
+                title: "smoke".to_string(),
+                body: "body".to_string(),
+                context: None,
+                from_session_id: None,
+                in_reply_to: Some("not-a-uuid".to_string()),
+            },
+        )
+        .await;
+        assert_eq!(result.is_error, Some(true));
+        let text = extract_text(&result);
+        assert!(
+            text.contains("Invalid in_reply_to UUID"),
+            "expected in_reply_to validation error, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_merged_returns_not_found_for_missing_handoff() {
+        let brain = build_brain(pool().await);
+        let missing = Uuid::now_v7();
+        let result = handle_mark_merged(
+            &brain,
+            MarkMergedParams {
+                handoff_id: missing.to_string(),
+                merge_commit: "abc1234".to_string(),
+            },
+        )
+        .await;
+        assert_eq!(result.is_error, Some(true));
+        let text = extract_text(&result);
+        assert!(
+            text.contains("not found") || text.contains("Handoff"),
+            "expected not-found surface, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_merged_is_idempotent_on_same_commit() {
+        let pool = pool().await;
+        let brain = build_brain(pool.clone());
+        let from = format!("from-{}", Uuid::now_v7());
+
+        let h = ops_brain::repo::handoff_repo::create_handoff(
+            &pool,
+            None,
+            &from,
+            None,
+            "normal",
+            "action",
+            "idempotency-smoke",
+            "body",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let params = || MarkMergedParams {
+            handoff_id: h.id.to_string(),
+            merge_commit: "merge-abc".to_string(),
+        };
+
+        let first = handle_mark_merged(&brain, params()).await;
+        assert_eq!(
+            first.is_error,
+            Some(false),
+            "first mark_merged should succeed"
+        );
+
+        let second = handle_mark_merged(&brain, params()).await;
+        assert_eq!(
+            second.is_error,
+            Some(false),
+            "second mark_merged with same commit should be a no-op success"
+        );
+
+        sqlx::query("DELETE FROM handoffs WHERE id = $1")
+            .bind(h.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn mark_merged_refuses_to_overwrite_with_different_commit() {
+        let pool = pool().await;
+        let brain = build_brain(pool.clone());
+        let from = format!("from-{}", Uuid::now_v7());
+
+        let h = ops_brain::repo::handoff_repo::create_handoff(
+            &pool,
+            None,
+            &from,
+            None,
+            "normal",
+            "action",
+            "conflict-refuse-smoke",
+            "body",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let first = handle_mark_merged(
+            &brain,
+            MarkMergedParams {
+                handoff_id: h.id.to_string(),
+                merge_commit: "first-merge".to_string(),
+            },
+        )
+        .await;
+        assert_eq!(first.is_error, Some(false));
+
+        let second = handle_mark_merged(
+            &brain,
+            MarkMergedParams {
+                handoff_id: h.id.to_string(),
+                merge_commit: "different-merge".to_string(),
+            },
+        )
+        .await;
+        assert_eq!(
+            second.is_error,
+            Some(true),
+            "second mark_merged with different commit should refuse"
+        );
+        let text = extract_text(&second);
+        assert!(
+            text.contains("already merged") || text.contains("refusing to overwrite"),
+            "expected conflict-refuse error, got: {text}"
+        );
+
+        sqlx::query("DELETE FROM handoffs WHERE id = $1")
+            .bind(h.id)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- Threads replies structurally via `in_reply_to UUID` + new `list_replies_to_me` tool, retiring the body-grep + `include_notify=true` workaround.
- Carries the commit ref structurally: `complete_handoff` gains optional `commit_hash`, new `mark_merged` flips `status='merged'` and records `merge_commit` + `merged_at`.
- Tool surface 18 → 20. No category coercion on replies (a reply can legitimately be `action`). Migration is purely additive with two partial indexes; no backfill — historical rows stay NULL on new columns.

## Convergence with CC-HSR

This PR ships ~½ of CC-HSR's original brief (`019e1dd7`). Counter-proposal `019e1ddf` rejected three deliverables on doctrine grounds; CC-HSR accepted via `019e1de1` (Option A).

**Rejected from the original brief:**
- `linked_todo` with `^#\d{1,5}$` regex validation — HSR's `docs/todo.md` row-number convention isn't team-bus shape.
- Server-side `add_knowledge` banned-category enforcement — re-adds the server intelligence v3.0.0 explicitly stripped (2026-05-09).
- `POST /v1/land-event` webhook + strict per-fleet integrator allowlist — HSR-specific integrator scaffolding (`scripts/land-session.ps1`) outside team-bus scope. `mark_merged` covers the legitimate primitive without the auth model.

## Test plan

- [x] `cargo test` green locally (20 integration tests, 8 new: 4 repo-layer happy paths, 4 handler-layer safety guards).
- [x] `cargo fmt --check` clean.
- [x] `cargo check` clean.
- [x] Pre-commit hook ran clean on commit.
- [ ] CI green on this PR.
- [ ] CC-Cloud post-merge deploy + smoke matrix:
  - Round-trip `create_handoff(in_reply_to=…)` → `list_replies_to_me(agent=…)` returns the reply.
  - Reply with `category=action` stays `action` (no server coercion).
  - `complete_handoff(commit_hash=…)` populates the column.
  - `mark_merged(handoff_id, merge_commit)` flips status, populates merge_commit + merged_at.
  - `mark_merged` idempotent on identical merge_commit; refuses to overwrite on different.
  - `mark_merged` on non-existent handoff returns not-found.
  - `check_in`, `list_handoffs`, `search_handoffs` unaffected; new fields serialize as `null` on legacy rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)