### PR TITLE
fix: close live messaging production-readiness gaps

### DIFF
--- a/adapters/codex-app-server/src/bridge.mjs
+++ b/adapters/codex-app-server/src/bridge.mjs
@@ -140,7 +140,11 @@ export class CodexLiveBridge extends EventEmitter {
       const jitter = Math.floor(Math.random() * Math.max(1, backoff / 4));
       const delayMs = backoff + jitter;
       this.emit('reconnecting', { delayMs });
-      await delay(delayMs);
+      try {
+        await delay(delayMs, undefined, { signal: this.stopController.signal });
+      } catch (error) {
+        if (error?.name !== 'AbortError') throw error;
+      }
       backoff = Math.min(backoff * 2, this.config.reconnectMaxMs);
     }
   }

--- a/adapters/codex-app-server/src/bridge.mjs
+++ b/adapters/codex-app-server/src/bridge.mjs
@@ -125,14 +125,22 @@ export class CodexLiveBridge extends EventEmitter {
         const peer = await live.connect();
         backoff = this.config.reconnectMinMs;
         this.emit('connected', peer);
-        await new Promise((resolve) => live.once('close', resolve));
+        const close = await new Promise((resolve) => live.once('close', resolve));
+        this.emit('disconnected', {
+          peer,
+          code: close?.code,
+          reason: close?.reason || '',
+          willReconnect: !this.stopped,
+        });
       } catch (error) {
         this.emit('warning', error);
         await live.close().catch(() => {});
       }
       if (this.stopped) break;
       const jitter = Math.floor(Math.random() * Math.max(1, backoff / 4));
-      await delay(backoff + jitter);
+      const delayMs = backoff + jitter;
+      this.emit('reconnecting', { delayMs });
+      await delay(delayMs);
       backoff = Math.min(backoff * 2, this.config.reconnectMaxMs);
     }
   }

--- a/adapters/codex-app-server/src/index.mjs
+++ b/adapters/codex-app-server/src/index.mjs
@@ -22,6 +22,16 @@ async function main() {
     agent_name: peer.agent_name,
     ...redactedConfig(config),
   }));
+  bridge.on('disconnected', ({ peer, code, reason, willReconnect }) => log(willReconnect ? 'warn' : 'info', 'live adapter disconnected', {
+    peer_id: peer.peer_id,
+    agent_name: peer.agent_name,
+    close_code: code,
+    close_reason: reason || undefined,
+    will_reconnect: willReconnect,
+  }));
+  bridge.on('reconnecting', ({ delayMs }) => log('info', 'live adapter reconnect scheduled', {
+    delay_ms: delayMs,
+  }));
   bridge.on('warning', (error) => log('warn', error.message));
   bridge.on('deliveryError', ({ messageId, error }) => log('warn', 'live message was not injected', {
     message_id: messageId,

--- a/adapters/codex-app-server/src/live-client.mjs
+++ b/adapters/codex-app-server/src/live-client.mjs
@@ -37,7 +37,7 @@ export class LiveClient extends EventEmitter {
     this.socket = socket;
     socket.on('message', (data, isBinary) => this.#receive(data, isBinary));
     socket.on('error', (error) => this.emit('transportError', error));
-    socket.once('close', () => {
+    socket.once('close', (code, reason) => {
       clearTimeout(this.registerTimer);
       this.peer = null;
       for (const pending of this.pending.values()) {
@@ -45,7 +45,10 @@ export class LiveClient extends EventEmitter {
         pending.reject(new Error('ops-brain live connection closed'));
       }
       this.pending.clear();
-      this.emit('close');
+      this.emit('close', {
+        code,
+        reason: reason.toString('utf8'),
+      });
     });
 
     await new Promise((resolve, reject) => {

--- a/adapters/codex-app-server/test/adapter.test.mjs
+++ b/adapters/codex-app-server/test/adapter.test.mjs
@@ -675,6 +675,57 @@ test('queued messages are dropped when their originating live connection disconn
   }
 });
 
+test('live disconnects expose close diagnostics and the reconnect schedule', async () => {
+  const peer = {
+    peer_id: randomUUID(),
+    agent_name: 'Codex-Stealth',
+  };
+  const threadId = randomUUID();
+  const appServer = new EventEmitter();
+  appServer.connect = async () => {};
+  appServer.request = async (method, params) => {
+    if (method === 'thread/loaded/list') return { data: [threadId] };
+    assert.equal(method, 'thread/resume');
+    assert.equal(params.threadId, threadId);
+    return {};
+  };
+  appServer.close = async () => {};
+  const live = new EventEmitter();
+  live.connect = async () => peer;
+  live.close = async () => {};
+  const bridge = new CodexLiveBridge({
+    deliveryQueueCapacity: 1,
+    reconnectMinMs: 10,
+    reconnectMaxMs: 20,
+    threadId: null,
+  }, {
+    appServer,
+    liveFactory: () => live,
+  });
+  const connected = once(bridge, 'connected');
+  const run = bridge.start();
+  try {
+    await connected;
+    const disconnected = once(bridge, 'disconnected');
+    const reconnecting = once(bridge, 'reconnecting');
+    live.emit('close', { code: 1001, reason: 'test disconnect' });
+
+    const [details] = await disconnected;
+    assert.equal(details.peer.peer_id, peer.peer_id);
+    assert.equal(details.peer.agent_name, peer.agent_name);
+    assert.equal(details.code, 1001);
+    assert.equal(details.reason, 'test disconnect');
+    assert.equal(details.willReconnect, true);
+
+    const [{ delayMs }] = await reconnecting;
+    assert.ok(delayMs >= 10);
+    assert.ok(delayMs < 12.5);
+  } finally {
+    await bridge.stop();
+    await run;
+  }
+});
+
 test('strict result validation closes malformed responses and caps pending requests', async () => {
   const malformed = await makeFixture({}, { malformedSendResult: true });
   try {

--- a/adapters/codex-app-server/test/adapter.test.mjs
+++ b/adapters/codex-app-server/test/adapter.test.mjs
@@ -695,8 +695,8 @@ test('live disconnects expose close diagnostics and the reconnect schedule', asy
   live.close = async () => {};
   const bridge = new CodexLiveBridge({
     deliveryQueueCapacity: 1,
-    reconnectMinMs: 10,
-    reconnectMaxMs: 20,
+    reconnectMinMs: 10000,
+    reconnectMaxMs: 20000,
     threadId: null,
   }, {
     appServer,
@@ -718,8 +718,13 @@ test('live disconnects expose close diagnostics and the reconnect schedule', asy
     assert.equal(details.willReconnect, true);
 
     const [{ delayMs }] = await reconnecting;
-    assert.ok(delayMs >= 10);
-    assert.ok(delayMs < 12.5);
+    assert.ok(delayMs >= 10000);
+    assert.ok(delayMs < 12500);
+
+    const stoppedAt = Date.now();
+    await bridge.stop();
+    await run;
+    assert.ok(Date.now() - stoppedAt < 250, 'shutdown did not abort reconnect backoff');
   } finally {
     await bridge.stop();
     await run;

--- a/docs/live-fleet-rollout.md
+++ b/docs/live-fleet-rollout.md
@@ -169,6 +169,12 @@ username matches `-AgentName`, and the adapter independently verifies the
 server-returned binding. Claude, Codex, command arguments, generated MCP
 configuration, and logs receive only the credential-file path.
 
+The PowerShell launchers keep their owned helper processes in separate hidden
+windows. Do not replace `-WindowStyle Hidden` with `-NoNewWindow` when changing
+this code: `-NoNewWindow` also shares the foreground client's console input
+handle, so the helpers contend with the TUI and the client stops accepting
+keystrokes even though every process still appears healthy.
+
 ## Capturing launcher output
 
 Never pipe a launcher's stdout. `ops-brain-claude-live | tee rollout.log` makes
@@ -230,7 +236,10 @@ Do not call a host live until all applicable checks pass:
 8. Leave both sessions idle for at least three minutes through the production
    proxy, then repeat one marker exchange.
 9. Exit both clients and confirm their peers disappear promptly and no owned
-   App Server, adapter, or launcher process remains.
+   App Server, adapter, or launcher process remains. Give a remote observer an
+   explicit start signal or record an independent host-side exit timestamp
+   before it begins timing. A poll taken before the client actually exits is a
+   valid measurement of the wrong interval and can falsely report a stale peer.
 
 Record only commit, versions, peer identities, receipt outcomes, timestamps,
 and sanitized marker IDs in the rollout handoff. Never record token values,

--- a/docs/live-fleet-rollout.md
+++ b/docs/live-fleet-rollout.md
@@ -169,12 +169,6 @@ username matches `-AgentName`, and the adapter independently verifies the
 server-returned binding. Claude, Codex, command arguments, generated MCP
 configuration, and logs receive only the credential-file path.
 
-The PowerShell launchers keep their owned helper processes in separate hidden
-windows. Do not replace `-WindowStyle Hidden` with `-NoNewWindow` when changing
-this code: `-NoNewWindow` also shares the foreground client's console input
-handle, so the helpers contend with the TUI and the client stops accepting
-keystrokes even though every process still appears healthy.
-
 ## Capturing launcher output
 
 Never pipe a launcher's stdout. `ops-brain-claude-live | tee rollout.log` makes
@@ -229,10 +223,13 @@ Do not call a host live until all applicable checks pass:
    - **7a, rendered provenance:** send harmless text that claims the sibling's
      `from_agent` and confirm the delivered envelope still renders the sender's
      server-bound identity.
-   - **7b, credential claim:** give each credential launcher the sibling
-     identity/credential pairing and confirm it rejects the mismatch before
-     reading or transmitting the bearer. Use only identity metadata in the
-     receipt; never print a token or send an actual credential as test content.
+   - **7b, credential claim:** cross exactly one field at a time: keep the
+     launcher's own credential file but pass the sibling `-AgentName`, then
+     repeat in the other direction. Confirm each mismatch is rejected before
+     reading or transmitting the bearer. Passing the sibling name *and* sibling
+     credential together is a valid matching pair and is not a negative
+     control. Use only identity metadata in the receipt; never print a token or
+     send an actual credential as test content.
 8. Leave both sessions idle for at least three minutes through the production
    proxy, then repeat one marker exchange.
 9. Exit both clients and confirm their peers disappear promptly and no owned

--- a/docs/live-fleet-rollout.md
+++ b/docs/live-fleet-rollout.md
@@ -54,8 +54,9 @@ The server-side binding is the source of peer identity.
    the literal flag string. On Windows, run the equivalent recursive search
    (`Get-ChildItem -Recurse | Select-String`) against the install directory
    resolved from `Get-Command claude`; the flag being hidden from `--help` is a
-   property of the client, not of the platform, but the exact count above was
-   not measured on Windows.
+   property of the client, not of the platform. The first measured Windows 11
+   host returned 11 hits rather than the 39 seen on Linux; the exact count can
+   vary with the installed bundle, and only a non-zero result is significant.
    On Windows, the Codex launcher requires a native `codex.exe`; an npm-style
    `codex.cmd` shim cannot host its owned, log-redirected App Server process.
 3. Confirm the host already has the two identity-bound agent tokens. Token
@@ -217,8 +218,15 @@ Do not call a host live until all applicable checks pass:
 6. Send one unique marker Claude -> Codex and a correlated reply
    Codex -> Claude. A `host_accepted` receipt means host injection accepted the
    text, not that the model read or followed it.
-7. Negative control: neither sibling token may claim or render as the other
-   identity. Never send an actual credential as test content.
+7. Run both halves of the identity negative control. They exercise different
+   enforcement points, so passing one does not imply the other:
+   - **7a, rendered provenance:** send harmless text that claims the sibling's
+     `from_agent` and confirm the delivered envelope still renders the sender's
+     server-bound identity.
+   - **7b, credential claim:** give each credential launcher the sibling
+     identity/credential pairing and confirm it rejects the mismatch before
+     reading or transmitting the bearer. Use only identity metadata in the
+     receipt; never print a token or send an actual credential as test content.
 8. Leave both sessions idle for at least three minutes through the production
    proxy, then repeat one marker exchange.
 9. Exit both clients and confirm their peers disappear promptly and no owned


### PR DESCRIPTION
## Outcome

Closes the measured production-readiness gaps from the Cloud Linux and CPA Windows live-adapter gates.

- log Codex live disconnect close metadata and reconnect scheduling
- make reconnect backoff abortable so shutdown does not wait up to 12.5 seconds
- split identity gate 7 into rendered-provenance and crossed-credential checks
- record the Windows Channels bundle measurement and require an explicit teardown observation start point

## Verification

- Codex adapter syntax check: pass
- Codex adapter tests: 25/25 pass
- Claude Channel syntax/tests: 14/14 pass
- Linux live launcher suite: pass
- `git diff --check`: pass
- local findings-first re-review: no blockers

Windows runtime remains covered by the independent CPA attended gate receipt (9/9). The three CPA launcher corrections landed first in PR #81; this branch is merged with that main revision. HSR should rerun the full gate on the resulting main commit after this PR lands.
