### PR TITLE
feat(api): machine-filed handoffs + wake poll (automation backbone phase 1+2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,13 @@ OPS_BRAIN_TRANSPORT=http
 # HTTP settings (only used when transport=http)
 OPS_BRAIN_LISTEN=0.0.0.0:3000
 OPS_BRAIN_AUTH_TOKEN=
+# Machine tokens: scoped credentials for non-interactive callers (monitors,
+# cron sweeps, wake shims). JSON array; each entry binds a secret to a fixed
+# from_agent, an agent allowlist, and scopes ("create" = POST /api/handoff,
+# "read" = GET /api/pending). Machine tokens can never reach /mcp.
+# See docs/machine-callers.md. Example (single line in a real .env):
+# OPS_BRAIN_MACHINE_TOKENS=[{"token":"<32+ char secret>","from_agent":"Example-Host1","client":"example","agents":["CC-Example"],"scopes":["create","read"]}]
+OPS_BRAIN_MACHINE_TOKENS=
 # Comma-separated allowed Host headers (DNS-rebind mitigation, rmcp 1.4+).
 # Defaults to loopback only. Public deployments behind a reverse proxy
 # MUST list their public hostname, e.g.: ops.example.com,ops.example.com:443

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — machine-filed handoffs + wake poll (automation backbone, phase 1+2)
+
+- **`POST /api/handoff`** — REST ingestion path for non-interactive producers (monitors, cron sweeps, scripts). Everything filed here is stamped `origin='machine'` server-side; interactive agents keep filing through the MCP `create_handoff` tool (`origin='agent'`). Optional caller-chosen `dedupe_key` makes recurring producers idempotent: while a handoff with the key is open (pending/accepted), repeat POSTs collapse into a `repeat_count` bump + `updated_at` touch on the existing row (returned with `deduplicated: true`); completing the handoff releases the key. Context payloads get lenient convention-v1 validation — non-object context is rejected, unknown keys and off-enum verdicts come back as `warnings`, never dropped.
+- **`GET /api/pending?agent=X&since=ISO`** — cheap wake-poll endpoint for local schedulers ("Claude kicks off Claude"): open action handoffs for an agent in a deliberately body-free item shape. `since` filters on `updated_at`, so dedupe bumps re-surface a still-firing monitor past the cursor.
+- **Machine tokens** (`OPS_BRAIN_MACHINE_TOKENS`, JSON array) — scoped credentials for the two endpoints above and nothing else (`/mcp` and `/api/briefing` reject them with 403). Each token binds a fixed `from_agent` (request-body overrides are a 400 — the token IS the identity), a case-insensitive agent allowlist gating both filing targets and pollable queues, and `create`/`read` scopes. Parse failures abort startup; secrets must be ≥32 chars, distinct from each other and from the main bearer.
+- Migration `20260717151000_machine_filed_handoffs.sql`: `origin` (CHECK agent|machine), `dedupe_key`, `repeat_count` on `handoffs`, plus the partial unique index (open rows only) that arbitrates the dedupe upsert.
+- `docs/machine-callers.md` — the producer-facing contract: endpoints, token config, dedupe lifecycle, context convention v1 (versioned via `v` for later field promotion), and the standing rules — recurrence lives on producers' own schedulers (ops-brain never owns execution timing), dead-man detection is the producer's job, context/body are PHI-free by contract.
+- **MCP tool surface unchanged (16 tools)** — the entire feature rides the REST layer.
+
 ## [4.0.0] — 2026-07-02
 
 ### Removed — Zammad ticketing retirement (breaking)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ For roadmap philosophy + hard stops (what we will/won't build, and why), see `RO
 - **Search** (1): `backfill_embeddings`
 - **Briefings** (1): `generate_briefing` (daily/weekly handoffs summary, optionally client-scoped)
 
+REST-only (no MCP tools, zero agent token cost): `POST /api/handoff` + `GET /api/pending` — machine-filed handoffs and wake polling for non-interactive producers, authenticated by scoped machine tokens (`OPS_BRAIN_MACHINE_TOKENS`). Producer contract in `docs/machine-callers.md`. Recurrence/dead-man stay on producers' own schedulers — ops-brain never owns execution timing.
+
 ## Architecture Constraints
 
 - All `#[tool]` stubs MUST remain in the single `#[tool_router] impl OpsBrain` block in `src/tools/mod.rs` — rmcp macro requirement. Each stub delegates to a `handle_*` function in the appropriate category module.

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,8 @@ External-user release sweep (#56 + #57) shipped on 2026-05-18: repo description,
 
 ## Open
 
+- **Automation-backbone charter (2026-07-17) — phases 1+2 shipped on `feat/machine-filed-handoffs`; phase 3 evidence-gated.** Joint design with CC-HSR (handoff thread `019f7094` → `019f709f`): machine-filed handoffs + wake poll, contract in `docs/machine-callers.md`. Deliberately NOT built (doctrine intact): server-side recurrence (producers' own schedulers + `dedupe_key` idempotency cover it), structured handoff columns (versioned `context` convention instead — promote fields only if the pilot bleeds from prose-parsing), webhooks-out (poll `GET /api/pending`; additive upgrade if sub-minute latency ever becomes real pain). Pilot consumer: CC-HSR's nightly backup-posture sweep; acceptance = file FAIL → wake poll shows it → repeat suppresses+bumps → complete → next FAIL files fresh.
+
 - **Case-insensitive agent matching on handoff queries.** The fleet convention is `Codex-HSR`-style, but prod data already has mixed casings (`Codex-HSR` and `codex-hsr` both live as distinct `from_agent` values), and `list_handoffs` `from_agent`/`to_agent` filters are exact-match — a targeted query silently misses the other casing. Bit CC-Stealth 2026-07-13 while hunting a CC-HSR handoff. Fix: `ILIKE`/`LOWER()=LOWER()` on the agent filters (cheap, no schema change); optionally lowercase-normalize `check_in`/`list_replies_to_me` the same way. Until shipped: query both casings or fall back to `search_handoffs`.
 
 ## Closed (2026-05-18 release sweep)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,8 @@ services:
       - OPS_BRAIN_TRANSPORT=http
       - OPS_BRAIN_LISTEN=0.0.0.0:3000
       - OPS_BRAIN_AUTH_TOKEN=${OPS_BRAIN_AUTH_TOKEN}
+      # Scoped machine tokens (JSON array) for POST /api/handoff + GET /api/pending
+      - OPS_BRAIN_MACHINE_TOKENS=${OPS_BRAIN_MACHINE_TOKENS:-}
       - OPS_BRAIN_MIGRATE=true
       # rmcp 1.4+ Host header allowlist (DNS-rebind mitigation, default loopback-only)
       - OPS_BRAIN_ALLOWED_HOSTS=${OPS_BRAIN_ALLOWED_HOSTS:-}

--- a/docs/machine-callers.md
+++ b/docs/machine-callers.md
@@ -1,0 +1,189 @@
+# Machine callers
+
+Non-interactive producers — monitors, cron sweeps, scripts — can file handoffs
+and poll an agent's open queue over plain HTTP, without an MCP session. This
+is the ingestion path for "routine work runs unattended; findings arrive as
+pre-filed work items; agents pick them up the same way they pick up
+human-filed work."
+
+Two endpoints, and only these two, are reachable with a machine token:
+
+| Endpoint | Scope | Purpose |
+|---|---|---|
+| `POST /api/handoff` | `create` | File a handoff (idempotent via `dedupe_key`) |
+| `GET /api/pending` | `read` | Poll an agent's open action queue (wake shims) |
+
+Everything else — `/mcp`, `/api/briefing` — rejects machine tokens with 403.
+
+## Scope boundaries (read first)
+
+- **ops-brain never owns execution timing.** Recurrence lives on the
+  producer's own scheduler (cron, systemd timers, Task Scheduler). "Weekly
+  check X" is a cron line that POSTs here — not a server-side definition.
+- **Dead-man detection is out of scope.** If a producer's scheduler dies, no
+  handoff is filed and silence looks green. Producers must self-monitor their
+  own liveness (e.g. a heartbeat/push monitor on the sweep itself).
+- **Context and body are PHI/PII-free by contract.** Pointers, counts,
+  hostnames, slugs — never record contents, personal data, or file payloads.
+  Evidence stays on the producer's infrastructure; the bus carries a
+  *reference* to it.
+
+## Auth: machine tokens
+
+Configured server-side via `OPS_BRAIN_MACHINE_TOKENS` (JSON array):
+
+```json
+[
+  {
+    "token": "<32+ char minted secret>",
+    "from_agent": "Example-Host1",
+    "client": "example",
+    "agents": ["CC-Example"],
+    "scopes": ["create", "read"]
+  }
+]
+```
+
+- `token` — the bearer secret, sent as `Authorization: Bearer <token>`.
+  Minimum 32 chars; must differ from the main auth token. Mint one per
+  machine (not per script — `context.source` carries script identity).
+- `from_agent` — stamped on every handoff this token files. Callers cannot
+  override it; supplying a different `from_agent` in the request body is a
+  400. The token IS the identity.
+- `client` — informational scope label, recorded in server logs.
+- `agents` — the routing allowlist: which agents this token may file
+  handoffs **to** and poll pending queues **for**. Case-insensitive exact
+  match, no wildcard, must be non-empty.
+- `scopes` — `create` and/or `read`, matching the endpoint table above.
+
+Never put the agents' full-surface bearer in a scheduled task. That token
+reaches the entire MCP surface; a machine token bounds theft blast-radius to
+"can file work items to its own lane and read that lane's queue titles."
+
+## `POST /api/handoff`
+
+```json
+{
+  "to_agent": "CC-Example",
+  "title": "[auto] Disk usage WARN: /var 91% (threshold 90%)",
+  "body": "Markdown body: what was measured, value vs threshold, runbook pointer.",
+  "priority": "normal",
+  "category": "action",
+  "dedupe_key": "example-host1-var-disk",
+  "context": { "...": "see convention below" }
+}
+```
+
+- `to_agent` — required; must be in the token's `agents` allowlist. Machine
+  callers cannot file open (unaddressed) handoffs.
+- `priority` — `low` | `normal` | `high` | `critical` (default `normal`).
+  Priority lives HERE, not in context — one source of truth.
+- `category` — `action` (default) or `notify`.
+- `origin` is stamped `machine` server-side on everything filed through this
+  endpoint. It is not a request field.
+
+**Responses**
+
+- `201` — filed fresh: `{"id": "...", "status": "pending", "deduplicated":
+  false, "repeat_count": 0, "warnings": [...]}`
+- `200` — suppressed into an existing open handoff with the same
+  `dedupe_key`: `{"id": "<existing id>", "deduplicated": true,
+  "repeat_count": N, ...}`. The existing row's `updated_at` is bumped and
+  `repeat_count` incremented, so consumers can tell "still firing after N
+  runs" from "filed once and went quiet."
+- `400` / `403` — validation / routing-scope failures. `warnings` are
+  advisory only and never block a filing.
+
+### Dedupe semantics
+
+`dedupe_key` is caller-chosen, per-*check* (not per-run): e.g.
+`example-host1-var-disk`, not `...-2026-07-17`. Uniqueness is enforced only
+against **open** handoffs (pending/accepted). The lifecycle:
+
+1. Check fails → POST files a fresh handoff (201).
+2. Check fails again next run → POST suppresses into the open handoff,
+   bumps `repeat_count` (200).
+3. An agent fixes the issue and completes the handoff → the key is released.
+4. Check fails again later → POST files a fresh handoff (201).
+
+Allowed key characters: `a-zA-Z0-9 . - _ /`, max 200 chars.
+
+**Suppression freezes the payload.** A suppressed POST bumps `repeat_count`
+and `updated_at` only — title, body, priority, and context stay as first
+filed. If a condition can escalate in severity (WARN → FAIL), either tier the
+key (`...-warn` / `...-fail` file as separate handoffs) or accept that the
+open handoff reflects first observation and the agent re-measures on pickup.
+
+### Context convention v1
+
+`context` must be a JSON object when present. Unknown keys are kept and
+warned about in the response — the convention is a contract, not a cage.
+Mirror this table in your own infrastructure's docs so producers don't
+depend on this repo to stay conformant.
+
+```json
+{
+  "v": 1,
+  "source": "host1/disk-sweep",
+  "check": "disk/var-usage",
+  "verdict": "WARN",
+  "observed_at": "2026-07-17T09:00:00Z",
+  "evidence_ref": "/var/log/disk-sweep/2026-07-17.json",
+  "metrics": { "used_pct": 91, "threshold_pct": 90 }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `v` | Convention version (currently `1`). Anchors future migrations. |
+| `source` | `machine/script` id — disambiguates producers under a per-machine token. |
+| `check` | Stable slug for the specific check; typically the `dedupe_key` stem. |
+| `verdict` | `PASS` \| `WARN` \| `FAIL` \| `UNKNOWN`. Convention: file only WARN/FAIL/UNKNOWN — PASS belongs in local reports, not on the bus. |
+| `observed_at` | Measurement time (ISO-8601) — distinct from the row's `created_at`. |
+| `evidence_ref` | **Pointer** to evidence on the producer's own infrastructure (local path, repo-relative report). Never a payload; there is deliberately no `evidence_url` — evidence does not leave the producer's boundary. |
+| `metrics` | Small flat numeric map (value vs threshold). Optional. |
+
+## `GET /api/pending?agent=CC-Example&since=2026-07-17T12:00:00Z&limit=50`
+
+Open **action** handoffs addressed to `agent` (which must be in a machine
+token's `agents` allowlist). `since` filters on `updated_at` — dedupe bumps
+re-surface past the cursor, so a still-firing monitor shows up even if the
+handoff predates it. `limit` defaults to 50 (max 200).
+
+```json
+{
+  "count": 1,
+  "items": [
+    {
+      "id": "0198...",
+      "title": "[auto] Disk usage WARN: /var 91% (threshold 90%)",
+      "status": "pending",
+      "priority": "normal",
+      "category": "action",
+      "origin": "machine",
+      "from_agent": "Example-Host1",
+      "dedupe_key": "example-host1-var-disk",
+      "repeat_count": 2,
+      "created_at": "2026-07-16T10:10:00Z",
+      "updated_at": "2026-07-17T10:10:00Z"
+    }
+  ]
+}
+```
+
+Items are deliberately body-free so a short-interval poll stays a few hundred
+bytes; the woken agent fetches full bodies over MCP (`check_in` /
+`list_handoffs`). A typical wake shim: poll every 5 minutes with a persisted
+`since` cursor; when `count > 0`, kick off a local headless agent run and
+advance the cursor once the run has picked the work up.
+
+## Wiring a new producer (checklist)
+
+1. Mint a 32+ char secret; add its binding to `OPS_BRAIN_MACHINE_TOKENS`
+   (both `.env` and the prod compose enumerate it) and redeploy.
+2. Store the secret on the producer machine with least privilege — never in
+   the repo, never the main bearer.
+3. Schedule the check locally; POST only on WARN/FAIL/UNKNOWN with a
+   per-check `dedupe_key`.
+4. Add a liveness heartbeat for the check itself (dead-man is yours).
+5. Mirror the context convention in your infra's own docs.

--- a/migrations/20260717151000_machine_filed_handoffs.sql
+++ b/migrations/20260717151000_machine_filed_handoffs.sql
@@ -1,0 +1,37 @@
+-- Machine-filed handoffs (automation backbone, phase 1+2).
+--
+-- Non-interactive producers (monitors, cron sweeps, scripts) file handoffs
+-- through a REST ingestion path (`POST /api/handoff`) authenticated by scoped
+-- machine tokens, and local wake shims poll `GET /api/pending` to kick off
+-- agent runs. Three structural additions:
+--
+--   1. `origin` — who filed the row. 'agent' (MCP tools, the default) or
+--      'machine' (the REST ingestion path). Stamped server-side from the
+--      caller class — callers never set it.
+--   2. `dedupe_key` — caller-chosen idempotency key for recurring producers.
+--      Uniqueness is enforced against OPEN rows only (pending/accepted): a
+--      nightly sweep re-detecting the same failure suppresses into the
+--      existing open handoff instead of piling up; once that handoff is
+--      completed, the same key may file fresh.
+--   3. `repeat_count` — server-maintained count of suppressed duplicates,
+--      bumped (with `updated_at`) on each deduped POST. Distinguishes
+--      "monitor still firing for 5 days" from "filed once and went quiet"
+--      without per-occurrence history.
+--
+-- Recurrence itself stays on the producers' own schedulers (cron / Task
+-- Scheduler) per the roadmap hard stop: ops-brain owns memory + coordination,
+-- never execution timing. Dead-man detection is likewise out of scope —
+-- producers must self-monitor their own liveness.
+
+ALTER TABLE handoffs
+    ADD COLUMN origin TEXT NOT NULL DEFAULT 'agent'
+        CONSTRAINT handoffs_origin_check CHECK (origin IN ('agent', 'machine')),
+    ADD COLUMN dedupe_key TEXT NULL,
+    ADD COLUMN repeat_count INTEGER NOT NULL DEFAULT 0;
+
+-- Arbiter index for the dedupe upsert. Partial: only open rows participate,
+-- so a completed handoff releases its key. The predicate here must stay in
+-- sync with the ON CONFLICT clause in handoff_repo::create_machine_handoff.
+CREATE UNIQUE INDEX idx_handoffs_dedupe_key_open
+    ON handoffs (dedupe_key)
+    WHERE dedupe_key IS NOT NULL AND status IN ('pending', 'accepted');

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,17 +3,358 @@
 //! These provide simple HTTP access to ops-brain data without requiring
 //! MCP protocol negotiation. Protected by the same bearer auth middleware.
 
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    Extension, Json,
+};
 use serde::Deserialize;
 use sqlx::PgPool;
 use std::sync::Arc;
 
+use crate::auth::CallerClass;
 use crate::tools::briefings;
+use crate::validation::{
+    validate_agent_name, validate_option, HANDOFF_CATEGORIES, HANDOFF_PRIORITIES,
+};
 
 /// Shared state for REST API handlers.
 #[derive(Clone)]
 pub struct ApiState {
     pub pool: PgPool,
+}
+
+// ===== Machine ingestion: POST /api/handoff =====
+
+/// Top-level keys of the machine-context convention v1. Unknown keys are
+/// warned about, never rejected — the contract is documented in
+/// `docs/machine-callers.md` and versioned by the `v` field.
+const CONTEXT_V1_KEYS: &[&str] = &[
+    "v",
+    "source",
+    "check",
+    "verdict",
+    "observed_at",
+    "evidence_ref",
+    "metrics",
+];
+const CONTEXT_VERDICTS: &[&str] = &["PASS", "WARN", "FAIL", "UNKNOWN"];
+
+const MAX_TITLE_CHARS: usize = 500;
+const MAX_BODY_CHARS: usize = 100_000;
+const MAX_DEDUPE_KEY_CHARS: usize = 200;
+/// Context is stored uncompressed and serialized into every MCP reader
+/// response untruncated (unlike body) — keep it a small structured payload,
+/// not an evidence dump. Evidence belongs behind `evidence_ref`.
+const MAX_CONTEXT_CHARS: usize = 8_192;
+
+#[derive(Debug, Deserialize)]
+pub struct CreateHandoffRequest {
+    /// Required for main-bearer callers. Machine callers get theirs from the
+    /// token binding — supplying a *different* value is a 400.
+    pub from_agent: Option<String>,
+    /// Required for machine callers (and must be within the token's agent
+    /// allowlist). Optional for main-bearer callers (open handoff).
+    pub to_agent: Option<String>,
+    pub priority: Option<String>,
+    pub category: Option<String>,
+    pub title: String,
+    pub body: String,
+    pub context: Option<serde_json::Value>,
+    /// Idempotency key for recurring producers. While a handoff with this
+    /// key is open, repeat POSTs no-op into a repeat_count bump.
+    pub dedupe_key: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CreateHandoffResponse {
+    pub id: String,
+    pub status: String,
+    /// True when the POST was suppressed into an existing open handoff
+    /// holding the same dedupe_key.
+    pub deduplicated: bool,
+    /// Suppressed-duplicate count on the returned row (0 = filed once).
+    pub repeat_count: i32,
+    /// Lenient-validation notes (unknown context keys etc.). Never fatal.
+    pub warnings: Vec<String>,
+}
+
+fn bad_request(msg: impl Into<String>) -> (StatusCode, String) {
+    (StatusCode::BAD_REQUEST, msg.into())
+}
+
+fn validate_dedupe_key(key: &str) -> Result<(), String> {
+    if key.is_empty() || key.len() > MAX_DEDUPE_KEY_CHARS {
+        return Err(format!(
+            "dedupe_key must be 1–{MAX_DEDUPE_KEY_CHARS} chars, got {}",
+            key.len()
+        ));
+    }
+    if !key
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/'))
+    {
+        return Err(format!(
+            "dedupe_key '{key}' contains invalid characters (allowed: a-zA-Z0-9 . - _ /)"
+        ));
+    }
+    Ok(())
+}
+
+/// Lenient context-convention check: reject only structural problems
+/// (non-object), warn on everything else. The producer sees the warnings in
+/// the response; nothing is dropped.
+fn check_context(context: &serde_json::Value) -> Result<Vec<String>, String> {
+    let Some(obj) = context.as_object() else {
+        return Err("context must be a JSON object when present".into());
+    };
+    let serialized_len = context.to_string().len();
+    if serialized_len > MAX_CONTEXT_CHARS {
+        return Err(format!(
+            "context too large ({serialized_len} chars serialized, max {MAX_CONTEXT_CHARS}) — \
+             point at evidence via evidence_ref instead of inlining it"
+        ));
+    }
+    let mut warnings = Vec::new();
+    for key in obj.keys() {
+        if !CONTEXT_V1_KEYS.contains(&key.as_str()) {
+            warnings.push(format!(
+                "context key '{key}' is not part of convention v1 (kept as-is; \
+                 see docs/machine-callers.md)"
+            ));
+        }
+    }
+    if let Some(v) = obj.get("verdict").and_then(|v| v.as_str()) {
+        if !CONTEXT_VERDICTS.contains(&v) {
+            warnings.push(format!(
+                "context.verdict '{v}' is not one of {}",
+                CONTEXT_VERDICTS.join("|")
+            ));
+        }
+    }
+    Ok(warnings)
+}
+
+/// POST /api/handoff — file a handoff from a non-interactive caller.
+///
+/// `origin` is stamped `machine` unconditionally: this is the machine
+/// ingestion path regardless of which credential reached it. Interactive
+/// agents file through the MCP `create_handoff` tool (`origin = agent`).
+pub async fn create_handoff(
+    State(state): State<Arc<ApiState>>,
+    Extension(caller): Extension<CallerClass>,
+    Json(req): Json<CreateHandoffRequest>,
+) -> Result<(StatusCode, Json<CreateHandoffResponse>), (StatusCode, String)> {
+    // Resolve identity from the caller class.
+    let from_agent = match &caller {
+        CallerClass::Machine(token) => {
+            if let Some(claimed) = req.from_agent.as_deref() {
+                if !claimed.eq_ignore_ascii_case(&token.from_agent) {
+                    return Err(bad_request(format!(
+                        "from_agent '{claimed}' does not match this token's binding — omit the \
+                         field; the token IS the identity"
+                    )));
+                }
+            }
+            token.from_agent.clone()
+        }
+        CallerClass::Full => {
+            let claimed = req
+                .from_agent
+                .as_deref()
+                .ok_or_else(|| bad_request("from_agent is required"))?;
+            validate_agent_name(claimed)
+                .map_err(bad_request)?
+                .to_string()
+        }
+    };
+
+    // Routing scope.
+    let to_agent = match (&caller, req.to_agent.as_deref()) {
+        (CallerClass::Machine(_), None) => {
+            return Err(bad_request(
+                "to_agent is required for machine-filed handoffs (no open filings)",
+            ));
+        }
+        (CallerClass::Machine(token), Some(to)) => {
+            let to = validate_agent_name(to).map_err(bad_request)?;
+            if !token.allows_agent(to) {
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    format!("this token may not file handoffs to '{to}'"),
+                ));
+            }
+            to.to_string()
+        }
+        (CallerClass::Full, Some(to)) => validate_agent_name(to).map_err(bad_request)?.to_string(),
+        (CallerClass::Full, None) => {
+            return Err(bad_request(
+                "to_agent is required on the REST ingestion path",
+            ));
+        }
+    };
+
+    validate_option(req.priority.as_deref(), "priority", HANDOFF_PRIORITIES)
+        .map_err(bad_request)?;
+    validate_option(req.category.as_deref(), "category", HANDOFF_CATEGORIES)
+        .map_err(bad_request)?;
+    let priority = req.priority.as_deref().unwrap_or("normal").to_lowercase();
+    let category = req.category.as_deref().unwrap_or("action").to_lowercase();
+
+    if req.title.trim().is_empty() || req.title.len() > MAX_TITLE_CHARS {
+        return Err(bad_request(format!(
+            "title must be 1–{MAX_TITLE_CHARS} chars"
+        )));
+    }
+    if req.body.trim().is_empty() || req.body.len() > MAX_BODY_CHARS {
+        return Err(bad_request(format!(
+            "body must be 1–{MAX_BODY_CHARS} chars"
+        )));
+    }
+    if let Some(key) = req.dedupe_key.as_deref() {
+        validate_dedupe_key(key).map_err(bad_request)?;
+    }
+
+    let warnings = match req.context.as_ref() {
+        Some(ctx) => check_context(ctx).map_err(bad_request)?,
+        None => Vec::new(),
+    };
+
+    let handoff = crate::repo::handoff_repo::create_machine_handoff(
+        &state.pool,
+        &from_agent,
+        &to_agent,
+        &priority,
+        &category,
+        &req.title,
+        &req.body,
+        req.context.as_ref(),
+        req.dedupe_key.as_deref(),
+    )
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("DB error: {e}")))?;
+
+    // The upsert returns the pre-existing row on dedupe suppression; a fresh
+    // insert always carries repeat_count 0 and the id we just minted — so a
+    // bumped repeat_count is the reliable dedupe signal.
+    let deduplicated = handoff.repeat_count > 0;
+    tracing::info!(
+        from_agent = %from_agent,
+        to_agent = %to_agent,
+        id = %handoff.id,
+        deduplicated,
+        repeat_count = handoff.repeat_count,
+        "machine-filed handoff"
+    );
+
+    let status = if deduplicated {
+        StatusCode::OK
+    } else {
+        StatusCode::CREATED
+    };
+    Ok((
+        status,
+        Json(CreateHandoffResponse {
+            id: handoff.id.to_string(),
+            status: handoff.status,
+            deduplicated,
+            repeat_count: handoff.repeat_count,
+            warnings,
+        }),
+    ))
+}
+
+// ===== Wake poll: GET /api/pending =====
+
+#[derive(Debug, Deserialize)]
+pub struct PendingQuery {
+    /// Agent whose open action queue to poll.
+    pub agent: String,
+    /// Optional ISO-8601 cursor: only items with `updated_at` after this
+    /// instant (dedupe bumps re-surface a still-firing monitor).
+    pub since: Option<String>,
+    pub limit: Option<i64>,
+}
+
+/// Trimmed item shape for the poll — deliberately body-free so a 5-minute
+/// cadence stays a few hundred bytes. Agents fetch full bodies over MCP
+/// once awake.
+#[derive(Debug, serde::Serialize)]
+pub struct PendingItem {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub priority: String,
+    pub category: String,
+    pub origin: String,
+    pub from_agent: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dedupe_key: Option<String>,
+    pub repeat_count: i32,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct PendingResponse {
+    pub count: usize,
+    pub items: Vec<PendingItem>,
+}
+
+/// GET /api/pending?agent=X&since=ISO — open action handoffs for an agent,
+/// cheap enough for dumb local schedulers to poll on a short interval.
+pub async fn list_pending(
+    State(state): State<Arc<ApiState>>,
+    Extension(caller): Extension<CallerClass>,
+    Query(q): Query<PendingQuery>,
+) -> Result<Json<PendingResponse>, (StatusCode, String)> {
+    let agent = validate_agent_name(&q.agent).map_err(bad_request)?;
+
+    if let CallerClass::Machine(token) = &caller {
+        if !token.allows_agent(agent) {
+            return Err((
+                StatusCode::FORBIDDEN,
+                format!("this token may not poll the queue of '{agent}'"),
+            ));
+        }
+    }
+
+    let since = match q.since.as_deref() {
+        Some(raw) => Some(
+            chrono::DateTime::parse_from_rfc3339(raw)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|e| bad_request(format!("invalid since timestamp '{raw}': {e}")))?,
+        ),
+        None => None,
+    };
+    let limit = q.limit.unwrap_or(50).clamp(1, 200);
+
+    let handoffs =
+        crate::repo::handoff_repo::list_pending_for_agent(&state.pool, agent, since, limit)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("DB error: {e}")))?;
+
+    let items: Vec<PendingItem> = handoffs
+        .into_iter()
+        .map(|h| PendingItem {
+            id: h.id.to_string(),
+            title: h.title,
+            status: h.status,
+            priority: h.priority,
+            category: h.category,
+            origin: h.origin,
+            from_agent: h.from_agent,
+            dedupe_key: h.dedupe_key,
+            repeat_count: h.repeat_count,
+            created_at: h.created_at,
+            updated_at: h.updated_at,
+        })
+        .collect();
+
+    Ok(Json(PendingResponse {
+        count: items.len(),
+        items,
+    }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,4 +1,5 @@
 use axum::{extract::State, http::StatusCode, middleware::Next, response::Response};
+use std::sync::Arc;
 
 /// Constant-time token comparison to prevent timing attacks.
 pub fn validate_token(token: &str, expected: &str) -> bool {
@@ -13,10 +14,156 @@ pub fn validate_token(token: &str, expected: &str) -> bool {
         == 0
 }
 
+/// A scoped credential for non-interactive callers (monitors, cron sweeps,
+/// wake shims). Machine tokens can reach exactly two endpoints — the REST
+/// ingestion path and the pending poll — never `/mcp` or the rest of `/api`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct MachineToken {
+    /// The bearer secret. Distinct from the main auth token by construction
+    /// (validated at parse time).
+    pub token: String,
+    /// The `from_agent` stamped on every handoff this token files. Callers
+    /// cannot override it — the binding IS the identity.
+    pub from_agent: String,
+    /// Informational client scope, recorded in logs for audit. Routing
+    /// enforcement is `agents` (handoffs carry no client column).
+    #[serde(default)]
+    pub client: Option<String>,
+    /// Agents this token may file handoffs to (`POST /api/handoff` to_agent)
+    /// and poll pending queues for (`GET /api/pending` agent). Matched
+    /// case-insensitively. Must be non-empty — there is no wildcard.
+    #[serde(default)]
+    pub agents: Vec<String>,
+    /// Granted scopes: "create" (POST /api/handoff), "read" (GET /api/pending).
+    #[serde(default)]
+    pub scopes: Vec<String>,
+}
+
+impl MachineToken {
+    pub fn has_scope(&self, scope: &str) -> bool {
+        self.scopes.iter().any(|s| s == scope)
+    }
+
+    /// Case-insensitive membership check against the token's agent allowlist.
+    pub fn allows_agent(&self, agent: &str) -> bool {
+        self.agents.iter().any(|a| a.eq_ignore_ascii_case(agent))
+    }
+}
+
+pub const MACHINE_SCOPES: &[&str] = &["create", "read"];
+
+/// Minimum machine-token length. These are minted secrets, not passwords —
+/// anything short enough to brute-force is a config error.
+const MIN_TOKEN_LEN: usize = 32;
+
+/// Parse and validate the `OPS_BRAIN_MACHINE_TOKENS` JSON config.
+///
+/// Fails fast (startup abort) on any invalid entry: a half-valid token list
+/// silently dropping entries would read as "monitor wired up" while its
+/// filings 401.
+pub fn parse_machine_tokens(
+    raw: Option<&str>,
+    main_token: Option<&str>,
+) -> Result<Vec<MachineToken>, String> {
+    let Some(raw) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(Vec::new());
+    };
+
+    let tokens: Vec<MachineToken> = serde_json::from_str(raw)
+        .map_err(|e| format!("OPS_BRAIN_MACHINE_TOKENS is not a valid JSON array: {e}"))?;
+
+    for (i, t) in tokens.iter().enumerate() {
+        if t.token.len() < MIN_TOKEN_LEN {
+            return Err(format!(
+                "machine token [{i}] is too short ({} chars, min {MIN_TOKEN_LEN})",
+                t.token.len()
+            ));
+        }
+        if let Some(main) = main_token {
+            if t.token == main {
+                return Err(format!(
+                    "machine token [{i}] equals OPS_BRAIN_AUTH_TOKEN — machine tokens must be \
+                     distinct secrets with a smaller blast radius"
+                ));
+            }
+        }
+        crate::validation::validate_agent_name(&t.from_agent)
+            .map_err(|e| format!("machine token [{i}] from_agent: {e}"))?;
+        if t.agents.is_empty() {
+            return Err(format!(
+                "machine token [{i}] ('{}') has an empty agents allowlist — list the agents it \
+                 may file to / poll for explicitly; there is no wildcard",
+                t.from_agent
+            ));
+        }
+        for a in &t.agents {
+            crate::validation::validate_agent_name(a)
+                .map_err(|e| format!("machine token [{i}] agents: {e}"))?;
+        }
+        if t.scopes.is_empty() {
+            return Err(format!(
+                "machine token [{i}] ('{}') has no scopes — grant \"create\" and/or \"read\"",
+                t.from_agent
+            ));
+        }
+        for s in &t.scopes {
+            if !MACHINE_SCOPES.contains(&s.as_str()) {
+                return Err(format!(
+                    "machine token [{i}] has unknown scope '{s}' (valid: {})",
+                    MACHINE_SCOPES.join(", ")
+                ));
+            }
+        }
+    }
+
+    // Duplicate secrets would make the first-match lookup ambiguous.
+    for i in 0..tokens.len() {
+        for j in (i + 1)..tokens.len() {
+            if tokens[i].token == tokens[j].token {
+                return Err(format!(
+                    "machine tokens [{i}] and [{j}] share the same secret — mint one per machine"
+                ));
+            }
+        }
+    }
+
+    Ok(tokens)
+}
+
+/// Who is calling, resolved by the auth middleware and stored in request
+/// extensions for handlers that differentiate (the machine endpoints).
+#[derive(Debug, Clone)]
+pub enum CallerClass {
+    /// Main bearer (or auth disabled in dev) — full surface.
+    Full,
+    /// A machine token — scoped to the machine endpoints it was granted.
+    Machine(Arc<MachineToken>),
+}
+
+#[derive(Clone)]
+pub struct AuthState {
+    pub main_token: Option<String>,
+    pub machine_tokens: Arc<Vec<MachineToken>>,
+}
+
+/// The (method, path) pairs a machine token may reach, and the scope each
+/// requires. Everything else is 403 for machine callers.
+fn required_machine_scope(method: &axum::http::Method, path: &str) -> Option<&'static str> {
+    match (method.as_str(), path) {
+        ("POST", "/api/handoff") => Some("create"),
+        ("GET", "/api/pending") => Some("read"),
+        _ => None,
+    }
+}
+
 /// Axum middleware: validates Bearer token on all non-health requests.
+///
+/// Main bearer → full access (CallerClass::Full). Machine token → only its
+/// granted machine endpoints (CallerClass::Machine). No token configured at
+/// all → dev mode, allow as Full.
 pub async fn bearer_auth(
-    State(expected_token): State<Option<String>>,
-    request: axum::extract::Request,
+    State(state): State<AuthState>,
+    mut request: axum::extract::Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
     // Health endpoint is always public
@@ -24,8 +171,11 @@ pub async fn bearer_auth(
         return Ok(next.run(request).await);
     }
 
-    // If no token configured, allow all requests
-    let Some(ref expected) = expected_token else {
+    // If no main token configured, allow all requests (dev mode). Machine
+    // tokens without a main token would be scoped credentials on an open
+    // server — pointless, so dev mode wins.
+    let Some(ref expected) = state.main_token else {
+        request.extensions_mut().insert(CallerClass::Full);
         return Ok(next.run(request).await);
     };
 
@@ -34,16 +184,50 @@ pub async fn bearer_auth(
         .get("authorization")
         .and_then(|v| v.to_str().ok());
 
-    match auth_header {
-        Some(header) if header.starts_with("Bearer ") => {
-            if validate_token(&header[7..], expected) {
-                Ok(next.run(request).await)
-            } else {
-                Err(StatusCode::UNAUTHORIZED)
-            }
-        }
-        _ => Err(StatusCode::UNAUTHORIZED),
+    let Some(presented) = auth_header.and_then(|h| h.strip_prefix("Bearer ")) else {
+        return Err(StatusCode::UNAUTHORIZED);
+    };
+
+    if validate_token(presented, expected) {
+        request.extensions_mut().insert(CallerClass::Full);
+        return Ok(next.run(request).await);
     }
+
+    // Scan machine tokens. Constant-time per comparison; the scan itself
+    // leaks only the (public) count of configured tokens.
+    let matched = state
+        .machine_tokens
+        .iter()
+        .find(|t| validate_token(presented, &t.token));
+
+    let Some(token) = matched else {
+        return Err(StatusCode::UNAUTHORIZED);
+    };
+
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    let Some(needed) = required_machine_scope(&method, &path) else {
+        tracing::warn!(
+            from_agent = %token.from_agent,
+            %path,
+            "machine token attempted a non-machine endpoint"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    };
+    if !token.has_scope(needed) {
+        tracing::warn!(
+            from_agent = %token.from_agent,
+            %path,
+            scope = needed,
+            "machine token lacks required scope"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    request
+        .extensions_mut()
+        .insert(CallerClass::Machine(Arc::new(token.clone())));
+    Ok(next.run(request).await)
 }
 
 #[cfg(test)]
@@ -77,5 +261,115 @@ mod tests {
     fn validate_token_single_char_diff() {
         assert!(!validate_token("aaaa", "aaab"));
         assert!(!validate_token("aaab", "aaaa"));
+    }
+
+    // parse_machine_tokens
+
+    const T: &str = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+    fn entry(token: &str) -> String {
+        format!(
+            r#"{{"token":"{token}","from_agent":"Example-Host1","client":"example",
+                "agents":["CC-Example"],"scopes":["create","read"]}}"#
+        )
+    }
+
+    #[test]
+    fn parse_none_and_empty_are_ok() {
+        assert!(parse_machine_tokens(None, None).unwrap().is_empty());
+        assert!(parse_machine_tokens(Some(""), None).unwrap().is_empty());
+        assert!(parse_machine_tokens(Some("  "), None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_valid_entry() {
+        let raw = format!("[{}]", entry(T));
+        let tokens = parse_machine_tokens(Some(&raw), Some("main-token")).unwrap();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].from_agent, "Example-Host1");
+        assert!(tokens[0].has_scope("create"));
+        assert!(tokens[0].has_scope("read"));
+        assert!(tokens[0].allows_agent("cc-example")); // case-insensitive
+        assert!(!tokens[0].allows_agent("CC-Other"));
+    }
+
+    #[test]
+    fn parse_rejects_invalid_json() {
+        assert!(parse_machine_tokens(Some("not json"), None).is_err());
+        assert!(parse_machine_tokens(Some(r#"{"token":"x"}"#), None).is_err()); // not an array
+    }
+
+    #[test]
+    fn parse_rejects_short_token() {
+        let raw = format!("[{}]", entry("short"));
+        let err = parse_machine_tokens(Some(&raw), None).unwrap_err();
+        assert!(err.contains("too short"));
+    }
+
+    #[test]
+    fn parse_rejects_token_equal_to_main() {
+        let raw = format!("[{}]", entry(T));
+        let err = parse_machine_tokens(Some(&raw), Some(T)).unwrap_err();
+        assert!(err.contains("OPS_BRAIN_AUTH_TOKEN"));
+    }
+
+    #[test]
+    fn parse_rejects_empty_agents() {
+        let raw = format!(
+            r#"[{{"token":"{T}","from_agent":"Example-Host1","agents":[],"scopes":["create"]}}]"#
+        );
+        let err = parse_machine_tokens(Some(&raw), None).unwrap_err();
+        assert!(err.contains("agents allowlist"));
+    }
+
+    #[test]
+    fn parse_rejects_empty_and_unknown_scopes() {
+        let raw = format!(
+            r#"[{{"token":"{T}","from_agent":"Example-Host1","agents":["CC-Example"],"scopes":[]}}]"#
+        );
+        assert!(parse_machine_tokens(Some(&raw), None)
+            .unwrap_err()
+            .contains("no scopes"));
+
+        let raw = format!(
+            r#"[{{"token":"{T}","from_agent":"Example-Host1","agents":["CC-Example"],"scopes":["admin"]}}]"#
+        );
+        assert!(parse_machine_tokens(Some(&raw), None)
+            .unwrap_err()
+            .contains("unknown scope"));
+    }
+
+    #[test]
+    fn parse_rejects_duplicate_secrets() {
+        let raw = format!("[{},{}]", entry(T), entry(T));
+        let err = parse_machine_tokens(Some(&raw), None).unwrap_err();
+        assert!(err.contains("same secret"));
+    }
+
+    #[test]
+    fn parse_rejects_bad_agent_names() {
+        let raw = format!(
+            r#"[{{"token":"{T}","from_agent":"bad agent","agents":["CC-Example"],"scopes":["create"]}}]"#
+        );
+        assert!(parse_machine_tokens(Some(&raw), None).is_err());
+    }
+
+    // scope routing table
+
+    #[test]
+    fn machine_scope_table() {
+        use axum::http::Method;
+        assert_eq!(
+            required_machine_scope(&Method::POST, "/api/handoff"),
+            Some("create")
+        );
+        assert_eq!(
+            required_machine_scope(&Method::GET, "/api/pending"),
+            Some("read")
+        );
+        assert_eq!(required_machine_scope(&Method::GET, "/api/handoff"), None);
+        assert_eq!(required_machine_scope(&Method::POST, "/api/pending"), None);
+        assert_eq!(required_machine_scope(&Method::POST, "/api/briefing"), None);
+        assert_eq!(required_machine_scope(&Method::POST, "/mcp"), None);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,15 @@ pub struct Config {
     #[arg(long, env = "OPS_BRAIN_AUTH_TOKEN")]
     pub auth_token: Option<String>,
 
+    /// Machine tokens for the REST ingestion path (http transport only).
+    /// JSON array of scoped token bindings, e.g.:
+    /// `[{"token":"...","from_agent":"Example-Host1","client":"example",
+    ///    "agents":["CC-Example"],"scopes":["create","read"]}]`
+    /// Each token is limited to `POST /api/handoff` ("create" scope) and/or
+    /// `GET /api/pending` ("read" scope) for the listed agents — never /mcp.
+    #[arg(long, env = "OPS_BRAIN_MACHINE_TOKENS")]
+    pub machine_tokens: Option<String>,
+
     /// Comma-separated allowed Host header values for HTTP transport (DNS-rebind mitigation
     /// added in rmcp 1.4). Defaults to loopback only — public deployments behind a reverse
     /// proxy must list their public hostname (e.g. `ops.example.com,ops.example.com:443`).

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -176,6 +176,9 @@ mod tests {
             commit_hash: None,
             merge_commit: None,
             merged_at: None,
+            origin: "agent".to_string(),
+            dedupe_key: None,
+            repeat_count: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -202,6 +205,9 @@ mod tests {
             commit_hash: None,
             merge_commit: None,
             merged_at: None,
+            origin: "agent".to_string(),
+            dedupe_key: None,
+            repeat_count: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,8 +101,39 @@ async fn main() -> anyhow::Result<()> {
                 http_config,
             );
 
+            // Machine tokens: scoped credentials for the REST ingestion path
+            // (POST /api/handoff) and wake poll (GET /api/pending). Parse
+            // failures abort startup — a silently dropped token would read
+            // as "monitor wired up" while its filings 401.
+            let machine_tokens = auth::parse_machine_tokens(
+                config.machine_tokens.as_deref(),
+                config.auth_token.as_deref(),
+            )
+            .map_err(|e| anyhow::anyhow!("OPS_BRAIN_MACHINE_TOKENS: {e}"))?;
+            if !machine_tokens.is_empty() {
+                tracing::info!(
+                    count = machine_tokens.len(),
+                    bindings = ?machine_tokens
+                        .iter()
+                        .map(|t| format!(
+                            "{} (client={}, scopes={})",
+                            t.from_agent,
+                            t.client.as_deref().unwrap_or("-"),
+                            t.scopes.join("+")
+                        ))
+                        .collect::<Vec<_>>(),
+                    "machine tokens configured"
+                );
+            }
+            let auth_state = auth::AuthState {
+                main_token: config.auth_token.clone(),
+                machine_tokens: Arc::new(machine_tokens),
+            };
+
             let api_routes = axum::Router::new()
                 .route("/briefing", axum::routing::post(api::generate_briefing))
+                .route("/handoff", axum::routing::post(api::create_handoff))
+                .route("/pending", axum::routing::get(api::list_pending))
                 .with_state(api_state);
 
             // Outer .layer wraps everything below — auth runs BEFORE rmcp's
@@ -113,7 +144,7 @@ async fn main() -> anyhow::Result<()> {
                 .nest("/api", api_routes)
                 .nest_service("/mcp", mcp_service)
                 .layer(axum::middleware::from_fn_with_state(
-                    config.auth_token.clone(),
+                    auth_state,
                     auth::bearer_auth,
                 ));
 

--- a/src/models/handoff.rs
+++ b/src/models/handoff.rs
@@ -25,6 +25,15 @@ pub struct Handoff {
     /// `commit_hash` lands in main.
     pub merge_commit: Option<String>,
     pub merged_at: Option<DateTime<Utc>>,
+    /// Who filed the row: "agent" (MCP tools) or "machine" (REST ingestion
+    /// path). Stamped server-side from the caller class, never caller-set.
+    pub origin: String,
+    /// Caller-chosen idempotency key for recurring machine producers.
+    /// Unique among OPEN handoffs only — completion releases the key.
+    pub dedupe_key: Option<String>,
+    /// Server-maintained count of suppressed duplicate filings against this
+    /// row's `dedupe_key` while it was open. 0 = filed once.
+    pub repeat_count: i32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/src/repo/handoff_repo.rs
+++ b/src/repo/handoff_repo.rs
@@ -46,6 +46,82 @@ pub async fn create_handoff(
     .await
 }
 
+/// Insert a machine-filed handoff (`origin = 'machine'`), idempotent on
+/// `dedupe_key` against OPEN rows: if a pending/accepted handoff already
+/// holds the key, the insert collapses into a bump of that row's
+/// `repeat_count` + `updated_at` and returns it unchanged otherwise.
+/// Callers detect suppression by comparing the returned id to `id`.
+///
+/// The ON CONFLICT clause must stay in sync with the partial unique index
+/// `idx_handoffs_dedupe_key_open` (see migration 20260717151000).
+#[allow(clippy::too_many_arguments)]
+pub async fn create_machine_handoff(
+    pool: &PgPool,
+    from_agent: &str,
+    to_agent: &str,
+    priority: &str,
+    category: &str,
+    title: &str,
+    body: &str,
+    context: Option<&serde_json::Value>,
+    dedupe_key: Option<&str>,
+) -> Result<Handoff, sqlx::Error> {
+    let id = Uuid::now_v7();
+    sqlx::query_as::<_, Handoff>(
+        "INSERT INTO handoffs (id, from_agent, to_agent, priority, category, title, body,
+                               context, origin, dedupe_key)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'machine', $9)
+         ON CONFLICT (dedupe_key)
+            WHERE dedupe_key IS NOT NULL AND status IN ('pending', 'accepted')
+         DO UPDATE SET repeat_count = handoffs.repeat_count + 1,
+                       updated_at = now()
+         RETURNING *",
+    )
+    .bind(id)
+    .bind(from_agent)
+    .bind(to_agent)
+    .bind(priority)
+    .bind(category)
+    .bind(title)
+    .bind(body)
+    .bind(context)
+    .bind(dedupe_key)
+    .fetch_one(pool)
+    .await
+}
+
+/// Open action handoffs addressed to `agent`, for wake-shim polling.
+/// `since` filters on `updated_at` (which `create_machine_handoff` bumps on
+/// dedupe suppression, so a still-firing monitor re-surfaces past a cursor).
+pub async fn list_pending_for_agent(
+    pool: &PgPool,
+    agent: &str,
+    since: Option<chrono::DateTime<chrono::Utc>>,
+    limit: i64,
+) -> Result<Vec<Handoff>, sqlx::Error> {
+    // Exact case-insensitive match, NOT ILIKE: this query sits behind the
+    // machine-token agent allowlist (an exact compare), and ILIKE's `_`
+    // wildcard — legal in agent names — would over-match past that gate.
+    let mut q = String::from(
+        "SELECT * FROM handoffs
+          WHERE status IN ('pending', 'accepted')
+            AND category = 'action'
+            AND LOWER(to_agent) = LOWER($1)",
+    );
+    if since.is_some() {
+        q.push_str(" AND updated_at > $2 ORDER BY updated_at DESC LIMIT $3");
+    } else {
+        q.push_str(" ORDER BY updated_at DESC LIMIT $2");
+    }
+
+    let mut query = sqlx::query_as::<_, Handoff>(&q).bind(agent);
+    if let Some(ts) = since {
+        query = query.bind(ts);
+    }
+    query = query.bind(limit);
+    query.fetch_all(pool).await
+}
+
 pub async fn update_handoff_status(
     pool: &PgPool,
     id: Uuid,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1040,3 +1040,223 @@ mod coordination_handler_tests {
             .unwrap();
     }
 }
+
+mod machine_handoff_tests {
+    use super::*;
+
+    /// The pilot acceptance round-trip: file fresh → duplicate suppresses
+    /// with a repeat_count bump → complete releases the key → next filing
+    /// is fresh again.
+    #[tokio::test]
+    async fn machine_dedupe_lifecycle() {
+        let pool = pool().await;
+        let key = format!("test-check-{}", uuid::Uuid::now_v7());
+
+        let first = ops_brain::repo::handoff_repo::create_machine_handoff(
+            &pool,
+            "Test-Host1",
+            "test-agent",
+            "high",
+            "action",
+            "[auto] test check FAIL",
+            "measured value vs threshold",
+            None,
+            Some(&key),
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.origin, "machine");
+        assert_eq!(first.status, "pending");
+        assert_eq!(first.repeat_count, 0);
+        assert_eq!(first.dedupe_key.as_deref(), Some(key.as_str()));
+
+        // Second nightly run: suppressed into the same row, count bumped,
+        // updated_at moved forward.
+        let second = ops_brain::repo::handoff_repo::create_machine_handoff(
+            &pool,
+            "Test-Host1",
+            "test-agent",
+            "high",
+            "action",
+            "[auto] test check FAIL",
+            "measured value vs threshold",
+            None,
+            Some(&key),
+        )
+        .await
+        .unwrap();
+        assert_eq!(second.id, first.id);
+        assert_eq!(second.repeat_count, 1);
+        assert!(second.updated_at > first.updated_at);
+
+        // Suppression also holds across accepted (still open).
+        ops_brain::repo::handoff_repo::update_handoff_status(&pool, first.id, "accepted")
+            .await
+            .unwrap();
+        let third = ops_brain::repo::handoff_repo::create_machine_handoff(
+            &pool,
+            "Test-Host1",
+            "test-agent",
+            "high",
+            "action",
+            "[auto] test check FAIL",
+            "measured value vs threshold",
+            None,
+            Some(&key),
+        )
+        .await
+        .unwrap();
+        assert_eq!(third.id, first.id);
+        assert_eq!(third.repeat_count, 2);
+
+        // Completion releases the key: the same check failing later files fresh.
+        ops_brain::repo::handoff_repo::update_handoff_status(&pool, first.id, "completed")
+            .await
+            .unwrap();
+        let fresh = ops_brain::repo::handoff_repo::create_machine_handoff(
+            &pool,
+            "Test-Host1",
+            "test-agent",
+            "high",
+            "action",
+            "[auto] test check FAIL",
+            "measured value vs threshold",
+            None,
+            Some(&key),
+        )
+        .await
+        .unwrap();
+        assert_ne!(fresh.id, first.id);
+        assert_eq!(fresh.repeat_count, 0);
+        assert_eq!(fresh.status, "pending");
+
+        sqlx::query("DELETE FROM handoffs WHERE id = ANY($1)")
+            .bind(vec![first.id, fresh.id])
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// NULL dedupe keys never collide — every filing inserts.
+    #[tokio::test]
+    async fn machine_null_dedupe_keys_always_insert() {
+        let pool = pool().await;
+
+        let a = ops_brain::repo::handoff_repo::create_machine_handoff(
+            &pool,
+            "Test-Host1",
+            "test-agent",
+            "normal",
+            "action",
+            "[auto] one-off finding",
+            "body",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let b = ops_brain::repo::handoff_repo::create_machine_handoff(
+            &pool,
+            "Test-Host1",
+            "test-agent",
+            "normal",
+            "action",
+            "[auto] one-off finding",
+            "body",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_ne!(a.id, b.id);
+        assert_eq!(a.repeat_count, 0);
+        assert_eq!(b.repeat_count, 0);
+
+        sqlx::query("DELETE FROM handoffs WHERE id = ANY($1)")
+            .bind(vec![a.id, b.id])
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// The wake-poll query: agent match is case-insensitive, `since` filters
+    /// on updated_at so dedupe bumps re-surface a still-firing monitor.
+    #[tokio::test]
+    async fn list_pending_since_cursor_resurfaces_dedupe_bumps() {
+        let pool = pool().await;
+        // Unique agent per run keeps this test isolated from real rows.
+        let agent = format!("test-agent-{}", uuid::Uuid::now_v7().simple());
+        let key = format!("test-check-{}", uuid::Uuid::now_v7());
+
+        let filed = ops_brain::repo::handoff_repo::create_machine_handoff(
+            &pool,
+            "Test-Host1",
+            &agent,
+            "high",
+            "action",
+            "[auto] test check FAIL",
+            "body",
+            None,
+            Some(&key),
+        )
+        .await
+        .unwrap();
+
+        // Case-insensitive agent match, no cursor.
+        let all = ops_brain::repo::handoff_repo::list_pending_for_agent(
+            &pool,
+            &agent.to_uppercase(),
+            None,
+            50,
+        )
+        .await
+        .unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, filed.id);
+
+        // Cursor after the filing hides it.
+        let cursor = filed.updated_at;
+        let after =
+            ops_brain::repo::handoff_repo::list_pending_for_agent(&pool, &agent, Some(cursor), 50)
+                .await
+                .unwrap();
+        assert!(after.is_empty());
+
+        // A dedupe bump moves updated_at past the cursor → re-surfaces.
+        ops_brain::repo::handoff_repo::create_machine_handoff(
+            &pool,
+            "Test-Host1",
+            &agent,
+            "high",
+            "action",
+            "[auto] test check FAIL",
+            "body",
+            None,
+            Some(&key),
+        )
+        .await
+        .unwrap();
+        let resurfaced =
+            ops_brain::repo::handoff_repo::list_pending_for_agent(&pool, &agent, Some(cursor), 50)
+                .await
+                .unwrap();
+        assert_eq!(resurfaced.len(), 1);
+        assert_eq!(resurfaced[0].id, filed.id);
+        assert_eq!(resurfaced[0].repeat_count, 1);
+
+        // Completed rows drop out of the poll.
+        ops_brain::repo::handoff_repo::update_handoff_status(&pool, filed.id, "completed")
+            .await
+            .unwrap();
+        let done = ops_brain::repo::handoff_repo::list_pending_for_agent(&pool, &agent, None, 50)
+            .await
+            .unwrap();
+        assert!(done.is_empty());
+
+        sqlx::query("DELETE FROM handoffs WHERE id = $1")
+            .bind(filed.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

The "Claude kicks off Claude" primitive: non-interactive producers (monitors, cron sweeps, scripts) can now file handoffs over REST, and local wake shims can cheaply poll an agent's open queue to trigger runs. Jointly specced with CC-HSR on the bus (thread `019f7094` → `019f709f`), Eduardo-chartered.

**Zero new MCP tools** — the entire feature rides the REST layer; agent-facing token cost is unchanged (16 tools). ROADMAP hard stops intact by design: recurrence stays on producers' own schedulers (`dedupe_key` idempotency replaces server-side scheduling), handoffs stay freeform markdown (context is a documented convention, not columns), and dead-man detection is explicitly the producer's job.

## What's in it

- **`POST /api/handoff`** — machine ingestion. `origin='machine'` and `from_agent` stamped server-side from the token binding (body overrides are a 400). `dedupe_key` makes recurring producers idempotent: while a handoff with the key is open, repeat POSTs collapse into a `repeat_count` bump + `updated_at` touch (`200 {deduplicated: true}`); completion releases the key. Context gets lenient convention-v1 validation — non-object rejected, >8KB rejected, unknown keys returned as warnings.
- **`GET /api/pending?agent&since`** — body-free open-action items for wake shims. `since` cursors on `updated_at` so dedupe bumps re-surface still-firing checks. Exact case-insensitive agent match (not ILIKE — `_` in agent names must not wildcard past the token allowlist).
- **Machine tokens** (`OPS_BRAIN_MACHINE_TOKENS` JSON) — per-machine scoped credentials: fixed `from_agent`, agent allowlist gating both filing targets and pollable queues, `create`/`read` scopes. 403 on `/mcp`, `/api/briefing`, and everything else. Startup aborts on invalid config; secrets ≥32 chars and distinct from the main bearer.
- **Migration `20260717151000`** — `origin` (CHECK), `dedupe_key`, `repeat_count` + partial unique index (open rows only) arbitrating the ON CONFLICT upsert. Metadata-only ALTERs, safe on live prod data.
- **`docs/machine-callers.md`** — the producer contract (endpoints, token config, dedupe lifecycle, context convention v1, PHI-free rule, suppression-freezes-payload semantics).

## Testing

- 101 tests pass on a fresh DB (75 unit incl. new token-parsing/scope-table tests; 26 integration incl. dedupe lifecycle, NULL-key non-collision, since-cursor resurfacing).
- E2E against the running server: 201 fresh → 200 dedupe+bump with warning surfacing → wake poll shows `origin=machine`/`repeat_count` → future-cursor hides → 403 out-of-scope poll/file → 403 on `/api/briefing` + `/mcp` with machine token → 401 garbage token → 400 identity mismatch → key release after completion → 201 fresh refile. All passed.
- Reviewed via /prereview (Opus reviewer agent); all three warnings fixed in this diff (ILIKE→exact match on the poll, context size cap, suppression semantics documented).

## Deploy notes (CC-Cloud)

- New env var: `OPS_BRAIN_MACHINE_TOKENS` — already enumerated in `docker-compose.prod.yml` as `${OPS_BRAIN_MACHINE_TOKENS:-}`; add the JSON to prod `.env` when the pilot token is minted (empty = feature dormant, nothing to do on this deploy).
- Migration auto-applies on boot (`OPS_BRAIN_MIGRATE=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)