### PR TITLE
chore: release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [4.1.0] — 2026-07-17
+
+Hardening release from a four-lens full-codebase audit (security / correctness / performance / refactor) run after the automation backbone shipped. PRs #64, #65, #67.
 
 ### Changed — refactor + safety tests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ops-brain"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ops-brain"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server team bus: cross-agent handoffs, knowledge, briefings"


### PR DESCRIPTION
Version bump + CHANGELOG roll for the audit-hardening release (#64 #65 #67). Tag v4.1.0 follows the merge; GHCR multi-arch build fires on the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)