### PR TITLE
chore(ci): bump actions to Node-24 majors ahead of 2026-06-02 auto-force

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install mold linker
         run: sudo apt-get update && sudo apt-get install -y mold
@@ -76,7 +76,7 @@ jobs:
     # Advisory-only: don't block CI on upstream vulnerabilities we can't fix
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
@@ -57,10 +57,10 @@ jobs:
         id: img
         run: echo "name=${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -82,7 +82,7 @@ jobs:
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.arch }}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.arch }}
           path: /tmp/digests/${{ matrix.arch }}
@@ -106,16 +106,16 @@ jobs:
         id: img
         run: echo "name=${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digest-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -152,7 +152,7 @@ jobs:
         id: tag
         run: echo "tag=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
@@ -180,7 +180,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create or update release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}

--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,10 @@ External-user release sweep (#56 + #57) shipped on 2026-05-18: repo description,
 
 ## Open
 
-- **Node 20 → Node 24 action versions in `.github/workflows/release.yml`.** GitHub auto-forces Node 24 on **2026-06-02** and removes Node 20 on **2026-09-16**. The `@v4`/`@v6`/`@v3` pins will get auto-upgraded; bump them to the maintainers' explicit Node-24 releases when those land so the deprecation annotation goes away.
+_(empty)_
 
 ## Closed (2026-05-18 release sweep)
 
 - ~~Tier 1: repo description + topics, GitHub Releases backfill for v1.7.0/v1.8.0/v3.2.0, README lede + quick-start.~~ Shipped in #56.
 - ~~Tier 2: GHCR multi-arch release pipeline, standalone `docker-compose.example.yml`, README quick-start refresh.~~ Shipped in #57; `v3.2.0` image live and public at `ghcr.io/thek3nsai/ops-brain`.
+- ~~Node 20 → Node 24 action versions across `.github/workflows/`.~~ Bumped to explicit Node-24 majors ahead of GitHub's 2026-06-02 auto-force: checkout v5→v6, upload-artifact v4→v7, download-artifact v4→v8, setup-buildx-action v3→v4, login-action v3→v4, build-push-action v6→v7, action-gh-release v2→v3. `actions/cache@v5` already on Node 24.


### PR DESCRIPTION
## Summary

- GitHub auto-forces Node 24 on **2026-06-02** and removes Node 20 on **2026-09-16**. This PR moves every Node-runtime action in our workflows to the maintainers' explicit Node-24 majors so the deprecation annotations clear and we land on supported releases before the cutover.
- Closes the lone open item in `TODO.md`.

## Pin changes

`release.yml`:
| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v5` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/download-artifact` | `@v4` | `@v8` |
| `docker/setup-buildx-action` | `@v3` | `@v4` |
| `docker/login-action` | `@v3` | `@v4` |
| `docker/build-push-action` | `@v6` | `@v7` |
| `softprops/action-gh-release` | `@v2` | `@v3` |

`ci.yml`:
- `actions/checkout` `@v5` → `@v6`
- `actions/cache@v5` stays (already `runs.using: node24`)

All target pins were verified `runs.using: node24` against `action.yml` on the referenced major.

## Notes on the larger jumps

- **`download-artifact@v4` → `@v8`**: v5 carried a breaking single-artifact-by-ID path change. Our workflow uses `pattern: digest-*` + `merge-multiple: true`, so the v5 behavior change does not apply.
- **`upload-artifact@v4` → `@v7`** and **`build-push-action@v6` → `@v7`**: pure runtime/maintenance majors, no input-surface changes that affect our usage.
- **`action-gh-release@v2` → `@v3`**: pure runtime bump per the v3.0.0 release notes ("moves the action runtime from Node 20 to Node 24"). Inputs unchanged.

## Test plan

- [ ] CI runs green on this PR (exercises the `ci.yml` bumps directly).
- [ ] `release.yml` bumps are exercised on the next `v*` tag push. Acceptable risk — same provider, same major-version contracts, action runtime change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)