### PR TITLE
feat(ops): operator-notify reports to a dead-man monitor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,40 +6,18 @@ Open work only. Shipped history lives in `CHANGELOG.md`, doctrine and hard stops
 
 ## Open
 
-**The operator notifier shares fate with the channel it reports on (2026-07-28).**
-Found during the #77 deploy itself. The ops Gmail app password had been revoked
-on Google's side, which killed the daily briefing, the Logwatch security digest,
-and operator-notify *simultaneously* — every outbound path runs through
-`ops/bin/send-gmail.py`. The handoff reporting "outbound ops email is dead"
-could not be delivered **because of the condition it was reporting**.
+**Uptime Kuma has no notification provider (2026-07-29).** Not an ops-brain
+change — recorded here because it is the load-bearing half of the fix below,
+and because it is live right now. Kuma runs 25 monitors on the cloud host, 12
+of them push dead-man monitors including `Wake Shim`. Its `notification` table
+is **empty**: it alerts nowhere and is a dashboard someone has to remember to
+open. At the time of writing, `System Updates` (10 security updates pending),
+`Container Resources`, and `Disk Usage` had been red for hours with no one
+told — the same silence as a dead mail credential, a different cause.
 
-Failure is safe but silent. A failed send does not advance the cursor
-(control-tested: rc=1, cursor stayed `<none>`), so items are retried rather than
-dropped — nothing is lost. The problem is that a dead notifier and a quiet bus
-look **identical** from the operator's side: no mail either way. For a component
-whose entire job is "tell you when something needs you," failing into a state
-indistinguishable from healthy is the one failure mode that actually matters.
-It only surfaced this time because a human happened to be mid-deploy watching
-the log.
-
-Scope: host-side, not server-side. Delegating transport to
-`$OPS_NOTIFY_MAIL_CMD` was deliberate and stays — mail belongs to the host that
-already sends briefings. The fix lives in `scripts/operator-notify.sh` and the
-ops layer. **No Rust, no new tool surface, no new MCP fields.**
-
-Direction, not yet decided: the script *already knows* it failed — it logs
-`send FAILED` and holds the cursor. The only missing piece is carrying that
-knowledge somewhere that does not share Gmail's fate. Escalating to a second,
-independent channel after N consecutive failures keeps the normal path
-unchanged (no added noise) and exercises the fallback exactly when the primary
-is dead. Weigh that against the cost of a second credential that can also
-expire quietly.
-
-Two shapes to reject up front: a heartbeat whose *absence* you're supposed to
-notice (same class of problem — it asks a human to detect silence), and a
-pre-flight credential check (useful, but its alert path is the broken one).
-
-Both threads that previously sat here closed on 2026-07-28.
+Until Kuma has a default notification provider **that does not share the ops
+Gmail credential**, `$OPS_NOTIFY_HEARTBEAT_URL` reports into a void. Handed to
+CC-Cloud with the deploy.
 
 ## Don't re-propose without new evidence
 
@@ -57,6 +35,38 @@ Deliberate decisions with their reasons. If real friction ever shows up, re-open
 **Operator visibility, tier 2 (2026-07-28).** A log or view of everything happening headless. The handoffs table already *is* the log — `origin`, `status`, `repeat_count`, threading, timestamps. The only real gap is that `updated_at` is destructive, so there's no `accepted_at` and "how long did this sit on a human" isn't answerable. That's a schema change in service of a metric nothing is bleeding from. If friction shows up, the cheapest next step is a section in the briefing that already gets read — not a web view, not event sourcing. Full reasoning in `docs/operator-notify.md`.
 
 ## Closed
+
+- **The operator notifier shares fate with the channel it reports on** —
+  2026-07-29. Opened 07-28 during the #77 deploy: one revoked Gmail app
+  password killed the briefing, the security digest, and operator-notify at
+  once, so the handoff reporting "outbound ops email is dead" could not be
+  delivered *because of the condition it was reporting*. Nothing was ever lost
+  (a failed send holds the cursor and retries), but a dead notifier and a quiet
+  bus looked identical.
+
+  Resolved without the second credential the item was weighing. The escalation
+  channel already existed and was already exercised daily — Uptime Kuma, which
+  the sibling wake shim has pushed to since day one and which owns monitoring
+  by doctrine. `operator-notify.sh` gained an optional
+  `$OPS_NOTIFY_HEARTBEAT_URL` it pings `up`/`down` on every real run;
+  monitoring, thresholds, and alert routing stay in the product that owns them.
+  No Rust, no MCP surface, no new state, no failure counter — and no
+  outage-only path that could rot unnoticed. Pinging is best-effort: an
+  unreachable monitor logs and changes neither exit code nor cursor.
+  Control-tested 12/12 across every exit path, including that cursor retry
+  semantics are unchanged and that a dead monitor is not a new failure mode.
+  Reasoning in `docs/operator-notify.md`.
+
+  Scope boundary held deliberately: this covers a dead *channel*, not a dead
+  *host*. If the box dies, monitor and notifier die together — that wants an
+  off-box check and is a different problem.
+
+  The two shapes the item rejected up front stay rejected, and neither is what
+  shipped: a heartbeat whose absence a *human* must notice is the same failure
+  with more steps, and a pre-flight credential check alerts down the broken
+  path. A dead-man monitor differs on exactly that axis — the silence is
+  noticed by a machine whose only job is noticing silence, on the first missed
+  window.
 
 - **Operator visibility, tier 1** — 2026-07-28, #77. The design session resolved it to a convention plus a cron with **zero lines of Rust**: agents reply into the existing thread addressed to the operator's slug, and a read-scoped machine token plus a cron polls that queue and mails a digest. Contract in `docs/operator-notify.md`, poller in `scripts/operator-notify.sh`. Deployment and token mint handed to CC-Cloud (`019fa9fe`).
 - **Per-agent MCP tokens with server-bound `from_agent`** — 2026-07-28, #73 and #75, released in v4.2.0. Deployed 2026-07-21; minting completed fleet-wide 2026-07-24 (prod boots `agent tokens configured count=8`), binding control-tested per host, and revoked tokens verified dead by probing for 401 rather than assumed. Remaining residuals are ops on other lanes: CC-HSR's local install of the re-minted pair (`019f95df`) and demoting the old shared bearer to break-glass.

--- a/docs/operator-notify.md
+++ b/docs/operator-notify.md
@@ -78,6 +78,68 @@ cursor**, so the next run retries the same items rather than dropping them. The
 script is silent and exits 0 while the token file is absent, so the cron can be
 installed before the mint lands.
 
+## The notifier must not share fate with the channel it reports on
+
+Nothing is ever lost when a send fails — the cursor is held and the items are
+retried. The problem is narrower and worse: **a dead mailer and a quiet bus
+look identical from the operator's side.** No mail either way. For a component
+whose whole job is "tell you when something needs you," failing into a state
+indistinguishable from healthy is the one failure mode that actually matters.
+
+This is not hypothetical. On 2026-07-28 the mail credential behind
+`$OPS_NOTIFY_MAIL_CMD` was revoked provider-side, taking the daily briefing,
+the security digest, and this notifier down together — every outbound path ran
+through one credential. The handoff reporting *"outbound ops email is dead"*
+could not be delivered **because of the condition it was reporting**. It
+surfaced only because a human happened to be watching a log during a deploy.
+
+The fix is not a second mailer. Set `$OPS_NOTIFY_HEARTBEAT_URL` to a dead-man
+monitor — an Uptime Kuma push monitor, or anything else accepting
+`?status=up|down&msg=...`:
+
+```cron
+*/20 * * * * . "$HOME/ops/conf/.env"; \
+             OPS_BRAIN_URL='https://ops.example.com' \
+             OPS_NOTIFY_MAIL_CMD='<the mailer>' \
+             OPS_NOTIFY_HEARTBEAT_URL="$KUMA_OPERATOR_NOTIFY_PUSH" \
+             /path/to/operator-notify.sh
+```
+
+Keep the URL in a mode-600 env file rather than inline in the crontab: its last
+path segment is a push token, and a crontab command line is visible in `ps` to
+every local user. `--status` elides that segment for the same reason.
+
+Every real run reports: `up` when it polled cleanly (with or without items to
+send), `down` with a reason when the poll fails, the token is unusable, or the
+send fails. Miss enough runs entirely — cron dead, host down, script removed —
+and the monitor goes stale on its own. `--dry-run` never reports, so testing
+cannot flip a live monitor.
+
+Three properties make this the right shape rather than a second credential:
+
+- **The silence is noticed by a machine whose only job is noticing silence.**
+  A heartbeat a *human* has to miss is the same failure again with more steps.
+- **The escalation path is exercised continuously.** A fallback used only
+  during outages is a fallback that is broken when you finally need it. The
+  monitoring system is running and alerting on other monitors every day, so it
+  cannot rot unnoticed the way an idle backup credential does.
+- **No new state and no threshold.** The script does not count consecutive
+  failures; it reports each run truthfully and lets the monitor's own retry and
+  resend settings decide when a human is worth waking. Alerting policy belongs
+  to the monitoring system, not to this script.
+
+Pinging is best-effort by construction: an unreachable monitor logs a line and
+changes neither the exit code nor the cursor. The channel that reports failures
+must never become a new way to fail.
+
+**This covers a dead channel, not a dead host.** If the box goes down, the
+monitor and the notifier go with it. Whole-host outage is a different problem
+and wants an off-box check; do not conflate the two.
+
+For this to mean anything, **the monitoring system needs a notification
+channel that does not depend on the same credential as the mailer.** A dead-man
+monitor wired back into the mail path that just died buys nothing.
+
 ## Division of labor with the briefing
 
 | Surface | Answers |

--- a/scripts/operator-notify.sh
+++ b/scripts/operator-notify.sh
@@ -13,6 +13,12 @@
 #
 # Exit codes: 0 = nothing to send, or sent. 1 = poll/send failed (cursor is
 # NOT advanced, so the next run retries the same items).
+#
+# A notifier that fails silently is worse than no notifier: a dead mailer and a
+# quiet bus look identical from the operator's side. $OPS_NOTIFY_HEARTBEAT_URL
+# points at a dead-man monitor — an Uptime Kuma push monitor, or anything else
+# accepting `?status=up|down&msg=...` — which this script pings on every run, so
+# the monitoring system, not a human, is what notices this channel going dark.
 
 set -euo pipefail
 
@@ -23,6 +29,7 @@ STATE_DIR="${OPS_NOTIFY_STATE_DIR:-$HOME/.local/state/operator-notify}"
 CURSOR_FILE="$STATE_DIR/since"
 LOG_FILE="$STATE_DIR/notify.log"
 MAIL_CMD="${OPS_NOTIFY_MAIL_CMD:-}"
+HEARTBEAT_URL="${OPS_NOTIFY_HEARTBEAT_URL:-}"
 
 usage() {
     cat <<'EOF'
@@ -43,6 +50,7 @@ Environment:
   OPS_NOTIFY_TOKEN_FILE    read-scoped machine token, mode 600 (required)
   OPS_NOTIFY_MAIL_CMD      command fed the digest on stdin; unset = stdout
   OPS_NOTIFY_STATE_DIR     cursor + log location
+  OPS_NOTIFY_HEARTBEAT_URL dead-man ping; ?status=up|down&msg=... appended
 
 Dormant (exit 0, silent) until the token file exists, so the cron can be
 installed before the token is minted.
@@ -71,6 +79,19 @@ log() {
     printf '%s %s\n' "$(date -Is)" "$*" >>"$LOG_FILE"
 }
 
+# Ping the dead-man monitor. Deliberately best-effort and never fatal: this is
+# the channel that reports on failure, so it must not become a new way to fail.
+# Only a real `poll` run reports — a --dry-run must not flip a live monitor.
+heartbeat() {
+    local status="$1" msg="${2:-}"
+    [[ -n $HEARTBEAT_URL && $mode == poll ]] || return 0
+    local url="$HEARTBEAT_URL?status=$status"
+    [[ -n $msg ]] && url="$url&msg=$(printf '%s' "$msg" | jq -sRr @uri)"
+    curl -sf --max-time 10 "$url" >/dev/null 2>&1 ||
+        log "heartbeat ping failed (status=$status) — monitor will go stale"
+    return 0
+}
+
 if [[ $mode == status ]]; then
     echo "url:    ${OPS_URL:-<unset — set OPS_BRAIN_URL>}"
     echo "agent:  $AGENT"
@@ -80,6 +101,13 @@ if [[ $mode == status ]]; then
         echo "token:  MISSING at $TOKEN_FILE — dormant"
     fi
     echo "mailer: ${MAIL_CMD:-<stdout>}"
+    # Trailing segment elided: a push URL's last path element is its token, and
+    # --status output gets pasted into logs and handoffs.
+    if [[ -n $HEARTBEAT_URL ]]; then
+        echo "beat:   ${HEARTBEAT_URL%/*}/…"
+    else
+        echo "beat:   <unset — failures will be silent>"
+    fi
     echo "cursor: $(cat "$CURSOR_FILE" 2>/dev/null || echo '<none>')"
     [[ -f $LOG_FILE ]] && { echo "--- recent ---"; tail -n 10 "$LOG_FILE"; }
     exit 0
@@ -95,6 +123,7 @@ fi
 # carry someone's host. Unlike a missing token this is a config error, not a
 # not-yet-provisioned state, so it fails loudly.
 if [[ -z $OPS_URL ]]; then
+    heartbeat down "OPS_BRAIN_URL not set"
     echo "OPS_BRAIN_URL is not set — point it at your ops-brain deployment" >&2
     exit 2
 fi
@@ -108,12 +137,14 @@ fi
 perms=$(stat -c '%a' "$TOKEN_FILE")
 if [[ $perms != 600 && $perms != 400 ]]; then
     log "REFUSING: $TOKEN_FILE has mode $perms (want 600)"
+    heartbeat down "token file mode $perms"
     echo "$TOKEN_FILE has mode $perms — chmod 600 it" >&2
     exit 1
 fi
 token=$(<"$TOKEN_FILE")
 if [[ -z $token ]]; then
     log "REFUSING: token file empty"
+    heartbeat down "token file empty"
     exit 1
 fi
 
@@ -124,11 +155,13 @@ url="$OPS_URL/api/pending?agent=$AGENT"
 
 if ! response=$(curl -sf --max-time 20 -H "Authorization: Bearer $token" "$url"); then
     log "poll failed: curl error against $OPS_URL"
+    heartbeat down "poll failed against $OPS_URL"
     echo "operator-notify: poll failed against $OPS_URL" >&2
     exit 1
 fi
 if ! count=$(jq -r '.count' <<<"$response" 2>/dev/null); then
     log "poll failed: unparseable response"
+    heartbeat down "unparseable poll response"
     echo "operator-notify: unparseable response" >&2
     exit 1
 fi
@@ -137,6 +170,7 @@ if ((count == 0)); then
     # Advance the cursor even on an empty poll: nothing new happened, and
     # holding the old cursor would re-report items on the next non-empty run.
     [[ $mode == poll ]] && echo "$poll_started" >"$CURSOR_FILE"
+    heartbeat up "nothing pending"
     exit 0
 fi
 
@@ -163,6 +197,9 @@ fi
 if [[ -n $MAIL_CMD ]]; then
     if ! printf '%s\n' "$digest" | eval "$MAIL_CMD"; then
         log "send FAILED via \$OPS_NOTIFY_MAIL_CMD — cursor NOT advanced"
+        # The one failure that matters: $count items need a human and the
+        # channel for telling them is down. Say so on the independent one.
+        heartbeat down "send failed — $count item(s) undelivered"
         echo "operator-notify: send failed" >&2
         exit 1
     fi
@@ -173,4 +210,5 @@ fi
 echo "$poll_started" >"$CURSOR_FILE"
 titles=$(jq -r '[.items[].title] | join("; ")' <<<"$response")
 log "notified: $count item(s) — $titles"
+heartbeat up "notified $count item(s)"
 exit 0


### PR DESCRIPTION
Closes the TODO item opened during the #77 deploy: *"the operator notifier shares fate with the channel it reports on."*

## The problem

Nothing was ever lost — a failed send holds the cursor and retries (control-tested at the time). The gap was narrower and worse: **a dead mailer and a quiet bus look identical from the operator's side.** No mail either way.

On 2026-07-28 one revoked Gmail app password took the daily briefing, the Logwatch digest, and operator-notify down simultaneously — every outbound path runs through `ops/bin/send-gmail.py`. The handoff reporting *"outbound ops email is dead"* could not be delivered **because of the condition it was reporting**. It surfaced only because a human happened to be watching a log mid-deploy.

## Why not the second credential the TODO was weighing

The TODO's open direction was "escalate to a second independent channel after N consecutive failures," weighed against the cost of a second credential that can also expire quietly. That tradeoff dissolves once you notice **the escalation channel already exists and is already exercised daily**:

- Uptime Kuma runs 25 monitors on the cloud host, 12 of them push dead-man monitors.
- The sibling `ops-brain-wake-shim.sh` has pushed `up`/`down` to one since day one.
- `operator-notify.sh` was the only bus script never wired in.
- `ROADMAP.md` already says **Uptime Kuma owns monitoring** — this is the doctrinally correct home, not a workaround.

The decisive property: *a fallback used only during outages is a fallback that is broken when you need it.* Kuma is exercised continuously by other monitors, so it cannot rot unnoticed the way an idle backup credential does.

## What this adds

Optional `$OPS_NOTIFY_HEARTBEAT_URL`, pinged on every real run:

| Path | Ping |
|---|---|
| Clean poll, nothing pending | `up` |
| Digest sent | `up notified N item(s)` |
| **Send failed** | `down send failed — N item(s) undelivered` |
| Poll unreachable / unparseable | `down` + reason |
| Token unusable, `OPS_BRAIN_URL` unset | `down` + reason |
| Cron dead / host down / script gone | *no ping — monitor goes stale on its own* |
| `--dry-run`, `--status`, dormant (pre-mint) | *none* |

**No failure counter and no new state.** The script reports each run truthfully; the monitor's own retry/resend settings decide when a human is worth waking. Alerting policy belongs to the product that owns it.

**No Rust, no MCP surface, no new tool** — exactly the scope the TODO drew. Unset = no-op, so the public reference implementation stays deployment-agnostic.

## Safety properties

- **Pinging is best-effort by construction.** An unreachable monitor logs one line and changes neither exit code nor cursor. The channel that reports failures must not become a new way to fail.
- **`--dry-run` never pings**, so testing can't flip a live monitor green.
- **Cursor/retry semantics are untouched** — explicitly regression-tested.
- **The push token stays out of `ps` and out of pasted logs** — docs put the URL in a mode-600 env file (matching the wake shim's existing `~/ops/conf/.env` pattern, where all 12 push URLs already live), and `--status` elides the URL's last path segment.

## Testing

Control-tested 12/12 against a mock ops-brain + mock monitor, covering every exit path:

```
PASS  healthy empty poll                 rc=0 beats=up|nothing pending
PASS  dry-run pings nothing              rc=0 beats=<none>
PASS  dormant (no token) is silent       rc=0 beats=<none>
PASS  bad token perms -> down            rc=1 beats=down|token file mode 644
PASS  empty token -> down                rc=1 beats=down|token file empty
PASS  no OPS_BRAIN_URL -> down           rc=2 beats=down|OPS_BRAIN_URL not set
PASS  poll unreachable -> down           rc=1 beats=down|poll failed against ...
PASS  send ok -> up                      rc=0 beats=up|notified 2 item(s)
PASS  send FAILS -> down + count         rc=1 beats=down|send failed — 2 item(s) undelivered
PASS  cursor advanced on success
PASS  cursor held on send failure
PASS  dead monitor: rc=0, logged
```

shellcheck clean.

## Scope boundary held deliberately

This covers a dead **channel**, not a dead **host**. If the box dies, monitor and notifier die together — that wants an off-box check and is a different problem. Called out in the docs rather than quietly folded in.

## Blocking dependency — this is inert until the other half lands

**Uptime Kuma's `notification` table is empty.** 25 monitors, zero notification providers: it alerts nowhere and is a dashboard someone has to remember to open. At the time of writing, `System Updates` (10 security updates pending), `Container Resources`, and `Disk Usage` had been red for hours with nobody told — the same silence as a dead mail credential, different cause.

Until Kuma has a default provider **that does not share the ops Gmail credential**, `$OPS_NOTIFY_HEARTBEAT_URL` reports into a void. Tracked as the sole open item in `TODO.md` and handed to CC-Cloud with the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)