### PR TITLE
docs: post-audit drift sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ For roadmap philosophy + hard stops (what we will/won't build, and why), see `RO
 - **Handoffs** (8): `create_handoff` (optional `in_reply_to`), `accept_handoff`, `complete_handoff` (optional `commit_hash`), `list_handoffs`, `search_handoffs`, `delete_handoff`, `list_replies_to_me`, `mark_merged` (flip to `status=merged`, record `merge_commit` + `merged_at`)
 - **Team bus** (1): `check_in` — open action handoffs (pending + accepted) + recent notify-class handoffs for `agent_name`
 - **Search** (1): `backfill_embeddings`
-- **Briefings** (1): `generate_briefing` (daily/weekly handoffs summary, optionally client-scoped)
+- **Briefings** (1): `generate_briefing` (daily/weekly handoffs summary, fleet-wide — handoffs carry no client column; `client_slug` was dropped in v4.1.0)
 
 REST-only (no MCP tools, zero agent token cost): `POST /api/handoff` + `GET /api/pending` — machine-filed handoffs and wake polling for non-interactive producers, authenticated by scoped machine tokens (`OPS_BRAIN_MACHINE_TOKENS`). Producer contract in `docs/machine-callers.md`. Recurrence/dead-man stay on producers' own schedulers — ops-brain never owns execution timing.
 
@@ -45,6 +45,7 @@ Multi-client data handling for a solo operator managing clients with different c
 - Different client + `cross_client_safe = true` → allowed (marked safe)
 - Different client + `cross_client_safe = false` + `acknowledge_cross_client = true` → released (audit logged)
 - Different client + `cross_client_safe = false` + no acknowledgment → **WITHHELD** (notice returned, audit logged)
+- No `client_slug` on the query → gate is inert (all rows returned), but every item carries provenance and the response carries a `_note` saying the gate is off (v4.1.0)
 
 ## Coordination
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Public HTTP deployments behind a reverse proxy must also set `OPS_BRAIN_ALLOWED_
 - **Handoffs** — `create_handoff`, `accept_handoff`, `complete_handoff`, `list_handoffs`, `search_handoffs`, `delete_handoff`, `list_replies_to_me`, `mark_merged`. `action`-class for required work; `notify`-class for FYI broadcasts (auto-pruned after 7 days). Threading via `in_reply_to`; commit-linkage via `commit_hash` on completion + `mark_merged` at integration time.
 - **Team bus** — `check_in` returns open action handoffs (pending + accepted) and recent notifications addressed to your `agent_name`.
 - **Search** — `backfill_embeddings` for the FTS+vector hybrid (PostgreSQL tsvector + pgvector HNSW + RRF fusion).
-- **Briefings** — `generate_briefing` produces daily/weekly markdown summaries of pending handoffs, optionally client-scoped, stored for history. Same logic available at `POST /api/briefing`.
+- **Briefings** — `generate_briefing` produces daily/weekly markdown summaries of pending handoffs (fleet-wide), stored for history. Same logic available at `POST /api/briefing`.
 
 ## Cross-client safety
 
@@ -102,7 +102,7 @@ Claude Code, Codex CLI, Gemini CLI, and future agents can each have their own on
 ## REST endpoints
 
 ```
-POST /api/briefing  { "type": "daily" | "weekly", "client_slug": "..." (optional) }
+POST /api/briefing  { "type": "daily" | "weekly" }
 GET  /health
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,15 @@
 
 External-user release sweep (#56 + #57) shipped on 2026-05-18: repo description, topics, GitHub Releases backfilled, README lede + quick-start, GHCR multi-arch image pipeline, standalone `docker-compose.example.yml`. The release-intent doctrine — _"don't sharpen for optics; build for the 4 CCs"_ — still applies: no further external-polish work without actual external signal (someone files an issue, asks for help, or otherwise shows up).
 
+## Audit disposition (2026-07-17, v4.1.0 — don't re-flag these)
+
+Four-lens full-codebase audit (security/correctness/performance/refactor) shipped as PRs #64/#65/#67. Every finding was fixed, tested, or **consciously declined**. Declined by doctrine — do not re-propose without new evidence:
+
+- **Verbatim DB error strings to callers** — all callers are our own authenticated agents; informative errors beat sanitization theater here.
+- **`build_client_lookup` caching / backfill batching / embedding retry-backoff** — real but irrelevant at 4-agent scale (perf audit's "theater" list).
+- **Unified error enum** — current boundary-appropriate typing (sqlx::Error → CallToolResult / (StatusCode, String)) is deliberate, not mess.
+- **Briefing cosmetic nits** (section omitted when a LIMIT-20 page holds none of a counted status; unscoped `_note` yields to the rarer embedding note on multi-table) — edge-case cosmetic, flagged in PR #67 body.
+
 ## Open
 
 - **Automation-backbone charter (2026-07-17) — phases 1+2 shipped on `feat/machine-filed-handoffs`; phase 3 evidence-gated.** Joint design with CC-HSR (handoff thread `019f7094` → `019f709f`): machine-filed handoffs + wake poll, contract in `docs/machine-callers.md`. Deliberately NOT built (doctrine intact): server-side recurrence (producers' own schedulers + `dedupe_key` idempotency cover it), structured handoff columns (versioned `context` convention instead — promote fields only if the pilot bleeds from prose-parsing), webhooks-out (poll `GET /api/pending`; additive upgrade if sub-minute latency ever becomes real pain). Pilot consumer: CC-HSR's nightly backup-posture sweep; acceptance = file FAIL → wake poll shows it → repeat suppresses+bumps → complete → next FAIL files fresh. **Stealth wake path smoke-verified 2026-07-17**: Stealth-WS machine token live on stealth, `019f70e2` smoke handoff filed via `POST /api/handoff` → 5-min poll → headless CC-Stealth wake → accept/reply/complete, full loop green.


### PR DESCRIPTION
Docs-only: README/CLAUDE.md still called briefings client-scoped after v4.1.0 dropped the param; CLAUDE.md gate table gains the unscoped-query row; TODO.md records the audit's consciously-declined items (anti-re-flag). Also removed the empty Zammad-era src/integrations/ dir locally (untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)