### PR TITLE
release: v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.2.0] — 2026-05-16
+
 ### Changed
 
 - `check_in` and generated briefings now treat accepted handoffs as open work, not hidden work. Responses split open action handoffs into pending and accepted counts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ops-brain"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ops-brain"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server team bus: cross-agent handoffs, knowledge, briefings, Zammad orchestration"


### PR DESCRIPTION
## Summary

Date the 11 commits that have been sitting on `main` since v3.1.0 squash-merged on 2026-05-12. Bumps `Cargo.toml` / `Cargo.lock` 3.1.0 → 3.2.0 and moves the `[Unreleased]` CHANGELOG block into `[3.2.0] — 2026-05-16`.

### Why minor, not patch
`mark_merged` now rejects pending/accepted handoffs and completed handoffs without a `commit_hash` — a narrower contract than v3.1.0 shipped with. `check_in` and briefings split open action handoffs into `pending` + `accepted` counts (response shape change, additive but observable). Tool surface stays at 20 — not a major.

### What's in this release

**Changed**
- `check_in` + briefings show accepted handoffs as open work; response splits pending/accepted
- `mark_merged` tightened (see above)
- Fleet-naming convention (CC-/Codex-/Gemini-) documented; validator still free-form
- Fleet-stewardship model documented
- `cross_client_withheld` metadata key standardized across search modes
- Binary imports the library crate so `cargo test` no longer double-runs the test suite

**Fixed**
- HTTP MCP session keep_alive 5min → 1h (kills the `Session not found` reconnect papercut across Claude Code rmcp and Gemini CLI Node SDK)
- Prod healthcheck gotcha documented (port 3000 not host-published; use container health or `https://ops.kensai.cloud/health`)
- Stale watchdog test env removed from CI
- Stale Zammad `upsert_client` guidance replaced

## Test plan
- [ ] CI green (fmt / clippy / check / test on this branch)
- [ ] After squash-merge: tag `v3.2.0` on the merge commit
- [ ] Hand off to CC-Cloud for prod deploy via `-f docker-compose.prod.yml`
- [ ] Post-deploy: `curl -sf https://ops.kensai.cloud/health` + verify `/mcp` reconnect across CCs picks up the 1h keep_alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)