### PR TITLE
docs: record four measured live-launcher traps in the fleet rollout runbook

### DIFF
--- a/docs/live-fleet-rollout.md
+++ b/docs/live-fleet-rollout.md
@@ -9,6 +9,16 @@ Live messaging is an attended, online-only lane. Do not install either adapter
 as a service, scheduled task, login daemon, or wake-session dependency. A peer
 is present only while its foreground Claude or Codex session is running.
 
+**"Attended" is a mechanism, not a preference.** Both clients fail closed
+without a real terminal, and they fail late. `codex --remote` exits with
+`Error: stdin is not a terminal`, after which the Codex adapter blocks on
+`waiting for exactly one loaded Codex thread; found 0` — registration is gated
+on a genuinely loaded Codex thread, not on the adapter process being up. The
+confusing part is that everything upstream succeeds first: the App Server
+starts and `readyz` passes, so a headless attempt looks like it is working
+right up to the moment it is not, and the failure reads as a broken adapter
+rather than a missing TTY. Do not script, cron, or service-wrap this lane.
+
 ## Fleet matrix
 
 | Host class | Platform | Claude identity | Codex identity | Launcher family |
@@ -25,6 +35,27 @@ The server-side binding is the source of peer identity.
 1. Pull an ops-brain revision containing the live adapters and launchers.
 2. Install Node.js 22 or newer, current Claude Code with Channels support, and
    current Codex CLI with App Server/`--remote` support.
+   **Do not verify Channels support with `claude --help`.** The
+   `--dangerously-load-development-channels` flag is hidden: it is absent from
+   `--help` output while present in the bundle and fully functional. Claude Code
+   **2.1.231** is known good, confirmed independently on two Linux hosts.
+   Checking `--help` will make you conclude the client lacks support and chase
+   an upgrade that changes nothing. To check positively, grep the installed
+   bundle instead of the help text:
+
+   ```bash
+   grep -rasoh dangerously-load-development-channels \
+     "$(dirname "$(readlink -f "$(command -v claude)")")" | wc -l
+   ```
+
+   A non-zero count means the client supports Channels. On 2.1.231 this returns
+   39 on both Linux hosts measured. The check is the principle, not the
+   one-liner: recursively search the installed Claude Code bundle directory for
+   the literal flag string. On Windows, run the equivalent recursive search
+   (`Get-ChildItem -Recurse | Select-String`) against the install directory
+   resolved from `Get-Command claude`; the flag being hidden from `--help` is a
+   property of the client, not of the platform, but the exact count above was
+   not measured on Windows.
    On Windows, the Codex launcher requires a native `codex.exe`; an npm-style
    `codex.cmd` shim cannot host its owned, log-redirected App Server process.
 3. Confirm the host already has the two identity-bound agent tokens. Token
@@ -137,6 +168,34 @@ username matches `-AgentName`, and the adapter independently verifies the
 server-returned binding. Claude, Codex, command arguments, generated MCP
 configuration, and logs receive only the credential-file path.
 
+## Capturing launcher output
+
+Never pipe a launcher's stdout. `ops-brain-claude-live | tee rollout.log` makes
+Claude Code see a non-TTY stdout and silently switch to `--print` mode, which
+then dies with `Input must be provided either through stdin or as a prompt
+argument when using --print`. This is the trap in recording a rollout receipt:
+piping to `tee` is the obvious way to capture one and is exactly what breaks
+the launch.
+
+Use a recorder that keeps a real terminal in front of the client:
+
+```bash
+OPS_BRAIN_LIVE_URL=wss://ops-brain.example/live \
+OPS_BRAIN_AGENT_TOKEN_FILE="$HOME/.config/ops-brain/agent-token-cc-example" \
+OPS_BRAIN_EXPECTED_AGENT=CC-Example \
+OPS_BRAIN_LIVE_LABEL=claude-example \
+script -q -c ops-brain-claude-live rollout.log
+```
+
+`tmux pipe-pane` records the same way, but do not assume tmux is available for
+this: on at least one fleet host the tmux *server* itself dies (`server exited
+unexpectedly`) while hosting the Claude TUI. Prefer `script`; treat tmux as the
+fallback.
+
+The same rule applies to the PowerShell launchers — record with
+`Start-Transcript` rather than piping to `Tee-Object`. That mechanism is
+inferred from the Linux measurement, not yet measured on Windows.
+
 ## Per-host acceptance gate
 
 Do not call a host live until all applicable checks pass:
@@ -148,14 +207,21 @@ Do not call a host live until all applicable checks pass:
 3. Start only Claude. `list_live_peers` from its bound MCP token shows one
    `claude_code` peer with the exact Claude fleet identity.
 4. Stop Claude and confirm the peer disappears. Repeat for Codex.
-5. Start both. Send one unique marker Claude -> Codex and a correlated reply
+5. Start both, then confirm `list_live_peers` reports **exactly one** peer per
+   identity before sending anything. `send_live_message` requires exactly one
+   connected local adapter per bound agent to attribute source provenance; a
+   stale adapter left by an earlier attempt leaves two peers under one identity
+   and makes every send ambiguous. Nothing else surfaces this, and a failed
+   earlier attempt is precisely when a stale peer exists — so check here rather
+   than diagnosing a later send failure as a server problem.
+6. Send one unique marker Claude -> Codex and a correlated reply
    Codex -> Claude. A `host_accepted` receipt means host injection accepted the
    text, not that the model read or followed it.
-6. Negative control: neither sibling token may claim or render as the other
+7. Negative control: neither sibling token may claim or render as the other
    identity. Never send an actual credential as test content.
-7. Leave both sessions idle for at least three minutes through the production
+8. Leave both sessions idle for at least three minutes through the production
    proxy, then repeat one marker exchange.
-8. Exit both clients and confirm their peers disappear promptly and no owned
+9. Exit both clients and confirm their peers disappear promptly and no owned
    App Server, adapter, or launcher process remains.
 
 Record only commit, versions, peer identities, receipt outcomes, timestamps,


### PR DESCRIPTION
Closes the doc half of handoff `019ffcf5`. All four traps were measured by CC-Cloud rolling out `6357af8`; detail in knowledge `019ffcf0-fe1b`. Docs only — no code, schema, or server behavior change.

## The four traps

**1. "Attended" is a mechanism, not a preference** — new paragraph directly under the existing policy line. The doc read as policy, which invites scripting it anyway. It is enforced: `codex --remote` exits `stdin is not a terminal`, then the adapter blocks on `found 0` loaded threads. The reason this bites is that everything upstream *succeeds* first — App Server starts, `readyz` passes — so the failure reads as a broken adapter rather than a missing TTY. Stated in the prerequisites rather than only in the acceptance gate, per CC-Cloud's suggestion.

**2. Never pipe a launcher's stdout** — new "Capturing launcher output" section. `ops-brain-claude-live | tee rollout.log` makes Claude Code see a non-TTY stdout, silently switch to `--print`, and die. This one is self-inflicted by the runbook: it asks operators to record receipts, and `| tee` is the obvious way to do that. Recommends `script`, with `tmux pipe-pane` demoted to fallback given the tmux-server death CC-Cloud hit. `Start-Transcript` noted for PowerShell and explicitly marked inferred, not measured on Windows.

**3. Duplicate adapters break sending, invisibly** — acceptance gate step 5 split in two; old steps 5–8 renumber to 6–9. `send_live_message` needs exactly one connected local adapter per bound agent for provenance, and only `list_live_peers` surfaces a stale duplicate. Checked before the first send, since a failed earlier attempt is exactly when a stale peer exists.

**4. The Channels prerequisite can't be checked the obvious way** — `--dangerously-load-development-channels` is absent from `claude --help` but present and functional. Pins **2.1.231** as known good.

## Independent verification on a second Linux host

Traps 2 and 4 were reproduced on stealth before landing, rather than transcribed:

- `claude --version` → `2.1.231`
- `claude --help | grep -c development-channels` → **0** (flag hidden)
- recursive bundle search → **39** hits (exact match to CC-Cloud's count)

## One addition beyond the report

Trap 4 as reported says *don't* use `--help` but leaves the prerequisite with no way to check it at all — which is a problem when the next consumer is CPA's Windows rollout (`019ffcca-6883`). Added a **positive** bundle-search check, verified as written on stealth. Since the concrete one-liner is bash-only, the doc states the check as a principle (recursively search the install directory for the literal flag string) and points Windows operators at `Get-ChildItem -Recurse | Select-String`, flagging that the count itself was not measured on Windows.

## Review notes

- Local pre-commit hook could not run here: the wake-shim session lacks Gentoo's `env.d` PATH, so `clang` is off-PATH and every `cargo` invocation fails at the linker. The toolchain is fine — `bash -lc 'command -v clang'` resolves. Filed separately; unrelated to this change. Zero Rust files touched, so `fmt`/`clippy`/`check` are vacuous for this diff.
- The fleet-private-string guard, which *is* relevant to a public-repo doc change, was run manually and is clean. All endpoints remain `ops-brain.example` placeholders.
- Step renumbering: no other file in the repo references acceptance-gate step numbers (checked README, `docs/live-messaging.md`, both adapter READMEs). Note that handoff `019ffcf5` refers to "gate steps 5 and 7" under the old numbering — those are now **6 and 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)