### PR TITLE
feat(zammad): add update_ticket tool to close/update tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `update_ticket` Zammad tool (21st tool) — closes the loop the fleet was missing: agents could open and hand off tickets but had no way to close them. Drives state transitions (incl. `state="closed"`), priority changes, and an optional inline `note` article (e.g. a resolution summary recorded in the same call, customer-visible by default or `note_internal: true`). Mirrors `create_ticket`'s article-inline shape via `PUT /tickets/{id}`; rejects no-op calls (must provide at least one of state/priority/note). Supports `time_unit`/`time_accounting_type_id` so closing notes can carry time accounting.
 - `.github/workflows/secret-scan.yml` blocks PRs and pushes-to-main that re-introduce the cleaned-up fleet-private patterns. Self-excluded from its own scan. Pairs with a workstation-side pre-commit hook for immediate feedback. Bypass for the rare legitimate case: `ALLOW_FLEET_STRINGS=1 git commit ...`.
 
 ## [3.2.0] — 2026-05-16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@ Rust MCP server for cross-agent coordination. Rust 2021, rmcp 1.6, PostgreSQL 18
 
 For roadmap philosophy + hard stops (what we will/won't build, and why), see `ROADMAP.md`. For shipped history, see `CHANGELOG.md`.
 
-## Surface (20 tools)
+## Surface (21 tools)
 
 - **Knowledge** (5): `add_knowledge`, `update_knowledge`, `delete_knowledge`, `search_knowledge`, `list_knowledge`
 - **Handoffs** (8): `create_handoff` (optional `in_reply_to`), `accept_handoff`, `complete_handoff` (optional `commit_hash`), `list_handoffs`, `search_handoffs`, `delete_handoff`, `list_replies_to_me`, `mark_merged` (flip to `status=merged`, record `merge_commit` + `merged_at`)
 - **Team bus** (1): `check_in` — open action handoffs (pending + accepted) + recent notify-class handoffs for `agent_name`
 - **Search** (1): `backfill_embeddings`
-- **Zammad** (4): `list_tickets`, `get_ticket`, `create_ticket`, `search_tickets`
+- **Zammad** (5): `list_tickets`, `get_ticket`, `create_ticket`, `update_ticket` (state/priority + inline note; `state="closed"` closes), `search_tickets`
 - **Briefings** (1): `generate_briefing` (daily/weekly handoffs+tickets summary, optionally client-scoped)
 
 ## Architecture Constraints

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ ops-brain speaks MCP over either stdio (default) or HTTP. Most multi-machine set
 
 Public HTTP deployments behind a reverse proxy must also set `OPS_BRAIN_ALLOWED_HOSTS` to your hostname — see the config table below.
 
-## Surface (20 tools)
+## Surface (21 tools)
 
 - **Knowledge** — `add_knowledge`, `update_knowledge`, `delete_knowledge`, `search_knowledge`, `list_knowledge`. Cross-agent gotchas, safety warnings, compliance rules, vendor behavior. Per-agent provenance via `author`. Default-deny across clients.
 - **Handoffs** — `create_handoff`, `accept_handoff`, `complete_handoff`, `list_handoffs`, `search_handoffs`, `delete_handoff`, `list_replies_to_me`, `mark_merged`. `action`-class for required work; `notify`-class for FYI broadcasts (auto-pruned after 7 days). Threading via `in_reply_to`; commit-linkage via `commit_hash` on completion + `mark_merged` at integration time.
 - **Team bus** — `check_in` returns open action handoffs (pending + accepted) and recent notifications addressed to your `agent_name`.
 - **Search** — `backfill_embeddings` for the FTS+vector hybrid (PostgreSQL tsvector + pgvector HNSW + RRF fusion).
-- **Zammad** — `list_tickets`, `get_ticket`, `create_ticket`, `search_tickets`. Resolves `client_slug` to Zammad group/org/customer.
+- **Zammad** — `list_tickets`, `get_ticket`, `create_ticket`, `update_ticket`, `search_tickets`. Resolves `client_slug` to Zammad group/org/customer. `update_ticket` drives state transitions (incl. close), priority, and inline resolution notes.
 - **Briefings** — `generate_briefing` produces daily/weekly markdown summaries (handoffs + tickets), optionally client-scoped, stored for history. Same logic available at `POST /api/briefing`.
 
 ## Cross-client safety

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -267,6 +267,19 @@ impl OpsBrain {
         Ok(zammad::handle_search_tickets(self, params.0).await)
     }
 
+    #[tool(
+        name = "update_ticket",
+        description = "Update a Zammad ticket's state, priority, and/or add a note. \
+        Use state='closed' to close a ticket; pass `note` to record the resolution \
+        in the same call. Provide at least one of state, priority, or note."
+    )]
+    async fn update_ticket(
+        &self,
+        params: Parameters<zammad::UpdateTicketParams>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(zammad::handle_update_ticket(self, params.0).await)
+    }
+
     // ===== BRIEFING TOOLS =====
 
     #[tool(

--- a/src/tools/zammad.rs
+++ b/src/tools/zammad.rs
@@ -54,6 +54,25 @@ pub struct SearchTicketsParams {
     pub limit: Option<i64>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateTicketParams {
+    /// Zammad ticket ID (integer)
+    pub ticket_id: i64,
+    /// New state: "new", "open", "pending_reminder", "closed" (optional). Use "closed" to close.
+    pub state: Option<String>,
+    /// New priority: "low", "normal", "high" (optional)
+    pub priority: Option<String>,
+    /// Optional note added as an article in the same request — e.g. a resolution
+    /// summary when closing. Recommended when closing so the "why" is recorded.
+    pub note: Option<String>,
+    /// Whether the note is internal-only (default: false — visible to the customer)
+    pub note_internal: Option<bool>,
+    /// Time spent in minutes for time accounting (applies to the note article)
+    pub time_unit: Option<f64>,
+    /// Time accounting type: 1=Maintenance, 2=On-site, 3=Remote, 4=On-site/Remote
+    pub time_accounting_type_id: Option<i64>,
+}
+
 // ===== HANDLERS =====
 
 pub(crate) async fn handle_list_tickets(
@@ -214,6 +233,71 @@ pub(crate) async fn handle_create_ticket(
     };
 
     json_result(&ticket)
+}
+
+pub(crate) async fn handle_update_ticket(
+    brain: &super::OpsBrain,
+    p: UpdateTicketParams,
+) -> CallToolResult {
+    let zammad = match &brain.zammad_config {
+        Some(c) => c,
+        None => return error_result("Zammad not configured (set ZAMMAD_URL and ZAMMAD_API_TOKEN)"),
+    };
+
+    let state_id = match &p.state {
+        Some(s) => match crate::zammad::state_name_to_id(s) {
+            Some(id) => Some(id),
+            None => {
+                return error_result(&format!(
+                    "Unknown state: '{s}'. Use: new, open, pending_reminder, closed"
+                ))
+            }
+        },
+        None => None,
+    };
+
+    let priority_id = match &p.priority {
+        Some(pr) => match crate::zammad::priority_name_to_id(pr) {
+            Some(id) => Some(id),
+            None => {
+                return error_result(&format!("Unknown priority: '{pr}'. Use: low, normal, high"))
+            }
+        },
+        None => None,
+    };
+
+    let article = p
+        .note
+        .as_ref()
+        .map(|body| crate::zammad::CreateArticleInline {
+            body: body.clone(),
+            content_type: Some("text/plain".to_string()),
+            article_type: Some("note".to_string()),
+            internal: Some(p.note_internal.unwrap_or(false)),
+            time_unit: p.time_unit,
+            time_accounting_type_id: p.time_accounting_type_id,
+        });
+
+    // Reject no-op calls so callers get a clear error rather than a silent PUT
+    // that changes nothing.
+    if state_id.is_none() && priority_id.is_none() && article.is_none() {
+        return error_result("Nothing to update — provide at least one of: state, priority, note.");
+    }
+
+    let payload = crate::zammad::UpdateTicketPayload {
+        state_id,
+        priority_id,
+        // Never reassign ownership on update — clobbering the in-flight owner on
+        // every close would be worse than leaving it. (create_ticket sets the
+        // default owner; updates intentionally do not.)
+        owner_id: None,
+        article,
+    };
+
+    match crate::zammad::update_ticket(zammad, p.ticket_id, &payload).await {
+        Ok(ticket) => json_result(&ticket),
+        Err(e) => error_result(&e),
+    }
 }
 
 pub(crate) async fn handle_search_tickets(

--- a/src/zammad.rs
+++ b/src/zammad.rs
@@ -162,6 +162,21 @@ pub struct CreateArticleInline {
     pub time_accounting_type_id: Option<i64>,
 }
 
+/// Partial update for an existing ticket. All fields optional — only the
+/// provided ones are sent (and changed). An inline `article` adds a note in the
+/// same request, e.g. a resolution summary when transitioning to `closed`.
+#[derive(Debug, Default, Serialize)]
+pub struct UpdateTicketPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub article: Option<CreateArticleInline>,
+}
+
 // ===== API functions =====
 
 fn build_client(_config: &ZammadConfig) -> reqwest::Client {
@@ -343,6 +358,40 @@ pub async fn create_ticket(
         .map_err(|e| format!("Failed to parse Zammad create ticket response: {e}"))
 }
 
+/// Update an existing ticket (state, priority, owner) and optionally add an
+/// inline article. Returns the updated ticket. Uses `PUT /tickets/{id}`.
+pub async fn update_ticket(
+    config: &ZammadConfig,
+    ticket_id: i64,
+    payload: &UpdateTicketPayload,
+) -> Result<ZammadTicket, String> {
+    let client = build_client(config);
+    let url = api_url(config, &format!("/tickets/{ticket_id}"));
+
+    let response = client
+        .put(&url)
+        .header("Authorization", auth_header(config))
+        .header("Content-Type", "application/json")
+        .query(&[("expand", "true")])
+        .json(payload)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to update Zammad ticket {ticket_id}: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!(
+            "Zammad PUT ticket {ticket_id} returned HTTP {status}: {body}"
+        ));
+    }
+
+    response
+        .json::<ZammadTicket>()
+        .await
+        .map_err(|e| format!("Failed to parse Zammad update ticket response: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -521,6 +570,41 @@ mod tests {
         assert_eq!(json["article"]["internal"], true);
         // time_unit should be skipped
         assert!(json["article"].get("time_unit").is_none());
+    }
+
+    #[test]
+    fn serialize_update_ticket_payload_close_with_note() {
+        let payload = UpdateTicketPayload {
+            state_id: Some(4), // closed
+            article: Some(CreateArticleInline {
+                body: "Resolved: replaced the failing PSU.".to_string(),
+                content_type: Some("text/plain".to_string()),
+                article_type: Some("note".to_string()),
+                internal: Some(false),
+                time_unit: None,
+                time_accounting_type_id: None,
+            }),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["state_id"], 4);
+        assert_eq!(
+            json["article"]["body"],
+            "Resolved: replaced the failing PSU."
+        );
+        assert_eq!(json["article"]["internal"], false);
+        // unset fields are omitted entirely
+        assert!(json.get("priority_id").is_none());
+        assert!(json.get("owner_id").is_none());
+    }
+
+    #[test]
+    fn serialize_update_ticket_payload_empty_is_empty_object() {
+        // A no-op update serializes to `{}` — all fields skip_serializing_if None.
+        let payload = UpdateTicketPayload::default();
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json, serde_json::json!({}));
     }
 
     // parse_ticket_search_response


### PR DESCRIPTION
## Why

The fleet could open, list, get, and search Zammad tickets but had **no way to close them**. CC-HSR hit this directly: a ticket handed off as "needs closing" had no closing path through ops-brain. This adds the missing write-back primitive.

## What

A single `update_ticket` tool — the CRUD complement to `create_ticket` (Zammad's `PUT /tickets/{id}` mirrors `POST`), so it's the minimal generic primitive rather than a narrow `close_ticket` that would grow flags. Covers the whole lifecycle: close, reopen, re-prioritize, annotate.

- **Close with a resolution note in one call** — `state="closed"` + `note="..."` posts the closing article in the same request, so the *why* is recorded. Customer-visible by default; `note_internal: true` to keep it internal.
- Reuses the existing `state_name_to_id` (`closed→4`) / `priority_name_to_id` and `create_ticket`'s inline-article shape (`CreateArticleInline`).
- **Rejects no-op calls** — must provide at least one of state/priority/note, so a bad call errors loudly instead of a silent PUT that changes nothing.
- **Never reassigns ownership** on update (unlike create, which sets the default owner).
- Surfaces full HTTP status + body on failure, so a Zammad state-machine 422 comes back as a readable error.
- Carries time accounting (`time_unit` / `time_accounting_type_id`) on the note article.

Surface is now **21 tools** (Zammad 4 → 5).

## Safety

No cross-client gating — consistent with the sibling `get_ticket`/`create_ticket`/`search_tickets`, which also resolve by `client_slug` or raw `ticket_id` and don't run the `filter_cross_client` gate (that gate operates on ops-brain's own `client_id`/`cross_client_safe` rows; a Zammad ticket doesn't carry those). Closing by raw ID is a strictly smaller blast radius than *reading* by raw ID, which already ships.

## Tests

- `serialize_update_ticket_payload_close_with_note` — close + note serializes correctly, unset fields omitted.
- `serialize_update_ticket_payload_empty_is_empty_object` — no-op payload is `{}`.
- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test --lib` all green (88 tests).
- `/prereview` returned "ship it" — no critical/warning findings.

## Docs

README, CLAUDE.md (both 20 → 21 tools), and CHANGELOG `[Unreleased]` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)