### PR TITLE
ci: lint shell in CI, and record #77 in the changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,32 @@ jobs:
       - name: Run tests
         run: cargo test
 
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # -x follows sourced files; --source-path=SCRIPTDIR resolves
+      # `# shellcheck source=` relative to the script rather than the CWD.
+      # Without both, any script sourcing a sibling library trips SC1091.
+      - name: Run shellcheck
+        run: |
+          mapfile -t files < <(
+            find scripts -type f \( -name '*.sh' -o -name '*.bash' \) 2>/dev/null
+            find scripts -type f -perm -u+x ! -name '*.*' 2>/dev/null \
+              | while read -r f; do
+                  head -c 60 "$f" | grep -qE '^#!.*(bash|sh)' && echo "$f"
+                done
+          )
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No shell scripts to check."
+            exit 0
+          fi
+          printf 'Checking %s file(s):\n' "${#files[@]}"
+          printf '  %s\n' "${files[@]}"
+          shellcheck -x --source-path=SCRIPTDIR "${files[@]}"
+
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — operator notification (no server change)
+
+- **The operator is just another agent on the bus.** When an agent is blocked on a human, it replies *into the existing thread* with `to_agent: "<operator slug>"` and `category: "action"`; a read-scoped machine token plus a cron polls that queue and mails a digest. This required **zero server code** — `GET /api/pending` already filters on status/category/`to_agent` and does not care that the agent is a person, machine tokens already carry a `read` scope and an agent allowlist, and the `since` cursor already de-duplicates. Convention + operator contract in `docs/operator-notify.md`; reference poller in `scripts/operator-notify.sh`, which renders the digest and delegates sending to `$OPS_NOTIFY_MAIL_CMD` so mail transport stays with the host that already sends briefings. A failed poll or send does not advance the cursor.
+- **Deliberately not built:** a dashboard, a read-only web view, an event log, or transition timestamps. The handoffs table already is the log; the only real gap (`accepted_at` does not exist — `updated_at` is overwritten on every touch) is a schema change in service of a metric nothing is bleeding from. The division of labor is that the notifier answers "something new needs you" and the already cron-mailed daily briefing answers "everything still open".
+
+### Added — CI
+
+- **Shellcheck job** covering `scripts/`, matching `*.sh`/`*.bash` plus extensionless files with a shell shebang, run with `-x --source-path=SCRIPTDIR`. The repo ships shell now; it should be linted like the Rust is.
+
 ## [4.2.0] — 2026-07-28
 
 Identity release. The bus gains a sender guarantee: interactive MCP sessions authenticate with per-agent tokens that bind `from_agent` server-side, so a slug can no longer appear on the bus without an operator-minted credential. PR #73, with the operator contract in `docs/agent-tokens.md` (#75) and the bus-trust convention in `docs/bus-trust.md`. Live fleet-wide since 2026-07-24 — eight bindings across the four infras.


### PR DESCRIPTION
End-of-session drift sweep turned up two gaps. Both are small; neither is new behavior in the server.

## 1. The repo ships shell that nothing lints

`scripts/operator-notify.sh` landed in #77. The Rust in this repo is gated four ways (fmt, clippy, test, audit) and the shell was gated zero — and the local pre-commit hook is not a substitute, because it silently no-ops when shellcheck isn't installed on the committer's machine, which is exactly how this was missed in the first place.

New `Shellcheck` job over `scripts/`, matching `*.sh`/`*.bash` plus extensionless files with a shell shebang. It runs with **`-x --source-path=SCRIPTDIR`**: without both flags, `# shellcheck source=` resolves relative to the CWD rather than the script, so any script sourcing a sibling library trips SC1091 — info severity, but still a nonzero exit, so it would fail CI on a false positive.

Snippet was run locally against the repo before committing: finds 1 file, passes.

## 2. `[Unreleased]` was empty while #77 was shipped

#77 merged after v4.2.0 was cut, so the operator-notify work had no changelog entry. Added, along with the CI job — including the explicit record of what was *deliberately not built* (dashboard, web view, event log, transition timestamps) so the next person doesn't re-litigate it from scratch.

No server code, no migration, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)