### PR TITLE
Security + correctness hardening from full-codebase audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ OPS_BRAIN_TRANSPORT=http
 
 # HTTP settings (only used when transport=http)
 OPS_BRAIN_LISTEN=0.0.0.0:3000
+# Required for http transport: startup aborts on a missing/blank token.
+# Generate with: openssl rand -hex 32
+# (For a deliberately open LOCAL dev server only: OPS_BRAIN_DEV_NO_AUTH=true)
 OPS_BRAIN_AUTH_TOKEN=
 # Machine tokens: scoped credentials for non-interactive callers (monitors,
 # cron sweeps, wake shims). JSON array; each entry binds a secret to a fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security — full-codebase audit hardening
+
+- **HTTP transport now fails closed on a missing or blank `OPS_BRAIN_AUTH_TOKEN`.** Previously a present-but-empty env var (`OPS_BRAIN_AUTH_TOKEN=`) reached the auth middleware as a valid zero-length secret, and `Authorization: Bearer ` (empty credential) authenticated as full access — one config slip from an open server on a public host. Startup now aborts unless a non-blank token is set or the operator explicitly passes `--dev-no-auth` / `OPS_BRAIN_DEV_NO_AUTH=true`; `validate_token` additionally refuses to match an empty expected secret, and `docker-compose.prod.yml` fails fast at compose level via `${OPS_BRAIN_AUTH_TOKEN:?...}`.
+- All MCP tool `limit`/`batch_size` params are clamped (`1..=200`, backfill `1..=100`) — negative values no longer reach Postgres and oversized values can't pull whole tables per call.
+
+### Fixed — correctness audit
+
+- **`accept_handoff` race**: the pending-check and the status UPDATE were separate statements, so two agents accepting concurrently could both "win" and both walk away owning the work — the exact duplicate-work failure the bus exists to prevent. Accept/complete/mark-merged are now single atomic conditional UPDATEs (`WHERE id = $1 AND status = ...` + `RETURNING`); the loser gets a clear "already '<status>'" error. The generic `update_handoff_status` repo fn is gone.
+- **`dedupe_key` is now scoped per recipient** (migration `20260717220000`): the arbiter index moved from `(dedupe_key)` to `(dedupe_key, LOWER(to_agent))` over open rows. Previously a producer reusing one key across two target agents had the second filing silently suppressed into the first agent's handoff — the second recipient never got woken.
+- **Agent-name filters use exact case-insensitive matching** (`LOWER(col) = LOWER($n)`) instead of `ILIKE` in `list_handoffs`, `list_open_handoffs`, and `list_replies_to_me` — `_` is legal in agent names and ILIKE treated it as a single-char wildcard, over-matching sibling agents. Matches the wake-poll path's existing semantics.
+- **Embedding batches are reassembled by the response `index` field** instead of positional zip, with a length check — an OpenAI-compatible backend that reorders or short-returns its `data` array can no longer silently store vectors under the wrong rows.
+
 ### Added — machine-filed handoffs + wake poll (automation backbone, phase 1+2)
 
 - **`POST /api/handoff`** — REST ingestion path for non-interactive producers (monitors, cron sweeps, scripts). Everything filed here is stamped `origin='machine'` server-side; interactive agents keep filing through the MCP `create_handoff` tool (`origin='agent'`). Optional caller-chosen `dedupe_key` makes recurring producers idempotent: while a handoff with the key is open (pending/accepted), repeat POSTs collapse into a `repeat_count` bump + `updated_at` touch on the existing row (returned with `deduplicated: true`); completing the handoff releases the key. Context payloads get lenient convention-v1 validation — non-object context is rejected, unknown keys and off-enum verdicts come back as `warnings`, never dropped.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Every audit event lands in the `audit_log` table.
 | `DATABASE_URL` | (required) | PostgreSQL connection string |
 | `OPS_BRAIN_TRANSPORT` | `stdio` | Transport: `stdio` or `http` |
 | `OPS_BRAIN_LISTEN` | `0.0.0.0:3000` | HTTP bind address |
-| `OPS_BRAIN_AUTH_TOKEN` | (none) | Bearer token for HTTP auth |
+| `OPS_BRAIN_AUTH_TOKEN` | (none) | Bearer token for HTTP auth. Required for `http` transport — a missing or blank token aborts startup unless `OPS_BRAIN_DEV_NO_AUTH=true` explicitly opts into an open dev server. |
+| `OPS_BRAIN_DEV_NO_AUTH` | `false` | Explicitly serve HTTP without authentication (dev only — never expose beyond localhost) |
 | `OPS_BRAIN_ALLOWED_HOSTS` | loopback only | Comma-separated allowed `Host` header values for HTTP transport (rmcp DNS-rebind mitigation). Public deploys behind a reverse proxy must set their hostname. |
 | `OPS_BRAIN_MIGRATE` | `true` | Run migrations on startup |
 | `OPS_BRAIN_EMBEDDINGS_ENABLED` | `true` | Set `false` to disable embeddings |

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,7 +21,7 @@ services:
       - DATABASE_URL=postgresql://ops_brain:${OPS_BRAIN_DB_PASSWORD}@shared-postgres:5432/ops_brain
       - OPS_BRAIN_TRANSPORT=http
       - OPS_BRAIN_LISTEN=0.0.0.0:3000
-      - OPS_BRAIN_AUTH_TOKEN=${OPS_BRAIN_AUTH_TOKEN}
+      - OPS_BRAIN_AUTH_TOKEN=${OPS_BRAIN_AUTH_TOKEN:?OPS_BRAIN_AUTH_TOKEN must be set — refusing to start unauthenticated}
       # Scoped machine tokens (JSON array) for POST /api/handoff + GET /api/pending
       - OPS_BRAIN_MACHINE_TOKENS=${OPS_BRAIN_MACHINE_TOKENS:-}
       - OPS_BRAIN_MIGRATE=true

--- a/docs/machine-callers.md
+++ b/docs/machine-callers.md
@@ -98,7 +98,10 @@ reaches the entire MCP surface; a machine token bounds theft blast-radius to
 
 `dedupe_key` is caller-chosen, per-*check* (not per-run): e.g.
 `example-host1-var-disk`, not `...-2026-07-17`. Uniqueness is enforced only
-against **open** handoffs (pending/accepted). The lifecycle:
+against **open** handoffs (pending/accepted), and is scoped **per recipient**
+(`to_agent`, case-insensitive): the same key filed to two different agents
+files two independent handoffs — suppression only applies to repeat filings
+targeting the same agent. The lifecycle:
 
 1. Check fails → POST files a fresh handoff (201).
 2. Check fails again next run → POST suppresses into the open handoff,

--- a/migrations/20260717220000_dedupe_key_per_recipient.sql
+++ b/migrations/20260717220000_dedupe_key_per_recipient.sql
@@ -1,0 +1,20 @@
+-- Dedupe scope: per recipient, not global.
+--
+-- The original arbiter index was on (dedupe_key) alone, so a producer
+-- reusing one key across two target agents had its second filing silently
+-- suppressed into the FIRST agent's open handoff — the second recipient
+-- never saw it, and the response gave no hint the recipient differed.
+--
+-- Scoping the index to (dedupe_key, LOWER(to_agent)) makes the same key
+-- file independently per recipient, matching the wake-poll mental model:
+-- "this check, for this agent, is already open." LOWER() because agent
+-- routing is case-insensitive everywhere else (allowlists, wake poll).
+--
+-- The predicate must stay in sync with the ON CONFLICT clause in
+-- handoff_repo::create_machine_handoff.
+
+DROP INDEX idx_handoffs_dedupe_key_open;
+
+CREATE UNIQUE INDEX idx_handoffs_dedupe_key_open
+    ON handoffs (dedupe_key, LOWER(to_agent))
+    WHERE dedupe_key IS NOT NULL AND status IN ('pending', 'accepted');

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,8 +2,11 @@ use axum::{extract::State, http::StatusCode, middleware::Next, response::Respons
 use std::sync::Arc;
 
 /// Constant-time token comparison to prevent timing attacks.
+///
+/// An empty `expected` never matches: a blank configured secret must not
+/// turn `Authorization: Bearer ` (empty credential) into a valid login.
 pub fn validate_token(token: &str, expected: &str) -> bool {
-    if token.len() != expected.len() {
+    if expected.is_empty() || token.len() != expected.len() {
         return false;
     }
     token
@@ -254,7 +257,9 @@ mod tests {
     fn validate_token_empty() {
         assert!(!validate_token("", "my-secret-token"));
         assert!(!validate_token("something", ""));
-        assert!(validate_token("", "")); // both empty = match
+        // A blank configured secret must never validate anything — not even
+        // an equally blank presented credential.
+        assert!(!validate_token("", ""));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,12 @@ pub struct Config {
     #[arg(long, env = "OPS_BRAIN_AUTH_TOKEN")]
     pub auth_token: Option<String>,
 
+    /// Explicitly serve HTTP without authentication. Without this flag, a
+    /// missing or blank OPS_BRAIN_AUTH_TOKEN aborts startup on the http
+    /// transport — an empty env var must never silently mean "open server".
+    #[arg(long, env = "OPS_BRAIN_DEV_NO_AUTH", default_value_t = false)]
+    pub dev_no_auth: bool,
+
     /// Machine tokens for the REST ingestion path (http transport only).
     /// JSON array of scoped token bindings, e.g.:
     /// `[{"token":"...","from_agent":"Example-Host1","client":"example",

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -25,6 +25,10 @@ struct EmbeddingResponse {
 #[derive(Deserialize)]
 struct EmbeddingData {
     embedding: Vec<f32>,
+    /// Input position this vector belongs to. The OpenAI-compatible spec
+    /// allows `data` to arrive out of order — assigning positionally would
+    /// silently store vectors under the wrong rows.
+    index: usize,
 }
 
 impl EmbeddingClient {
@@ -66,7 +70,22 @@ impl EmbeddingClient {
             anyhow::bail!("Embedding API error {status}: {body}");
         }
 
-        let resp: EmbeddingResponse = response.json().await?;
+        let mut resp: EmbeddingResponse = response.json().await?;
+        if resp.data.len() != texts.len() {
+            anyhow::bail!(
+                "Embedding API returned {} vectors for {} inputs",
+                resp.data.len(),
+                texts.len()
+            );
+        }
+        // Reorder by the spec's `index` field — positional zip would
+        // mislabel vectors if the backend reorders its response. After
+        // sorting, indices must be exactly 0..N: anything else (a gap, a
+        // duplicate) would silently hand some row another input's vector.
+        resp.data.sort_by_key(|d| d.index);
+        if resp.data.iter().enumerate().any(|(i, d)| d.index != i) {
+            anyhow::bail!("Embedding API response has gaps or duplicate indices");
+        }
         Ok(resp.data.into_iter().map(|d| d.embedding).collect())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,33 @@ async fn main() -> anyhow::Result<()> {
             session_manager.session_config.keep_alive = Some(Duration::from_secs(3600));
             let session_manager = Arc::new(session_manager);
 
+            // Fail closed on auth config. clap maps a present-but-empty env
+            // var (`OPS_BRAIN_AUTH_TOKEN=`) to Some(""), and an empty
+            // "secret" must never become a valid bearer credential — so
+            // blank and missing are both treated as "no token", and no
+            // token aborts unless the operator explicitly opted into an
+            // open dev server.
+            let main_token: Option<String> = config
+                .auth_token
+                .as_deref()
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .map(str::to_string);
+            if main_token.is_none() {
+                if config.dev_no_auth {
+                    tracing::warn!(
+                        "AUTH DISABLED (--dev-no-auth): every caller gets full access. \
+                         Never expose this listener beyond localhost."
+                    );
+                } else {
+                    anyhow::bail!(
+                        "OPS_BRAIN_AUTH_TOKEN is missing or blank; refusing to serve HTTP \
+                         without auth. Set a real token, or pass --dev-no-auth / \
+                         OPS_BRAIN_DEV_NO_AUTH=true for a deliberately open dev server."
+                    );
+                }
+            }
+
             let api_state = Arc::new(api::ApiState { pool: pool.clone() });
 
             let mut http_config = StreamableHttpServerConfig::default();
@@ -105,11 +132,9 @@ async fn main() -> anyhow::Result<()> {
             // (POST /api/handoff) and wake poll (GET /api/pending). Parse
             // failures abort startup — a silently dropped token would read
             // as "monitor wired up" while its filings 401.
-            let machine_tokens = auth::parse_machine_tokens(
-                config.machine_tokens.as_deref(),
-                config.auth_token.as_deref(),
-            )
-            .map_err(|e| anyhow::anyhow!("OPS_BRAIN_MACHINE_TOKENS: {e}"))?;
+            let machine_tokens =
+                auth::parse_machine_tokens(config.machine_tokens.as_deref(), main_token.as_deref())
+                    .map_err(|e| anyhow::anyhow!("OPS_BRAIN_MACHINE_TOKENS: {e}"))?;
             if !machine_tokens.is_empty() {
                 tracing::info!(
                     count = machine_tokens.len(),
@@ -126,7 +151,7 @@ async fn main() -> anyhow::Result<()> {
                 );
             }
             let auth_state = auth::AuthState {
-                main_token: config.auth_token.clone(),
+                main_token,
                 machine_tokens: Arc::new(machine_tokens),
             };
 

--- a/src/repo/handoff_repo.rs
+++ b/src/repo/handoff_repo.rs
@@ -47,13 +47,14 @@ pub async fn create_handoff(
 }
 
 /// Insert a machine-filed handoff (`origin = 'machine'`), idempotent on
-/// `dedupe_key` against OPEN rows: if a pending/accepted handoff already
-/// holds the key, the insert collapses into a bump of that row's
-/// `repeat_count` + `updated_at` and returns it unchanged otherwise.
-/// Callers detect suppression by comparing the returned id to `id`.
+/// `(dedupe_key, recipient)` against OPEN rows: if a pending/accepted
+/// handoff to the same agent already holds the key, the insert collapses
+/// into a bump of that row's `repeat_count` + `updated_at` and returns it
+/// unchanged otherwise. The same key filed to a *different* agent inserts
+/// independently — dedupe scope is per recipient, not global.
 ///
 /// The ON CONFLICT clause must stay in sync with the partial unique index
-/// `idx_handoffs_dedupe_key_open` (see migration 20260717151000).
+/// `idx_handoffs_dedupe_key_open` (see migration 20260717220000).
 #[allow(clippy::too_many_arguments)]
 pub async fn create_machine_handoff(
     pool: &PgPool,
@@ -71,7 +72,7 @@ pub async fn create_machine_handoff(
         "INSERT INTO handoffs (id, from_agent, to_agent, priority, category, title, body,
                                context, origin, dedupe_key)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'machine', $9)
-         ON CONFLICT (dedupe_key)
+         ON CONFLICT (dedupe_key, LOWER(to_agent))
             WHERE dedupe_key IS NOT NULL AND status IN ('pending', 'accepted')
          DO UPDATE SET repeat_count = handoffs.repeat_count + 1,
                        updated_at = now()
@@ -122,40 +123,42 @@ pub async fn list_pending_for_agent(
     query.fetch_all(pool).await
 }
 
-pub async fn update_handoff_status(
-    pool: &PgPool,
-    id: Uuid,
-    status: &str,
-) -> Result<Handoff, sqlx::Error> {
+/// Atomically accept a pending handoff. The status precondition lives in
+/// the UPDATE itself so two agents racing on the same handoff can't both
+/// win — the loser gets `None` and must re-read to see who beat them.
+pub async fn accept_handoff(pool: &PgPool, id: Uuid) -> Result<Option<Handoff>, sqlx::Error> {
     sqlx::query_as::<_, Handoff>(
-        "UPDATE handoffs SET status = $2, updated_at = now()
-         WHERE id = $1 RETURNING *",
+        "UPDATE handoffs SET status = 'accepted', updated_at = now()
+         WHERE id = $1 AND status = 'pending'
+         RETURNING *",
     )
     .bind(id)
-    .bind(status)
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await
 }
 
 /// Complete a handoff, optionally recording the commit hash of the work
 /// that closed it. `commit_hash` is free-form; callers typically pass a
 /// short or full git SHA, but any opaque identifier works.
+///
+/// Atomic: only open (pending/accepted) rows transition. `None` means the
+/// row is missing or already terminal — callers re-read to report which.
 pub async fn complete_handoff_with_commit(
     pool: &PgPool,
     id: Uuid,
     commit_hash: Option<&str>,
-) -> Result<Handoff, sqlx::Error> {
+) -> Result<Option<Handoff>, sqlx::Error> {
     sqlx::query_as::<_, Handoff>(
         "UPDATE handoffs
             SET status = 'completed',
                 commit_hash = COALESCE($2, commit_hash),
                 updated_at = now()
-          WHERE id = $1
+          WHERE id = $1 AND status IN ('pending', 'accepted')
           RETURNING *",
     )
     .bind(id)
     .bind(commit_hash)
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await
 }
 
@@ -163,23 +166,27 @@ pub async fn complete_handoff_with_commit(
 /// merge-to-main commit that bundled the work) and the merge timestamp.
 /// Does NOT require `commit_hash` to be set; callers who care about that
 /// linkage can verify it client-side before invoking.
+///
+/// Atomic: only 'completed' rows transition, so a concurrent merge (or a
+/// re-open) between the caller's precondition read and this write loses
+/// cleanly with `None` instead of overwriting.
 pub async fn mark_merged(
     pool: &PgPool,
     id: Uuid,
     merge_commit: &str,
-) -> Result<Handoff, sqlx::Error> {
+) -> Result<Option<Handoff>, sqlx::Error> {
     sqlx::query_as::<_, Handoff>(
         "UPDATE handoffs
             SET status = 'merged',
                 merge_commit = $2,
                 merged_at = now(),
                 updated_at = now()
-          WHERE id = $1
+          WHERE id = $1 AND status = 'completed'
           RETURNING *",
     )
     .bind(id)
     .bind(merge_commit)
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await
 }
 
@@ -196,7 +203,7 @@ pub async fn list_replies_to_me(
         "SELECT r.*
            FROM handoffs r
            JOIN handoffs parent ON parent.id = r.in_reply_to
-          WHERE parent.from_agent ILIKE $1",
+          WHERE LOWER(parent.from_agent) = LOWER($1)",
     );
     if since.is_some() {
         q.push_str(" AND r.created_at > $2");
@@ -231,12 +238,15 @@ pub async fn list_handoffs(
         conditions.push(format!("status = ${param_idx}"));
         param_idx += 1;
     }
+    // Exact case-insensitive agent matching, NOT ILIKE: `_` is legal in
+    // agent names and ILIKE treats it as a single-char wildcard (same
+    // reasoning as list_pending_for_agent).
     if to_agent.is_some() {
-        conditions.push(format!("to_agent ILIKE ${param_idx}"));
+        conditions.push(format!("LOWER(to_agent) = LOWER(${param_idx})"));
         param_idx += 1;
     }
     if from_agent.is_some() {
-        conditions.push(format!("from_agent ILIKE ${param_idx}"));
+        conditions.push(format!("LOWER(from_agent) = LOWER(${param_idx})"));
         param_idx += 1;
     }
     if category.is_some() {
@@ -291,12 +301,13 @@ pub async fn list_open_handoffs(
     let mut conditions: Vec<String> = vec!["status IN ('pending', 'accepted')".to_string()];
     let mut param_idx = 1u32;
 
+    // Exact case-insensitive agent matching — see list_handoffs.
     if to_agent.is_some() {
-        conditions.push(format!("to_agent ILIKE ${param_idx}"));
+        conditions.push(format!("LOWER(to_agent) = LOWER(${param_idx})"));
         param_idx += 1;
     }
     if from_agent.is_some() {
-        conditions.push(format!("from_agent ILIKE ${param_idx}"));
+        conditions.push(format!("LOWER(from_agent) = LOWER(${param_idx})"));
         param_idx += 1;
     }
     if category.is_some() {

--- a/src/tools/coordination.rs
+++ b/src/tools/coordination.rs
@@ -208,18 +208,20 @@ pub async fn handle_accept_handoff(
         Err(_) => return error_result(&format!("Invalid UUID: {}", p.handoff_id)),
     };
 
-    // Verify it's pending
-    match crate::repo::handoff_repo::get_handoff(&brain.pool, id).await {
-        Ok(Some(h)) if h.status == "pending" => {}
-        Ok(Some(h)) => {
-            return error_result(&format!("Handoff is already '{}', cannot accept", h.status))
+    // Atomic accept: the pending precondition is inside the UPDATE, so two
+    // agents racing on the same handoff can't both walk away owning it.
+    match crate::repo::handoff_repo::accept_handoff(&brain.pool, id).await {
+        Ok(Some(handoff)) => json_result(&handoff),
+        Ok(None) => {
+            // Lost the race or bad id — re-read to say which.
+            match crate::repo::handoff_repo::get_handoff(&brain.pool, id).await {
+                Ok(Some(h)) => {
+                    error_result(&format!("Handoff is already '{}', cannot accept", h.status))
+                }
+                Ok(None) => not_found("Handoff", &p.handoff_id),
+                Err(e) => error_result(&format!("Database error: {e}")),
+            }
         }
-        Ok(None) => return not_found("Handoff", &p.handoff_id),
-        Err(e) => return error_result(&format!("Database error: {e}")),
-    }
-
-    match crate::repo::handoff_repo::update_handoff_status(&brain.pool, id, "accepted").await {
-        Ok(handoff) => json_result(&handoff),
         Err(e) => error_result(&format!("Database error: {e}")),
     }
 }
@@ -233,19 +235,8 @@ pub async fn handle_complete_handoff(
         Err(_) => return error_result(&format!("Invalid UUID: {}", p.handoff_id)),
     };
 
-    // Verify it exists and is not already completed or merged. Mirroring
-    // the existing guard: re-completion is a no-op error, not a silent
-    // overwrite of commit_hash.
-    match crate::repo::handoff_repo::get_handoff(&brain.pool, id).await {
-        Ok(Some(h)) if h.status == "completed" => {
-            return error_result("Handoff is already completed")
-        }
-        Ok(Some(h)) if h.status == "merged" => return error_result("Handoff is already merged"),
-        Ok(Some(_)) => {}
-        Ok(None) => return not_found("Handoff", &p.handoff_id),
-        Err(e) => return error_result(&format!("Database error: {e}")),
-    }
-
+    // Atomic complete: only open (pending/accepted) rows transition, so a
+    // concurrent complete can't silently overwrite commit_hash.
     match crate::repo::handoff_repo::complete_handoff_with_commit(
         &brain.pool,
         id,
@@ -253,7 +244,17 @@ pub async fn handle_complete_handoff(
     )
     .await
     {
-        Ok(handoff) => json_result(&handoff),
+        Ok(Some(handoff)) => json_result(&handoff),
+        Ok(None) => match crate::repo::handoff_repo::get_handoff(&brain.pool, id).await {
+            Ok(Some(h)) if h.status == "completed" => error_result("Handoff is already completed"),
+            Ok(Some(h)) if h.status == "merged" => error_result("Handoff is already merged"),
+            Ok(Some(h)) => error_result(&format!(
+                "Handoff is '{}', cannot complete from that state",
+                h.status
+            )),
+            Ok(None) => not_found("Handoff", &p.handoff_id),
+            Err(e) => error_result(&format!("Database error: {e}")),
+        },
         Err(e) => error_result(&format!("Database error: {e}")),
     }
 }
@@ -277,7 +278,7 @@ pub async fn handle_list_replies_to_me(
         },
         None => None,
     };
-    let limit = p.limit.unwrap_or(20);
+    let limit = p.limit.unwrap_or(20).clamp(1, 200);
 
     match crate::repo::handoff_repo::list_replies_to_me(&brain.pool, &agent, since, limit).await {
         Ok(replies) => json_result(&replies),
@@ -322,8 +323,29 @@ pub async fn handle_mark_merged(brain: &super::OpsBrain, p: MarkMergedParams) ->
         Err(e) => return error_result(&format!("Database error: {e}")),
     }
 
+    // Atomic transition: only a 'completed' row can flip to merged, so a
+    // concurrent merge between the precondition read above and this write
+    // loses cleanly instead of overwriting merge_commit.
     match crate::repo::handoff_repo::mark_merged(&brain.pool, id, merge_commit).await {
-        Ok(handoff) => json_result(&handoff),
+        Ok(Some(handoff)) => json_result(&handoff),
+        Ok(None) => match crate::repo::handoff_repo::get_handoff(&brain.pool, id).await {
+            Ok(Some(h)) if h.status == "merged" => {
+                if h.merge_commit.as_deref() == Some(merge_commit) {
+                    json_result(&h)
+                } else {
+                    error_result(&format!(
+                        "Handoff already merged with commit {:?}; refusing to overwrite",
+                        h.merge_commit.as_deref().unwrap_or("(unknown)")
+                    ))
+                }
+            }
+            Ok(Some(h)) => error_result(&format!(
+                "Handoff must be completed before it can be marked merged (current status: '{}')",
+                h.status
+            )),
+            Ok(None) => not_found("Handoff", &p.handoff_id),
+            Err(e) => error_result(&format!("Database error: {e}")),
+        },
         Err(e) => error_result(&format!("Database error: {e}")),
     }
 }
@@ -332,7 +354,7 @@ pub async fn handle_list_handoffs(
     brain: &super::OpsBrain,
     p: ListHandoffsParams,
 ) -> CallToolResult {
-    let limit = p.limit.unwrap_or(20);
+    let limit = p.limit.unwrap_or(20).clamp(1, 200);
     let compact = p.compact.unwrap_or(true);
     let include_notify = p.include_notify.unwrap_or(false);
 
@@ -420,7 +442,7 @@ pub async fn handle_search_handoffs(
     {
         return error_result(&msg);
     }
-    let limit = p.limit.unwrap_or(20);
+    let limit = p.limit.unwrap_or(20).clamp(1, 200);
     let result = match mode {
         "semantic" => {
             let Some(emb) = get_query_embedding(&brain.embedding_client, &p.query).await else {

--- a/src/tools/knowledge.rs
+++ b/src/tools/knowledge.rs
@@ -392,7 +392,7 @@ pub(crate) async fn handle_search_knowledge(
             multi_table,
             p.client_slug.as_deref(),
             p.acknowledge_cross_client.unwrap_or(false),
-            p.limit.unwrap_or(20),
+            p.limit.unwrap_or(20).clamp(1, 200),
             compact,
         )
         .await;
@@ -427,7 +427,7 @@ pub(crate) async fn handle_search_knowledge(
         None => None,
     };
     let acknowledge = p.acknowledge_cross_client.unwrap_or(false);
-    let limit = p.limit.unwrap_or(20);
+    let limit = p.limit.unwrap_or(20).clamp(1, 200);
 
     // Compact mode: default true for multi-table, false for single-table
     let compact = p.compact.unwrap_or(multi_table);
@@ -794,7 +794,7 @@ pub async fn handle_list_knowledge(
         None => None,
     };
 
-    let limit = p.limit.unwrap_or(50);
+    let limit = p.limit.unwrap_or(50).clamp(1, 200);
     match crate::repo::knowledge_repo::list_knowledge(
         &brain.pool,
         p.category.as_deref(),

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -27,7 +27,7 @@ pub(crate) async fn handle_backfill_embeddings(
         );
     };
 
-    let batch_size = p.batch_size.unwrap_or(10);
+    let batch_size = p.batch_size.unwrap_or(10).clamp(1, 100);
     let tables: Vec<&str> = match &p.table {
         Some(t) => vec![t.as_str()],
         None => vec!["knowledge", "handoffs"],

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -201,18 +201,25 @@ mod coordination_tests {
         assert_eq!(handoff.from_agent, "dev-laptop");
         assert_eq!(handoff.to_agent.as_deref(), Some("prod-server"));
 
-        // Accept
-        let accepted =
-            ops_brain::repo::handoff_repo::update_handoff_status(&pool, handoff.id, "accepted")
-                .await
-                .unwrap();
+        // Accept (atomic: only flips a pending row)
+        let accepted = ops_brain::repo::handoff_repo::accept_handoff(&pool, handoff.id)
+            .await
+            .unwrap()
+            .expect("pending handoff should accept");
         assert_eq!(accepted.status, "accepted");
+
+        // Accepting again loses the precondition and returns None.
+        let reaccept = ops_brain::repo::handoff_repo::accept_handoff(&pool, handoff.id)
+            .await
+            .unwrap();
+        assert!(reaccept.is_none(), "second accept must not win");
 
         // Complete
         let completed =
-            ops_brain::repo::handoff_repo::update_handoff_status(&pool, handoff.id, "completed")
+            ops_brain::repo::handoff_repo::complete_handoff_with_commit(&pool, handoff.id, None)
                 .await
-                .unwrap();
+                .unwrap()
+                .expect("open handoff should complete");
         assert_eq!(completed.status, "completed");
 
         // List by status
@@ -501,7 +508,8 @@ mod coordination_tests {
             Some("abc1234"),
         )
         .await
-        .unwrap();
+        .unwrap()
+        .expect("open handoff should complete");
 
         assert_eq!(completed.status, "completed");
         assert_eq!(completed.commit_hash.as_deref(), Some("abc1234"));
@@ -534,7 +542,8 @@ mod coordination_tests {
 
         let merged = ops_brain::repo::handoff_repo::mark_merged(&pool, h.id, "deadbeef0001")
             .await
-            .unwrap();
+            .unwrap()
+            .expect("completed handoff should mark merged");
 
         assert_eq!(merged.status, "merged");
         assert_eq!(merged.merge_commit.as_deref(), Some("deadbeef0001"));
@@ -745,9 +754,10 @@ mod check_in_tests {
         )
         .await
         .unwrap();
-        let _ = ops_brain::repo::handoff_repo::update_handoff_status(&pool, h.id, "accepted")
+        let _ = ops_brain::repo::handoff_repo::accept_handoff(&pool, h.id)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("accept should succeed");
 
         let result = ops_brain::tools::check_in::handle_check_in(
             &brain,
@@ -1090,9 +1100,10 @@ mod machine_handoff_tests {
         assert!(second.updated_at > first.updated_at);
 
         // Suppression also holds across accepted (still open).
-        ops_brain::repo::handoff_repo::update_handoff_status(&pool, first.id, "accepted")
+        ops_brain::repo::handoff_repo::accept_handoff(&pool, first.id)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("accept should succeed");
         let third = ops_brain::repo::handoff_repo::create_machine_handoff(
             &pool,
             "Test-Host1",
@@ -1110,9 +1121,10 @@ mod machine_handoff_tests {
         assert_eq!(third.repeat_count, 2);
 
         // Completion releases the key: the same check failing later files fresh.
-        ops_brain::repo::handoff_repo::update_handoff_status(&pool, first.id, "completed")
+        ops_brain::repo::handoff_repo::complete_handoff_with_commit(&pool, first.id, None)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("complete should succeed");
         let fresh = ops_brain::repo::handoff_repo::create_machine_handoff(
             &pool,
             "Test-Host1",
@@ -1174,6 +1186,66 @@ mod machine_handoff_tests {
 
         sqlx::query("DELETE FROM handoffs WHERE id = ANY($1)")
             .bind(vec![a.id, b.id])
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// Dedupe scope is per recipient: the same key filed to two different
+    /// agents inserts independently instead of suppressing the second
+    /// filing into the first agent's handoff.
+    #[tokio::test]
+    async fn machine_dedupe_key_is_scoped_per_recipient() {
+        let pool = pool().await;
+        let key = format!("shared-check-{}", Uuid::now_v7());
+
+        let file = |to: &'static str| {
+            let pool = pool.clone();
+            let key = key.clone();
+            async move {
+                ops_brain::repo::handoff_repo::create_machine_handoff(
+                    &pool,
+                    "Test-Host1",
+                    to,
+                    "high",
+                    "action",
+                    "[auto] shared check FAIL",
+                    "body",
+                    None,
+                    Some(&key),
+                )
+                .await
+                .unwrap()
+            }
+        };
+
+        let first = file("test-agent-alpha").await;
+        let second = file("test-agent-beta").await;
+        assert_ne!(
+            first.id, second.id,
+            "same key to a different recipient must file fresh"
+        );
+        assert_eq!(second.repeat_count, 0);
+
+        // Same key to the SAME recipient (case-insensitive) still suppresses.
+        let repeat = ops_brain::repo::handoff_repo::create_machine_handoff(
+            &pool,
+            "Test-Host1",
+            "Test-Agent-Alpha",
+            "high",
+            "action",
+            "[auto] shared check FAIL",
+            "body",
+            None,
+            Some(&key),
+        )
+        .await
+        .unwrap();
+        assert_eq!(repeat.id, first.id);
+        assert_eq!(repeat.repeat_count, 1);
+
+        sqlx::query("DELETE FROM handoffs WHERE id = ANY($1)")
+            .bind(vec![first.id, second.id])
             .execute(&pool)
             .await
             .unwrap();
@@ -1245,9 +1317,10 @@ mod machine_handoff_tests {
         assert_eq!(resurfaced[0].repeat_count, 1);
 
         // Completed rows drop out of the poll.
-        ops_brain::repo::handoff_repo::update_handoff_status(&pool, filed.id, "completed")
+        ops_brain::repo::handoff_repo::complete_handoff_with_commit(&pool, filed.id, None)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("complete should succeed");
         let done = ops_brain::repo::handoff_repo::list_pending_for_agent(&pool, &agent, None, 50)
             .await
             .unwrap();


### PR DESCRIPTION
First of three PRs from a four-lens audit (security / correctness / performance / refactor) of the full codebase. This one carries everything exploit- or data-integrity-shaped.

## Security

- **HTTP transport fails closed on missing/blank `OPS_BRAIN_AUTH_TOKEN`.** clap maps a present-but-empty env var to `Some("")`, and `validate_token("", "")` returned true — so `OPS_BRAIN_AUTH_TOKEN=` in the cloud `.env` would have made `Authorization: Bearer ` (empty credential) a valid **full-access** login on a public host. Startup now aborts unless a non-blank token is set or `--dev-no-auth` / `OPS_BRAIN_DEV_NO_AUTH=true` explicitly opts into an open dev server. Defense in depth: `validate_token` refuses an empty expected secret, and `docker-compose.prod.yml` fails at compose level via `${OPS_BRAIN_AUTH_TOKEN:?}`.
- All MCP `limit`/`batch_size` params clamped (`1..=200`, backfill `1..=100`).

## Correctness

- **`accept_handoff` TOCTOU**: the pending-check and the UPDATE were separate statements — two agents accepting concurrently could both win and both walk away owning the work. Accept/complete/mark-merged are now single atomic conditional UPDATEs (`WHERE id = $1 AND status = ...` + `RETURNING`); the loser re-reads and gets a precise "already '<status>'" error. `update_handoff_status` is gone.
- **`dedupe_key` scoped per recipient** (migration `20260717220000`): arbiter index moves from `(dedupe_key)` to `(dedupe_key, LOWER(to_agent))` over open rows. Previously one key reused across two target agents silently suppressed the second filing into the first agent's handoff — the second recipient never got woken. Migration is safe on live data: the new key is strictly finer than the old unique key, so no existing rows can collide. New integration test locks in the semantics.
- **Agent-name filters** in `list_handoffs` / `list_open_handoffs` / `list_replies_to_me` use `LOWER(col) = LOWER($n)` instead of `ILIKE` — `_` is legal in agent names and ILIKE treated it as a wildcard, over-matching sibling agents. Now consistent with the wake-poll path. (Closes the TODO.md residual nit.)
- **Embedding batches** are reassembled by the response `index` field with a full permutation check (length + contiguity) instead of positional zip — an OpenAI-compatible backend that reorders or short-returns `data` can no longer silently store vectors under the wrong rows.

## Housekeeping

- `cargo update -p anyhow` (clears new RUSTSEC-2026-0190 from the audit report; we never call `downcast_mut`).
- README / `.env.example` / `docs/machine-callers.md` / CHANGELOG updated.

## Deploy notes (CC-Cloud)

- Migration `20260717220000` runs automatically (`OPS_BRAIN_MIGRATE=true`); drops + recreates the dedupe arbiter index inside the migration transaction. Brief exclusive lock on `handoffs` — table is tiny, non-issue.
- `OPS_BRAIN_AUTH_TOKEN` must be non-blank in the prod `.env` or the container now refuses to start (that's the point). Current prod value is fine.
- No MCP surface changes; wake-poll and machine-token contracts unchanged apart from the per-recipient dedupe scope, which is documented in `docs/machine-callers.md`.

## Test plan

- 75 unit + 27 integration tests green against a live dev DB with the new migration applied (includes new `machine_dedupe_key_is_scoped_per_recipient` and a second-accept-loses assertion).
- clippy clean, fmt clean; /prereview run — its one finding (permutation check missed duplicate-index case) fixed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)