### PR TITLE
Windows live launcher fixes: bare --listen URL, hidden child consoles, positional binding

### DIFF
--- a/docs/live-fleet-rollout.md
+++ b/docs/live-fleet-rollout.md
@@ -130,7 +130,9 @@ not a security boundary against processes already running as the same user.
 
 ## Windows installation and launch
 
-From a PowerShell 7.2+ prompt in the ops-brain checkout:
+From a PowerShell 7.4+ prompt in the ops-brain checkout. The Windows bundle
+requires .NET 8 because the Codex launcher redirects helper output while hiding
+the child windows; older runtimes ignore the hidden window style in that mode.
 
 ```powershell
 pwsh -NoProfile -File .\scripts\Install-OpsBrainLive.ps1

--- a/scripts/Install-OpsBrainLive.ps1
+++ b/scripts/Install-OpsBrainLive.ps1
@@ -1,4 +1,4 @@
-#requires -Version 7.2
+#requires -Version 7.4
 # Install private ops-brain live launch shims for one Windows user.
 
 [CmdletBinding()]

--- a/scripts/Test-OpsBrainLiveWindows.ps1
+++ b/scripts/Test-OpsBrainLiveWindows.ps1
@@ -103,7 +103,11 @@ fs.writeFileSync(capture, `${config}\n---ARGS---\n${args.join('\n')}`);
             '-LiveUrl', 'wss://ops-brain.example/live',
             '-AgentCredentialFile', $credential,
             '-AgentName', 'CC-CI',
-            '-Label', 'claude-ci'
+            '-Label', 'claude-ci',
+            # Trailing client arguments. These must reach $ClaudeArgs; with
+            # PositionalBinding left on, 'resume' binds to $Mode instead and the
+            # launcher dies in ValidateSet before Claude is ever invoked.
+            'resume', '--model', 'fixture-model'
         )) { [void]$startInfo.ArgumentList.Add($argument) }
         $process = [Diagnostics.Process]::Start($startInfo)
         $process.WaitForExit()
@@ -129,6 +133,19 @@ fs.writeFileSync(capture, `${config}\n---ARGS---\n${args.join('\n')}`);
     Assert-True ($configIndex -ge 0 -and $configIndex + 1 -lt $arguments.Count) 'Claude did not receive one MCP config path argument'
     Assert-True (-not (Test-Path -LiteralPath $arguments[$configIndex + 1])) 'temporary Claude MCP config was not removed'
     Assert-True ($arguments -contains '--dangerously-load-development-channels') 'Claude Channel opt-in flag is missing'
+    $resumeIndex = [Array]::IndexOf($arguments, 'resume')
+    Assert-True ($resumeIndex -ge 0) 'trailing client arguments did not reach $ClaudeArgs'
+    Assert-True ($arguments -contains '--model' -and $arguments -contains 'fixture-model') 'trailing client flag and its value did not reach $ClaudeArgs'
+    Assert-True ($resumeIndex -lt $configIndex) 'client arguments were not passed ahead of the launcher-owned Claude flags'
+
+    # The Codex launcher has no credential-free end-to-end path (it refuses .cmd
+    # shims, so there is no fake codex.exe to capture arguments). Status mode still
+    # proves the binding: with PositionalBinding on, 'resume' lands in $LiveUrl and
+    # Assert-LiveUrl throws on the relative URI instead of reaching $CodexArgs.
+    $codexStatus = $null
+    try { $codexStatus = & "$PSScriptRoot\ops-brain-codex-live.ps1" -Mode Status -Label 'codex-ci' resume --model fixture-model }
+    catch { $codexStatus = @() }
+    Assert-True (@($codexStatus) -contains 'label: codex-ci') 'Codex launcher mis-bound a trailing client argument instead of collecting it into $CodexArgs'
 
     [IO.File]::WriteAllText((Join-Path $fakeBin 'codex.cmd'), "@echo off`r`nexit /b 0`r`n", [Text.UTF8Encoding]::new($false))
     $shimRejected = $false

--- a/scripts/Test-OpsBrainLiveWindows.ps1
+++ b/scripts/Test-OpsBrainLiveWindows.ps1
@@ -38,7 +38,8 @@ try {
     & "$PSScriptRoot\Install-OpsBrainLive.ps1" -SkipDependencies -BinDirectory $binDirectory
     & "$PSScriptRoot\Install-OpsBrainLive.ps1" -Mode Status -BinDirectory $binDirectory
     & "$PSScriptRoot\ops-brain-claude-live.ps1" -Mode Status
-    & "$PSScriptRoot\ops-brain-codex-live.ps1" -Mode Status
+    $codexStatusOutput = & "$PSScriptRoot\ops-brain-codex-live.ps1" -Mode Status
+    Assert-True (@($codexStatusOutput) -contains 'App Server: ws://127.0.0.1:4500') 'Codex launcher status did not preserve the bare App Server endpoint'
 
     $unsafeBin = Join-Path $testDirectory 'unsafe-bin'
     [IO.Directory]::CreateDirectory($unsafeBin) | Out-Null

--- a/scripts/Test-OpsBrainLiveWindows.ps1
+++ b/scripts/Test-OpsBrainLiveWindows.ps1
@@ -1,4 +1,4 @@
-#requires -Version 7.2
+#requires -Version 7.4
 # Credential-free Windows runtime checks for the live installer and launchers.
 
 [CmdletBinding()]

--- a/scripts/ops-brain-claude-live.ps1
+++ b/scripts/ops-brain-claude-live.ps1
@@ -1,7 +1,10 @@
 #requires -Version 7.2
 # Launch Claude Code with the local ops-brain Channel adapter on Windows.
 
-[CmdletBinding()]
+# PositionalBinding must stay off: with it on, the first trailing Claude argument
+# binds to $LiveUrl by position instead of falling through to $ClaudeArgs, so
+# `ops-brain-claude-live resume` dies in Assert-LiveUrl on a relative URI.
+[CmdletBinding(PositionalBinding = $false)]
 param(
     [ValidateSet('Run', 'Status', 'DryRun')]
     [string]$Mode = 'Run',

--- a/scripts/ops-brain-claude-live.ps1
+++ b/scripts/ops-brain-claude-live.ps1
@@ -1,4 +1,4 @@
-#requires -Version 7.2
+#requires -Version 7.4
 # Launch Claude Code with the local ops-brain Channel adapter on Windows.
 
 # PositionalBinding must stay off: with it on, the first trailing Claude argument

--- a/scripts/ops-brain-codex-live.ps1
+++ b/scripts/ops-brain-codex-live.ps1
@@ -1,4 +1,4 @@
-#requires -Version 7.2
+#requires -Version 7.4
 # Launch one Codex TUI, App Server, and ops-brain adapter on Windows.
 
 # PositionalBinding must stay off: with it on, the first trailing Codex argument
@@ -161,7 +161,9 @@ try {
         throw "Port $AppServerPort already hosts an App Server; select another port"
     }
 
-    # Hidden, NOT -NoNewWindow. Without either, Start-Process gives this child its own
+    # Hidden, NOT -NoNewWindow. Redirecting output sets UseShellExecute=false, so this
+    # requires PowerShell 7.4/.NET 8; earlier runtimes silently ignored WindowStyle in
+    # that mode. Without either, Start-Process gives this child its own
     # console; because stdout and stderr are redirected to files it renders as an empty
     # terminal beside the TUI, looks like stray junk, and closing it kills the live lane
     # with no log entry at all (observed during the 2026-08-17 acceptance gate).

--- a/scripts/ops-brain-codex-live.ps1
+++ b/scripts/ops-brain-codex-live.ps1
@@ -1,7 +1,10 @@
 #requires -Version 7.2
 # Launch one Codex TUI, App Server, and ops-brain adapter on Windows.
 
-[CmdletBinding()]
+# PositionalBinding must stay off: with it on, the first trailing Codex argument
+# binds to $LiveUrl by position instead of falling through to $CodexArgs, so
+# `ops-brain-codex-live resume` dies in Assert-LiveUrl on a relative URI.
+[CmdletBinding(PositionalBinding = $false)]
 param(
     [ValidateSet('Run', 'Status', 'DryRun')]
     [string]$Mode = 'Run',

--- a/scripts/ops-brain-codex-live.ps1
+++ b/scripts/ops-brain-codex-live.ps1
@@ -101,6 +101,11 @@ $RepoDirectory = Split-Path -Parent $PSScriptRoot
 $Adapter = Join-Path $RepoDirectory 'adapters\codex-app-server\src\index.mjs'
 $CredentialLauncher = Join-Path $PSScriptRoot 'start-ops-brain-live-adapter.ps1'
 $AppServerUrl = [uri]"ws://127.0.0.1:$AppServerPort"
+# codex app-server --listen rejects any path component -- `--help` documents the
+# supported form as bare ws://IP:PORT. [uri].AbsoluteUri normalizes the empty path to
+# "/", producing ws://127.0.0.1:4500/, which the parser refuses outright. Keep the [uri]
+# above for validation and display; pass this bare string to codex.exe itself.
+$AppServerEndpoint = "ws://127.0.0.1:$AppServerPort"
 $StateDirectory = Get-NormalizedPath $StateDirectory
 if ($AgentCredentialFile) {
     $AgentCredentialFile = Get-NormalizedPath $AgentCredentialFile
@@ -113,7 +118,7 @@ if ($Mode -eq 'Status') {
     "live URL: $(if ($null -ne $LiveUrl) { $LiveUrl.AbsoluteUri } else { '<unset>' })"
     "label: $Label"
     "agent: $(if ($AgentName) { $AgentName } else { '<unset>' })"
-    "App Server: $($AppServerUrl.AbsoluteUri)"
+    "App Server: $AppServerEndpoint"
     "credential: $(if ($AgentCredentialFile) { $AgentCredentialFile } else { '<unset>' }) - $credentialStatus"
     "state: $StateDirectory"
     "codex: $(Get-ApplicationPath 'codex.exe')"
@@ -132,7 +137,7 @@ $codexCommand = Get-RequiredApplication 'codex.exe'
 $pwshCommand = Get-RequiredApplication 'pwsh.exe'
 
 if ($Mode -eq 'DryRun') {
-    "would launch App Server at $($AppServerUrl.AbsoluteUri)"
+    "would launch App Server at $AppServerEndpoint"
     'would launch the Codex adapter with a DPAPI credential (bearer redacted)'
     'would launch one Codex TUI through that App Server'
     exit 0
@@ -153,7 +158,7 @@ try {
         throw "Port $AppServerPort already hosts an App Server; select another port"
     }
 
-    $appProcess = Start-Process -FilePath $codexCommand.Source -ArgumentList @('app-server', '--listen', $AppServerUrl.AbsoluteUri) -RedirectStandardOutput $appOut -RedirectStandardError $appErr -PassThru
+    $appProcess = Start-Process -FilePath $codexCommand.Source -ArgumentList @('app-server', '--listen', $AppServerEndpoint) -RedirectStandardOutput $appOut -RedirectStandardError $appErr -PassThru
     $ready = $false
     foreach ($attempt in 1..50) {
         if ($appProcess.HasExited) { break }
@@ -173,7 +178,7 @@ try {
     )
     $adapterProcess = Start-Process -FilePath $pwshCommand.Source -ArgumentList @($adapterArguments | ForEach-Object { ConvertTo-ProcessArgument $_ }) -RedirectStandardOutput $adapterOut -RedirectStandardError $adapterErr -PassThru
 
-    & $codexCommand.Source --remote $AppServerUrl.AbsoluteUri @CodexArgs
+    & $codexCommand.Source --remote $AppServerEndpoint @CodexArgs
     exit $LASTEXITCODE
 }
 finally {

--- a/scripts/ops-brain-codex-live.ps1
+++ b/scripts/ops-brain-codex-live.ps1
@@ -158,7 +158,16 @@ try {
         throw "Port $AppServerPort already hosts an App Server; select another port"
     }
 
-    $appProcess = Start-Process -FilePath $codexCommand.Source -ArgumentList @('app-server', '--listen', $AppServerEndpoint) -RedirectStandardOutput $appOut -RedirectStandardError $appErr -PassThru
+    # Hidden, NOT -NoNewWindow. Without either, Start-Process gives this child its own
+    # console; because stdout and stderr are redirected to files it renders as an empty
+    # terminal beside the TUI, looks like stray junk, and closing it kills the live lane
+    # with no log entry at all (observed during the 2026-08-17 acceptance gate).
+    #
+    # -NoNewWindow fixes the closable window but breaks the gate a different way: the
+    # child then shares the launcher's console and holds its input handle, so the Codex
+    # TUI stops accepting keystrokes. Hidden keeps the child on its own console, off
+    # screen and away from the TUI's stdin.
+    $appProcess = Start-Process -FilePath $codexCommand.Source -ArgumentList @('app-server', '--listen', $AppServerEndpoint) -RedirectStandardOutput $appOut -RedirectStandardError $appErr -WindowStyle Hidden -PassThru
     $ready = $false
     foreach ($attempt in 1..50) {
         if ($appProcess.HasExited) { break }
@@ -176,7 +185,10 @@ try {
         '-Label', $Label,
         '-AppServerUrl', $AppServerUrl.AbsoluteUri
     )
-    $adapterProcess = Start-Process -FilePath $pwshCommand.Source -ArgumentList @($adapterArguments | ForEach-Object { ConvertTo-ProcessArgument $_ }) -RedirectStandardOutput $adapterOut -RedirectStandardError $adapterErr -PassThru
+    # Hidden for the same reasons as the App Server above. This is the process whose
+    # death removes the live peer, so it must be neither closable nor able to contend
+    # for the TUI's console input.
+    $adapterProcess = Start-Process -FilePath $pwshCommand.Source -ArgumentList @($adapterArguments | ForEach-Object { ConvertTo-ProcessArgument $_ }) -RedirectStandardOutput $adapterOut -RedirectStandardError $adapterErr -WindowStyle Hidden -PassThru
 
     & $codexCommand.Source --remote $AppServerEndpoint @CodexArgs
     exit $LASTEXITCODE

--- a/scripts/start-ops-brain-live-adapter.ps1
+++ b/scripts/start-ops-brain-live-adapter.ps1
@@ -1,4 +1,4 @@
-#requires -Version 7.2
+#requires -Version 7.4
 # Credential-isolating child used by the Windows Claude and Codex launchers.
 
 [CmdletBinding()]

--- a/scripts/test-live-launchers
+++ b/scripts/test-live-launchers
@@ -85,7 +85,7 @@ for file in \
     "$SCRIPT_DIR/ops-brain-codex-live.ps1" \
     "$SCRIPT_DIR/Install-OpsBrainLive.ps1"; do
     [[ -s $file ]] || fail "missing PowerShell fleet file: $file"
-    grep -Eq '^#requires -Version 7\.2$' "$file" || fail "PowerShell version gate missing: $file"
+    grep -Eq '^#requires -Version 7\.4$' "$file" || fail "PowerShell 7.4 version gate missing: $file"
 done
 grep -Fq 'Import-Clixml -LiteralPath' "$SCRIPT_DIR/start-ops-brain-live-adapter.ps1" || fail 'DPAPI credential import missing'
 grep -Fq "OPS_BRAIN_AGENT_TOKEN = \$secret" "$SCRIPT_DIR/start-ops-brain-live-adapter.ps1" || fail 'adapter-only bearer export missing'


### PR DESCRIPTION
Three launcher fixes found by running the live-adapter acceptance gate end to end on a Windows host. **All 9 acceptance steps pass** with this branch; step 4 cannot pass without commit 1.

Requested by Codex-Stealth. **Please do not merge from here** — this is for review and integration on their side.

## 1. `--listen` receives a trailing slash and Codex refuses it

The launcher built the App Server endpoint with `[uri]` and passed `.AbsoluteUri` to both `codex app-server --listen` and `codex --remote`. `[uri]` normalizes an empty path to `/`, so Codex received:

```
error: invalid value 'ws://127.0.0.1:4500/' for '--listen <URL>':
invalid websocket --listen URL `ws://127.0.0.1:4500/`; expected `ws://IP:PORT`
```

`codex app-server --help` lists the supported values as `stdio://` (default), `unix://`, `unix://PATH`, `ws://IP:PORT`, and `off` — a path component is never valid. **This is not Windows-specific**; it fails against any Codex build carrying this parser (observed on 0.147.0).

The `[uri]` is retained for validation and display; a bare string is passed to `codex.exe`.

Also worth noting as a process bug: the `Status` and `DryRun` output previously rendered the *malformed* URL and still exited zero. Acceptance step 2 therefore gave a false green and the failure only surfaced at step 4. A dry run that prints the exact string it will pass should validate it.

## 2. The App Server and adapter spawned closable blank consoles

`Start-Process` gave both children their own console windows. Since stdout and stderr are redirected to log files, each renders as an **empty terminal** beside the TUI and reads as leftover junk from the launch.

Closing one kills the live lane. During the gate the operator closed both: the Codex peer disappeared from ops-brain while the TUI stayed running and responsive, and **the adapter logged nothing at all** — it was killed before it could log a disconnect. From the host the symptoms were peer absent, no error, no reconnect attempt, App Server still listening. Nothing anywhere points at the cause.

**`-WindowStyle Hidden`, not `-NoNewWindow`.** This matters and is easy to get wrong: `-NoNewWindow` removes the window but puts the child on the launcher's console *including its input handle*, so the App Server and adapter contend with the Codex TUI for keystrokes and the session stops accepting typed input entirely. That was tried first and it silently disables the client. Hidden keeps each child on its own console, off screen and away from the TUI's stdin.

## 3. `ValueFromRemainingArguments` was dead code in both launchers

`$ClaudeArgs` and `$CodexArgs` could never collect anything: positional parameters are filled before remaining-args binding, so trailing client arguments landed on whatever positional parameter came next. In `ops-brain-codex-live.ps1` the first trailing argument bound to `$LiveUrl` and died inside `Assert-LiveUrl` on a relative URI.

Fixed with `[CmdletBinding(PositionalBinding = $false)]` on both launchers.

Regression coverage is included rather than deferred. The Claude path asserts end to end through the existing fake-client fixture that `resume --model fixture-model` reaches `$ClaudeArgs` *and* is ordered ahead of the launcher-owned flags. The Codex launcher has no credential-free end-to-end path (it correctly refuses `.cmd` shims, so there is no fake `codex.exe` to capture arguments), so `-Mode Status` is asserted instead: with positional binding on, `resume` lands in `$LiveUrl` and the launcher throws before reporting.

## Verification

`scripts/Test-OpsBrainLiveWindows.ps1` passes on this branch.

Full acceptance gate, attended, on a Windows 11 Pro host — Codex 0.147.0 (native vendored binary, not the npm shim), Node v24.13.1, PowerShell 7.6.4:

| Step | Result |
|---|---|
| 3, 4 | one peer per client with the correct identity; peer disappears on exit |
| 5 | exactly one peer per identity; host logs and bus agree |
| 6 | markers both directions, hand-typed in the clients, with a correlated reply |
| 7 | negative control, both halves — see below |
| 8 | ~11 minutes idle through the production proxy; both peers survived with unchanged peer ids, zero reconnects, zero transport errors; post-idle marker delivered |
| 9 | exit stamps taken host-side against native PIDs; peers reached zero; no orphaned App Server, adapter, or launcher |

Step 7 is worth splitting in the acceptance doc, because "neither sibling token may claim or render as the other identity" is two different mechanisms in two different places and it is easy to test only one:

- **claim** — mismatched identity/credential pairs are refused in both directions by `start-ops-brain-live-adapter.ps1`, before the token is read out or transmitted. Control: the matched pair passed that check and failed later at `ECONNREFUSED`, proving the refusal was the identity check and not a generic startup failure.
- **render** — a message body explicitly claiming `from_agent=<the other identity>` still rendered with the true sender. The server-side binding wins over message content.

No credentials, tokens, receipt contents, or client data appear in this branch or description.

## Not addressed here

- **The adapter does not log its own disconnects.** Highest-value follow-up: when the peer vanished, the log's last entry was still the original registration. Diagnosing it took ~30 minutes; one log line would have made it seconds. Codex-Stealth is handling this separately.
- `thread/resume failed: no rollout found` is misleading but benign. Measured against a scratch App Server: resume succeeds on old rollouts, on the exact thread that "failed", twice on an already-loaded thread, and `thread/read` works on a loaded thread with no resume at all. A nonexistent thread returns that error verbatim — so it was literally true when it fired: the adapter resumed a thread the TUI had just created, before Codex wrote its rollout. `#waitForThread` retries and it self-heals, but it reads as a hard failure in the logs.
