### PR TITLE
ops(release): GHCR pipeline + standalone compose

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,188 @@
+name: Release
+
+# Triggers:
+#   - push of any `v*` tag → full release pipeline
+#   - manual workflow_dispatch with a `tag` input → retroactively build an existing tag
+#     (used once to seed images for tags created before this workflow existed)
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to build (e.g. v3.2.0)'
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # Per-arch image builds — native runners avoid the ~5x slowdown of QEMU emulation.
+  # Each build pushes a manifest by digest only (no tag); the merge job stitches them
+  # into a multi-arch manifest tagged vX.Y.Z + latest.
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Refusing to build non-semver tag: $TAG" >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Lowercase image name
+        id: img
+        run: echo "name=${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.img.outputs.name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=release-${{ matrix.arch }}
+          cache-to: type=gha,scope=release-${{ matrix.arch }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.arch }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/${{ matrix.arch }}
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stitch the per-arch digests into a multi-arch manifest, tagged vX.Y.Z + latest.
+  merge:
+    name: Merge manifest
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: echo "tag=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Lowercase image name
+        id: img
+        run: echo "name=${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list (vX.Y.Z + latest)
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ steps.img.outputs.name }}"
+          TAG="${{ steps.tag.outputs.tag }}"
+          DIGESTS=()
+          for f in /tmp/digests/*; do
+            DIGESTS+=("$IMAGE@$(cat "$f")")
+          done
+          docker buildx imagetools create \
+            --tag "$IMAGE:$TAG" \
+            --tag "$IMAGE:latest" \
+            "${DIGESTS[@]}"
+
+      - name: Inspect
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ steps.img.outputs.name }}"
+          docker buildx imagetools inspect "$IMAGE:${{ steps.tag.outputs.tag }}"
+
+  # Create or update the GitHub Release with notes extracted from CHANGELOG.md.
+  # Idempotent: re-running against an existing tag updates the release body in place.
+  release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs: merge
+    permissions:
+      contents: write
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: echo "tag=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Extract CHANGELOG section
+        id: notes
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          VERSION="${TAG#v}"
+          {
+            echo 'body<<EOF'
+            awk -v v="$VERSION" '
+              $0 ~ "^## \\["v"\\]" { flag=1; next }
+              flag && $0 ~ "^## \\[" { exit }
+              flag
+            ' CHANGELOG.md | sed -E '1{/^[[:space:]]*$/d}'
+            echo ''
+            echo '## Image'
+            echo ''
+            echo '```'
+            echo "docker pull ghcr.io/${IMAGE_NAME,,}:$TAG"
+            echo '```'
+            echo ''
+            echo "Multi-arch: \`linux/amd64\`, \`linux/arm64\`."
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          body: ${{ steps.notes.outputs.body }}
+          make_latest: 'true'

--- a/README.md
+++ b/README.md
@@ -10,20 +10,21 @@ Solo operators and small teams running **multiple AI agents across multiple mach
 
 ## Quick start
 
-You need PostgreSQL 18 with the `pgvector` extension, and (optionally) an OpenAI-compatible embedding endpoint such as [Ollama](https://ollama.ai/) serving `nomic-embed-text`. Embeddings can be disabled.
+No clone required — grab the standalone compose file, set a token, run it. The bundled PostgreSQL has pgvector preinstalled; embeddings start disabled (FTS still works) and can be enabled by pointing at an OpenAI-compatible endpoint like [Ollama](https://ollama.ai/) serving `nomic-embed-text`.
 
 ```bash
-git clone https://github.com/TheK3nsai/ops-brain
-cd ops-brain
-cp .env.example .env       # set DATABASE_URL and OPS_BRAIN_AUTH_TOKEN
-docker build -t ops-brain:dev .
-docker run --rm --env-file .env -p 3000:3000 ops-brain:dev
+curl -O https://raw.githubusercontent.com/TheK3nsai/ops-brain/main/docker-compose.example.yml
+echo "OPS_BRAIN_AUTH_TOKEN=$(openssl rand -hex 32)" > .env
+docker compose -f docker-compose.example.yml up -d
 curl -sf http://localhost:3000/health   # → "OK"
 ```
 
-A prebuilt image on `ghcr.io` is on the roadmap; until then, build from source as above.
+Images are multi-arch (`linux/amd64`, `linux/arm64`) on [`ghcr.io/thek3nsai/ops-brain`](https://github.com/TheK3nsai/ops-brain/pkgs/container/ops-brain). Pin a specific version with `:vX.Y.Z` instead of `:latest`.
 
-For a full local stack including PostgreSQL + pgvector, see [`docker-compose.yml`](docker-compose.yml). For production deployment behind a reverse proxy with a shared database, see [`docker-compose.prod.yml`](docker-compose.prod.yml).
+Other deployment shapes:
+
+- **Building from source** (contributing or pinning a local change) — clone the repo and use [`docker-compose.yml`](docker-compose.yml), which builds the Dockerfile and runs the same bundled PostgreSQL stack as the example.
+- **Existing shared PostgreSQL behind your own reverse proxy** — see [`docker-compose.prod.yml`](docker-compose.prod.yml).
 
 ## Plug it into your agent
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,80 @@
+# ops-brain — Standalone "try it" deployment
+# ============================================================================
+#  Download just this file, no clone required. Pulls the prebuilt image from
+#  GHCR and bundles its own PostgreSQL.
+#
+#    curl -O https://raw.githubusercontent.com/TheK3nsai/ops-brain/main/docker-compose.example.yml
+#    echo "OPS_BRAIN_AUTH_TOKEN=$(openssl rand -hex 32)" > .env
+#    docker compose -f docker-compose.example.yml up -d
+#    curl -sf -H "Authorization: Bearer $(grep AUTH_TOKEN .env | cut -d= -f2)" \
+#         http://localhost:3000/health
+#
+#  USE THIS FILE WHEN: you want to try ops-brain end-to-end without cloning
+#  the repo or building from source.
+#
+#  USE docker-compose.yml WHEN: you cloned the repo and want to build from
+#  source (e.g. you're contributing or pinning to a local change).
+#
+#  USE docker-compose.prod.yml WHEN: you're deploying alongside an existing
+#  shared PostgreSQL behind your own reverse proxy.
+#
+#  Embeddings are disabled by default — semantic search is off, FTS still
+#  works. Enable embeddings by pointing OPS_BRAIN_EMBEDDING_URL at an
+#  OpenAI-compatible endpoint (e.g. Ollama running nomic-embed-text).
+# ============================================================================
+
+name: ops-brain
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg18
+    container_name: ops-brain-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ops_brain
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-ops_brain}
+      POSTGRES_DB: ops_brain
+    volumes:
+      - pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ops_brain -d ops_brain"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  ops-brain:
+    image: ghcr.io/thek3nsai/ops-brain:latest
+    container_name: ops-brain
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${OPS_BRAIN_PORT:-3000}:3000"
+    environment:
+      - DATABASE_URL=postgresql://ops_brain:${POSTGRES_PASSWORD:-ops_brain}@postgres:5432/ops_brain
+      - OPS_BRAIN_TRANSPORT=http
+      - OPS_BRAIN_LISTEN=0.0.0.0:3000
+      - OPS_BRAIN_AUTH_TOKEN=${OPS_BRAIN_AUTH_TOKEN:?set in .env, e.g. openssl rand -hex 32}
+      - OPS_BRAIN_MIGRATE=true
+      # Public deployments behind a reverse proxy must add the public hostname
+      # here (comma-separated). Defaults to loopback-only when unset.
+      - OPS_BRAIN_ALLOWED_HOSTS=${OPS_BRAIN_ALLOWED_HOSTS:-}
+      # Embeddings (off by default). To enable: run an OpenAI-compatible
+      # embedding endpoint (e.g. Ollama with nomic-embed-text) and set
+      # OPS_BRAIN_EMBEDDINGS_ENABLED=true + OPS_BRAIN_EMBEDDING_URL.
+      - OPS_BRAIN_EMBEDDINGS_ENABLED=${OPS_BRAIN_EMBEDDINGS_ENABLED:-false}
+      - OPS_BRAIN_EMBEDDING_URL=${OPS_BRAIN_EMBEDDING_URL:-http://host.docker.internal:11434/v1/embeddings}
+      - OPS_BRAIN_EMBEDDING_MODEL=${OPS_BRAIN_EMBEDDING_MODEL:-nomic-embed-text}
+      # Zammad ticketing (optional)
+      - ZAMMAD_URL=${ZAMMAD_URL:-}
+      - ZAMMAD_API_TOKEN=${ZAMMAD_API_TOKEN:-}
+      - RUST_LOG=${RUST_LOG:-ops_brain=info}
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary

Tier 2 of the "release-worthy for external users" sweep. Tier 1 (#56) made the repo *look* alive (description fixed, topics aligned, GitHub Releases backfilled, README lede rewritten). This PR makes it *actually installable* in one paste.

Three pieces:

1. **`.github/workflows/release.yml`** — on `v*` tag push or `workflow_dispatch` with a `tag` input, matrix-builds the Dockerfile **natively** on `ubuntu-latest` (amd64) + `ubuntu-24.04-arm` (arm64), merges digests into a multi-arch manifest at `ghcr.io/thek3nsai/ops-brain:vX.Y.Z` + `:latest`, then creates-or-updates the GitHub Release with notes extracted from the matching `CHANGELOG.md` section plus a `docker pull` snippet. Idempotent on re-run against the same tag.

2. **`docker-compose.example.yml`** — copy-pasteable standalone stack. Pulls GHCR image + `pgvector/pgvector:pg18` sidecar with named volume, embeddings off by default, token via `.env` with a hard `:?` failure if unset. The role split is now: `docker-compose.example.yml` for strangers, `docker-compose.yml` for contributors building from source, `docker-compose.prod.yml` for shared-PostgreSQL deployments.

3. **README quick-start refresh** — leads with `curl <compose> | docker compose up` instead of `git clone + docker build`. "GHCR image on the roadmap" caveat removed. Build-from-source moves below as the contributor path.

## Post-merge operator checklist

The README references a GHCR image that doesn't exist yet — the workflow has never run. I'll seed it from the branch before merge so the README never points at a missing image:

- [ ] **Before merge:** dispatch the workflow from this branch ref against `tag=v3.2.0` to retro-build the existing tag's image. Verifies the pipeline end-to-end without polluting main with a half-working state.
- [ ] **After first successful run:** flip the GHCR package visibility to public (UI: Packages → ops-brain → Package settings → Change visibility). First-push default is private.
- [ ] Verify `docker pull ghcr.io/thek3nsai/ops-brain:v3.2.0` works anonymously.
- [ ] `docker buildx imagetools inspect ghcr.io/thek3nsai/ops-brain:latest` shows both `linux/amd64` and `linux/arm64` entries.
- [ ] Smoke the standalone compose against the published image (clean directory, no repo clone).

## Test plan

- [ ] CI (Format + Lint + Test, Security Audit) green on the PR
- [ ] `workflow_dispatch` run against `v3.2.0` from this branch succeeds end-to-end:
  - [ ] Both matrix jobs (`build (linux/amd64)`, `build (linux/arm64)`) push digests
  - [ ] `merge` job creates the manifest list
  - [ ] `release` job updates the existing v3.2.0 release body with the `docker pull` snippet
- [ ] Multi-arch manifest pullable from a clean Docker on amd64 and arm64
- [ ] `docker compose -f docker-compose.example.yml config` validates (no schema errors, no unresolved refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)