### PR TITLE
docs(readme): lead with problem + quick-start for external users

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,45 @@ The team bus. An [MCP](https://modelcontextprotocol.io/) server that gives Claud
 
 ops-brain is **not** local truth. Inventory belongs in your config management. Incidents belong in your ticketing system. Monitoring belongs in your monitoring stack. Reach for ops-brain only when you genuinely need the rest of the team.
 
+## Who this is for
+
+Solo operators and small teams running **multiple AI agents across multiple machines or vendors** — e.g. a Claude Code instance on your workstation, a Codex CLI on a server, a Gemini CLI on a client site — who keep hitting the same wall: the agents can't see each other's work. ops-brain is the shared surface they coordinate over. If you run a single agent on a single box, you almost certainly don't need this.
+
+## Quick start
+
+You need PostgreSQL 18 with the `pgvector` extension, and (optionally) an OpenAI-compatible embedding endpoint such as [Ollama](https://ollama.ai/) serving `nomic-embed-text`. Embeddings can be disabled.
+
+```bash
+git clone https://github.com/TheK3nsai/ops-brain
+cd ops-brain
+cp .env.example .env       # set DATABASE_URL and OPS_BRAIN_AUTH_TOKEN
+docker build -t ops-brain:dev .
+docker run --rm --env-file .env -p 3000:3000 ops-brain:dev
+curl -sf http://localhost:3000/health   # → "OK"
+```
+
+A prebuilt image on `ghcr.io` is on the roadmap; until then, build from source as above.
+
+For a full local stack including PostgreSQL + pgvector, see [`docker-compose.yml`](docker-compose.yml). For production deployment behind a reverse proxy with a shared database, see [`docker-compose.prod.yml`](docker-compose.prod.yml).
+
+## Plug it into your agent
+
+ops-brain speaks MCP over either stdio (default) or HTTP. Most multi-machine setups want HTTP so several agents on different hosts can hit the same server.
+
+**Claude Code** — add to `~/.claude.json` under `mcpServers`:
+
+```json
+"ops-brain": {
+  "type": "http",
+  "url": "https://your-host.example.com/mcp",
+  "headers": { "Authorization": "Bearer $OPS_BRAIN_AUTH_TOKEN" }
+}
+```
+
+**Codex CLI** and **Gemini CLI** use the same HTTP MCP transport with their own config files — point them at `/mcp` and pass the same bearer token. Once connected, every agent should identify itself with a stable `agent_name` (e.g. `CC-Stealth`, `Codex-HSR`) on its first `check_in` call.
+
+Public HTTP deployments behind a reverse proxy must also set `OPS_BRAIN_ALLOWED_HOSTS` to your hostname — see the config table below.
+
 ## Surface (20 tools)
 
 - **Knowledge** — `add_knowledge`, `update_knowledge`, `delete_knowledge`, `search_knowledge`, `list_knowledge`. Cross-agent gotchas, safety warnings, compliance rules, vendor behavior. Per-agent provenance via `author`. Default-deny across clients.


### PR DESCRIPTION
## Summary

Part of a discoverability sweep so the public repo actually works for strangers who land on it. This PR is **Tier 1 only — README lede**. Repo description, topic tags, and GitHub Releases for v1.7.0/v1.8.0/v3.2.0 were already updated directly out-of-band (no code change needed).

Three sections inserted between the existing lede and `## Surface (20 tools)`:

- **Who this is for** — frames the multi-agent multi-machine use case so a stranger decides in 10 seconds whether they want this.
- **Quick start** — `docker build` path that gets `/health → "OK"` in under a minute. Calls out the missing GHCR image honestly.
- **Plug it into your agent** — Claude Code HTTP MCP config snippet, with Codex/Gemini pointed at the same transport. The server is useless without this wiring and we never documented it.

Everything below the new sections is unchanged.

## Deliberately deferred

- **GHCR image + release workflow.** Next PR. Tagging `v*` should auto-push `ghcr.io/thek3nsai/ops-brain:vX.Y.Z` + `:latest` and attach binaries to the GitHub Release. Once that lands the quick-start swaps `docker build` for `docker run ghcr.io/...`.
- **Standalone `docker-compose.example.yml`** that doesn't assume pre-existing `shared-db` / `traefik-net` networks. Bundled with the release-workflow PR.
- **CONTRIBUTING.md / crates.io / awesome-mcp submission.** Tier 3, only if there's real external interest.

## Pre-existing drift noted but not touched

`.env.example` defaults `OPS_BRAIN_EMBEDDINGS_ENABLED=false`; the README config table says default is `true`. Picking one and aligning the other belongs in its own commit.

## Test plan

- [ ] CI green (fmt + clippy + test against pg18 + audit)
- [ ] README renders cleanly on GitHub (preview the new sections render the code fences and the table-of-contents flow)
- [ ] `cp .env.example .env`, fill in `DATABASE_URL` + `OPS_BRAIN_AUTH_TOKEN`, run the docker quick-start, hit `/health` — verify the snippet is copy-pasteable end-to-end against a clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)