### PR TITLE
chore(compose): disable diun watching for locally-built ops-brain image

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,6 +41,11 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
+    labels:
+      # Locally-built image (no registry) — exclude from diun's watch-by-default
+      # so it stops probing a non-existent repo and logging daily "access denied".
+      # Base-image (Dockerfile FROM) updates are covered by Dependabot, not diun.
+      diun.enable: "false"
 
 networks:
   web-net:


### PR DESCRIPTION
## What

Add `diun.enable: "false"` to the `ops-brain` service in `docker-compose.prod.yml`.

## Why

`ops-brain`'s prod image is built from a local `Dockerfile` and exists in no registry. With diun's `WATCHBYDEFAULT=true`, diun probes it daily and logs `access denied`, showing up as `failed=N` in the 06:00 summary. This mirrors the existing `invoiceplane` fix (which already carries the label). Base-image (`FROM`) bumps remain covered by Dependabot, not diun.

This closes the long-standing pending item tracked in the infra `TODO.md` and noted in `docker-infrastructure/CLAUDE.md` ("ops-brain (separate public repo) is pending").

## Risk

Compose-label only — no code, env var, network, or image change. `docker compose -f docker-compose.prod.yml config` validates. Applied to production by recreating the `ops-brain` container (no rebuild required); deploy handled by CC-Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)